### PR TITLE
ve-silo: Fee swapper with extra data for a swap and extended permission system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2023-11-10
+### Fixed
+- [Issue #214](https://github.com/silo-finance/silo-contracts-v2/issues/214)
+
 ## [0.0.4] - 2023-11-10
 ### Fixed
 - [Issue #213](https://github.com/silo-finance/silo-contracts-v2/issues/213)

--- a/ve-silo/contracts/fees-distribution/fee-swapper/FeeSwapperConfig.sol
+++ b/ve-silo/contracts/fees-distribution/fee-swapper/FeeSwapperConfig.sol
@@ -15,13 +15,13 @@
 pragma solidity 0.8.21;
 
 import {IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable2Step} from "openzeppelin-contracts/access/Ownable2Step.sol";
 
 import {IFeeSwap} from "../interfaces/IFeeSwap.sol";
 import {IFeeSwapper} from "../interfaces/IFeeSwapper.sol";
 import {IFeeDistributor} from "../interfaces/IFeeDistributor.sol";
+import {ExtendedOwnable} from "ve-silo/contracts/access/ExtendedOwnable.sol";
 
-abstract contract FeeSwapperConfig is IFeeSwapper, Ownable2Step {
+abstract contract FeeSwapperConfig is IFeeSwapper, ExtendedOwnable {
     mapping(IERC20 asset => IFeeSwap feeSwap) public swappers;
 
     event SwapperUpdated(IERC20 asset, IFeeSwap swapper);

--- a/ve-silo/contracts/fees-distribution/fee-swapper/swappers/UniswapSwapper.sol
+++ b/ve-silo/contracts/fees-distribution/fee-swapper/swappers/UniswapSwapper.sol
@@ -46,10 +46,12 @@ contract UniswapSwapper is IFeeSwap, Ownable2Step {
     }
 
     /// @inheritdoc IFeeSwap
-    function swap(IERC20 _asset, uint256 _amount) external {
+    function swap(IERC20 _asset, uint256 _amount, bytes memory _data) external {
         SwapPath[] memory swapPath = config[_asset];
 
         if (swapPath.length == 0) revert AssetIsNotConfigured();
+
+        (uint256 amountOutMinimum) = abi.decode(_data, (uint256));
 
         bytes memory path = createPath(swapPath);
 
@@ -61,7 +63,7 @@ contract UniswapSwapper is IFeeSwap, Ownable2Step {
             recipient: msg.sender,
             deadline: block.timestamp,
             amountIn: _amount,
-            amountOutMinimum: 1
+            amountOutMinimum: amountOutMinimum
         });
 
         router.exactInput(params);

--- a/ve-silo/contracts/fees-distribution/interfaces/IFeeSwap.sol
+++ b/ve-silo/contracts/fees-distribution/interfaces/IFeeSwap.sol
@@ -17,5 +17,5 @@ pragma solidity ^0.8.0;
 import {IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
 
 interface IFeeSwap {
-    function swap(IERC20 _asset, uint256 _amount) external;
+    function swap(IERC20 _asset, uint256 _amount, bytes memory _data) external;
 }

--- a/ve-silo/contracts/fees-distribution/interfaces/IFeeSwapper.sol
+++ b/ve-silo/contracts/fees-distribution/interfaces/IFeeSwapper.sol
@@ -24,7 +24,7 @@ interface IFeeSwapper {
         IFeeSwap swap;
     }
 
-    function swapFeesAndDeposit(address[] calldata _assets) external;
+    function swapFeesAndDeposit(address[] calldata _assets, bytes[] memory _data) external;
 
     /// @notice Deposit into SILO-80%/WEH-20% Balancer pool
     function joinBalancerPool() external;
@@ -36,7 +36,9 @@ interface IFeeSwapper {
 
     /// @notice Swap all provided assets into WETH
     /// @param _assets A list of the asset to swap
-    function swapFees(address[] calldata _assets) external;
+    /// @param _data Extra data that will be passed into a swap implementation.
+    ///              For example encoded `amountOutMinimum` for an `UniswapSwapper`
+    function swapFees(address[] calldata _assets, bytes[] memory _data) external;
 
     /// @notice Configure swappers
     /// @param _inputs Swappers configurations

--- a/ve-silo/test/fee-dustribution/UniswapSwapper.integration..sol
+++ b/ve-silo/test/fee-dustribution/UniswapSwapper.integration..sol
@@ -67,10 +67,17 @@ contract UniswapSwapperTest is IntegrationTest {
         uint256 balance = _wethToken.balanceOf(address(this));
         assertEq(balance, 0, "Expect has no ETH before the swap");
 
-        feeSwap.swap(_snxToken, amount);
+        uint256 expectedAmount = 1163347406737788006;
+        bytes memory data = abi.encodePacked(expectedAmount + 1); // One wei more than we can receive
+
+        vm.expectRevert("Too little received");
+        feeSwap.swap(_snxToken, amount, data);
+        
+        data = abi.encodePacked(expectedAmount);
+        feeSwap.swap(_snxToken, amount, data);
 
         balance = _wethToken.balanceOf(address(this));
-        assertEq(balance, 1163347406737788006, "Expect to have ETH after the swap");
+        assertEq(balance, expectedAmount, "Expect to have ETH after the swap");
     }
 
     function configureSwapper() public {


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/214

An issue was resolved by:
1. Introducing an [extended ownable](https://github.com/silo-finance/silo-contracts-v2/blob/master/ve-silo/contracts/access/ExtendedOwnable.sol) permission system. So, only the `manager` will be able to perform a fee swap operation, which allows us to use RPC with front-running protection. 
2. Extending a fee swapper interface by adding an additional raw bytes input, which allows us to provide any extra data that may be needed in a fee swap smart contract. In our case with `UniswapSwapper`, we are using it by providing `amountOutMinimum`, which protects us from the unlimited slippage.