### PR TITLE
ve-silo: added 'receive' fn to the StakelessGaugeCheckpointerAdaptor

### DIFF
--- a/ve-silo/contracts/gauges/stakeless-gauge/StakelessGaugeCheckpointerAdaptor.sol
+++ b/ve-silo/contracts/gauges/stakeless-gauge/StakelessGaugeCheckpointerAdaptor.sol
@@ -28,6 +28,9 @@ contract StakelessGaugeCheckpointerAdaptor is Ownable2Step, IStakelessGaugeCheck
     error TheSameCheckpointer();
     error OnlyCheckpointer();
 
+    /// @notice Receive fn to be able to receive ether leftover from the gauge after checkpoint.
+    receive() external payable {}
+
     /// @inheritdoc IStakelessGaugeCheckpointerAdaptor
     function checkpoint(address gauge) external payable returns (bool result) {
         if (msg.sender != checkpointer) revert OnlyCheckpointer();


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/216

An issue was resolved by adding `receive` fn to the StakelessGaugeCheckpointerAdaptor