### PR TITLE
TOB-SILO2-6: ensure no one can initialise GaugeHookReceiver and SiloF…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.16] - 2023-11-28
+### Fixed
+- TOB-SILO2-6: ensure no one can initialise GaugeHookReceiver and SiloFactory 
+
 ## [0.0.15] - 2023-11-28
 ### Fixed
 - TOB-SILO2-1: ensure silo factory initialization can not be front-run

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.13",
+  "version": "0.0.16",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/SiloFactory.sol
+++ b/silo-core/contracts/SiloFactory.sol
@@ -42,6 +42,10 @@ contract SiloFactory is ISiloFactory, ERC721Upgradeable, OwnableUpgradeable, Cre
     mapping(uint256 id => address[2] silos) private _idToSilos;
     mapping(address silo => uint256 id) public siloToId;
 
+    /// @dev SiloFactory is not clonable contract. initialize() method is here only because we have
+    /// circular dependency: SiloFactory needs to know Silo address and Silo needs to know factory address.
+    /// Because of that, `initialize()` will be always executed on deployed factory, so there is no need for
+    /// disabling initializer by calling `_disableInitializers()` in constructor, especially that only creator can init.
     function initialize(
         address _siloImpl,
         address _shareCollateralTokenImpl,

--- a/silo-core/contracts/utils/Creator.sol
+++ b/silo-core/contracts/utils/Creator.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.21;
 contract Creator {
     address private immutable _creator;
 
-    error OnlyCreatorCanInitialise();
+    error OnlyCreator();
 
     constructor() {
         _creator = msg.sender;
     }
 
     modifier onlyCreator() {
-        if (msg.sender != _creator) revert OnlyCreatorCanInitialise();
+        if (msg.sender != _creator) revert OnlyCreator();
         _;
     }
 }

--- a/silo-core/contracts/utils/hook-receivers/gauge/GaugeHookReceiver.sol
+++ b/silo-core/contracts/utils/hook-receivers/gauge/GaugeHookReceiver.sol
@@ -14,6 +14,10 @@ contract GaugeHookReceiver is IGaugeHookReceiver, OwnableUpgradeable {
     IGauge public gauge;
     IShareToken public shareToken;
 
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @inheritdoc IHookReceiver
     function initialize(address _owner, IShareToken _token) external virtual initializer {
         if (_owner == address(0)) revert OwnerIsZeroAddress();

--- a/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
+++ b/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
@@ -27,7 +27,7 @@ contract SiloFactoryInitializeTest is Test {
         uint256 daoFee;
         address daoFeeReceiver = address(1);
 
-        vm.expectRevert(Creator.OnlyCreatorCanInitialise.selector);
+        vm.expectRevert(Creator.OnlyCreator.selector);
         vm.prank(address(1));
         f.initialize(siloImpl, shareCollateralTokenImpl, shareDebtTokenImpl, daoFee, daoFeeReceiver);
 

--- a/silo-core/test/foundry/deploy/GaugeHookReceiverDeploy.t.sol
+++ b/silo-core/test/foundry/deploy/GaugeHookReceiverDeploy.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+
+import {GaugeHookReceiverDeploy} from "silo-core/deploy/GaugeHookReceiverDeploy.s.sol";
+
+import {IGaugeHookReceiver} from "silo-core/contracts/utils/hook-receivers/gauge/interfaces/IGaugeHookReceiver.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+
+// FOUNDRY_PROFILE=core forge test -vv --ffi --mc GaugeHookReceiverTest
+contract GaugeHookReceiverDeployTest is Test {
+    // forge test -vv --ffi --mt test_GaugeHookReceiverDeploy_run
+    function test_GaugeHookReceiverDeploy_run() public {
+        GaugeHookReceiverDeploy deploy = new GaugeHookReceiverDeploy();
+        deploy.disableDeploymentsSync();
+
+        IGaugeHookReceiver hookReceiver = deploy.run();
+        assertTrue(address(hookReceiver) != address(0), "expect deployed address");
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        hookReceiver.initialize(makeAddr("owner"), IShareToken(makeAddr("IShareToken")));
+    }
+}


### PR DESCRIPTION
Closes #289 

- factory is fixed in previous PR #290  by adding `onlyCreator`, in this PR I only added comment explaining how we using init method
- for `GaugeHookReceiver` constructor was added with `_disableInitializers`
