### PR TITLE
TOB-SILO2-1: ensure silo factory initialization can not be front-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.15] - 2023-11-28
+### Fixed
+- TOB-SILO2-1: ensure silo factory initialization can not be front-run
+
+## [0.0.14] - 2023-11-28
+### Fixed
+- tob-silo2-5: fix deposit limit
+
 ## [0.0.13] - 2023-11-21
 ### Fixed
 - fix `ASSET_DATA_OVERFLOW_LIMIT` in IRM model

--- a/silo-core/contracts/SiloFactory.sol
+++ b/silo-core/contracts/SiloFactory.sol
@@ -11,8 +11,9 @@ import {IShareToken} from "./interfaces/IShareToken.sol";
 import {ISiloFactory} from "./interfaces/ISiloFactory.sol";
 import {ISiloConfig, SiloConfig} from "./SiloConfig.sol";
 import {ISilo, Silo} from "./Silo.sol";
+import {Creator} from "./utils/Creator.sol";
 
-contract SiloFactory is ISiloFactory, ERC721Upgradeable, OwnableUpgradeable {
+contract SiloFactory is ISiloFactory, ERC721Upgradeable, OwnableUpgradeable, Creator {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
     /// @dev max fee is 40%, 1e18 == 100%
@@ -47,7 +48,7 @@ contract SiloFactory is ISiloFactory, ERC721Upgradeable, OwnableUpgradeable {
         address _shareDebtTokenImpl,
         uint256 _daoFee,
         address _daoFeeReceiver
-    ) external virtual initializer {
+    ) external virtual initializer onlyCreator {
         __ERC721_init("Silo Finance Fee Receiver", "feeSILO");
         __Ownable_init();
 

--- a/silo-core/contracts/utils/Creator.sol
+++ b/silo-core/contracts/utils/Creator.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.21;
+
+contract Creator {
+    address private immutable _creator;
+
+    error OnlyCreatorCanInitialise();
+
+    constructor() {
+        _creator = msg.sender;
+    }
+
+    modifier onlyCreator() {
+        if (msg.sender != _creator) revert OnlyCreatorCanInitialise();
+        _;
+    }
+}

--- a/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
+++ b/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 
-import {ISiloFactory, SiloFactory} from "silo-core/contracts/SiloFactory.sol";
+import {ISiloFactory, SiloFactory, Creator} from "silo-core/contracts/SiloFactory.sol";
 
 /*
 forge test -vv --mc SiloFactoryInitializeTest
@@ -13,6 +13,25 @@ contract SiloFactoryInitializeTest is Test {
 
     function setUp() public {
         siloFactory = new SiloFactory();
+    }
+
+    /*
+    forge test -vv --mt test_initialize_onlyCreator
+    */
+    function test_initialize_onlyCreator() public {
+        SiloFactory f = new SiloFactory();
+
+        address siloImpl = address(1);
+        address shareCollateralTokenImpl = address(1);
+        address shareDebtTokenImpl = address(1);
+        uint256 daoFee;
+        address daoFeeReceiver = address(1);
+
+        vm.expectRevert(Creator.OnlyCreatorCanInitialise.selector);
+        vm.prank(address(1));
+        f.initialize(siloImpl, shareCollateralTokenImpl, shareDebtTokenImpl, daoFee, daoFeeReceiver);
+
+        f.initialize(siloImpl, shareCollateralTokenImpl, shareDebtTokenImpl, daoFee, daoFeeReceiver);
     }
 
     /*


### PR DESCRIPTION
Fixes #284

Front run fixed by allowing only creator to initialise the deployed contract.