### PR TITLE
ve-silo: SiloGovernor. Removed oneTimeInit fn

### DIFF
--- a/.github/workflows/ve-silo.yml
+++ b/.github/workflows/ve-silo.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: yarn install
         run: yarn install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2023-11-10
+### Fixed
+- [Issue #213](https://github.com/silo-finance/silo-contracts-v2/issues/213)
+
 ## [0.0.3] - 2023-10-26
 ### Added
 - silo-core for audit

--- a/ve-silo/contracts/governance/SiloGovernor.sol
+++ b/ve-silo/contracts/governance/SiloGovernor.sol
@@ -30,7 +30,7 @@ contract SiloGovernor is
     error VeSiloAlreadyInitialized();
 
     /// @param _timelock openzeppelin timelock contract
-    constructor(TimelockController _timelock)
+    constructor(TimelockController _timelock, IVeSilo _veSilo)
         Governor("SiloGovernor")
         GovernorSettings(
             1 /* initial voting deplay - 1 block */,
@@ -40,13 +40,8 @@ contract SiloGovernor is
         GovernorVotesQuorumFraction(1 /* quorum numerator value */)
         GovernorVotes(IVotes(address(0)))
         GovernorTimelockControl(_timelock)
-    {}
-
-    /// @param _token address of SiloGovernanceToken
-    function oneTimeInit(IVeSilo _token) external {
-        if (address(veSiloToken) != address(0)) revert VeSiloAlreadyInitialized();
-
-        veSiloToken = _token;
+    {
+        veSiloToken = _veSilo;
     }
 
     /// @inheritdoc IGovernor


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/213

An issue was resolved by changing the deployment transactions order so that oneTimeInit fn was unnecessary and removed.
