### PR TITLE
ve-silo: gauges implementations contracts initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.10] - 2023-11-14
+### Fixed
+- [Issue #223](https://github.com/silo-finance/silo-contracts-v2/issues/223)
+
+## [0.0.9] - 2023-11-13
+### Fixed
+- [Issue #221](https://github.com/silo-finance/silo-contracts-v2/issues/221)
+
 ## [0.0.8] - 2023-11-13
 ### Fixed
 - [Issue #219](https://github.com/silo-finance/silo-contracts-v2/issues/219)

--- a/ve-silo/contracts/gauges/ethereum/SiloLiquidityGauge.vy
+++ b/ve-silo/contracts/gauges/ethereum/SiloLiquidityGauge.vy
@@ -159,6 +159,10 @@ def __init__(minter: address, veBoostProxy: address, authorizerAdaptor: address)
     VOTING_ESCROW = Controller(gaugeController).voting_escrow()
     VEBOOST_PROXY = veBoostProxy
 
+    # Set the hook_receiver variable to a non-zero value
+    # in order to prevent the implementation contracts from being initialized
+    self.hook_receiver = 0x000000000000000000000000000000000000dEaD
+
 # Internal Functions
 
 

--- a/ve-silo/contracts/gauges/l2-common/ChildChainGauge.vy
+++ b/ve-silo/contracts/gauges/l2-common/ChildChainGauge.vy
@@ -108,12 +108,15 @@ def __init__(
     _version: String[128]
 ):
     self.version = _version
-    self.factory = 0x000000000000000000000000000000000000dEaD
 
     VE_DELEGATION_PROXY = _voting_escrow_delegation_proxy
     BAL_PSEUDO_MINTER = _bal_pseudo_minter
     BAL = Minter(_bal_pseudo_minter).getBalancerToken()
     AUTHORIZER_ADAPTOR = _authorizer_adaptor
+
+    # Set the hook_receiver variable to a non-zero value
+    # in order to prevent the implementation contracts from being initialized
+    self.hook_receiver = 0x000000000000000000000000000000000000dEaD
 
 
 @internal


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/223

An issue was resolved by setting the hook_receiver variable to a non-zero value during construction for both SiloLiquidityGauge and ChildChainGauge