### PR TITLE
TOB-SILO2-4: add 2-step ownership for `SiloFactory` and `GaugeHookReceiver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.17] - 2023-11-29
+### Added
+- TOB-SILO2-4: add 2-step ownership for `SiloFactory` and `GaugeHookReceiver`
+
 ## [0.0.16] - 2023-11-28
 ### Fixed
 - TOB-SILO2-6: ensure no one can initialise GaugeHookReceiver and SiloFactory 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/SiloFactory.sol
+++ b/silo-core/contracts/SiloFactory.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import {CountersUpgradeable} from "openzeppelin-contracts-upgradeable/utils/CountersUpgradeable.sol";
 import {ClonesUpgradeable} from "openzeppelin-contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ERC721Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
 import {IShareToken} from "./interfaces/IShareToken.sol";
@@ -13,7 +13,7 @@ import {ISiloConfig, SiloConfig} from "./SiloConfig.sol";
 import {ISilo, Silo} from "./Silo.sol";
 import {Creator} from "./utils/Creator.sol";
 
-contract SiloFactory is ISiloFactory, ERC721Upgradeable, OwnableUpgradeable, Creator {
+contract SiloFactory is ISiloFactory, ERC721Upgradeable, Ownable2StepUpgradeable, Creator {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
     /// @dev max fee is 40%, 1e18 == 100%

--- a/silo-core/contracts/utils/hook-receivers/gauge/GaugeHookReceiver.sol
+++ b/silo-core/contracts/utils/hook-receivers/gauge/GaugeHookReceiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
 import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
@@ -10,7 +10,7 @@ import {IGaugeHookReceiver, IHookReceiver} from "./interfaces/IGaugeHookReceiver
 
 /// @notice Silo share token hook receiver for the gauge.
 /// It notifies the gauge (if configured) about any balance update in the Silo share token.
-contract GaugeHookReceiver is IGaugeHookReceiver, OwnableUpgradeable {
+contract GaugeHookReceiver is IGaugeHookReceiver, Ownable2StepUpgradeable {
     IGauge public gauge;
     IShareToken public shareToken;
 

--- a/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
+++ b/silo-core/test/foundry/SiloFactory/SiloFactoryInitializeTest.t.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 
 import {ISiloFactory, SiloFactory, Creator} from "silo-core/contracts/SiloFactory.sol";
+import {TransferOwnership} from "../_common/TransferOwnership.sol";
 
 /*
 forge test -vv --mc SiloFactoryInitializeTest
 */
-contract SiloFactoryInitializeTest is Test {
+contract SiloFactoryInitializeTest is Test, TransferOwnership {
     SiloFactory public siloFactory;
 
     function setUp() public {
@@ -83,5 +84,7 @@ contract SiloFactoryInitializeTest is Test {
         assertEq(siloFactory.maxDeployerFee(), 0.15e18);
         assertEq(siloFactory.maxFlashloanFee(), 0.15e18);
         assertEq(siloFactory.maxLiquidationFee(), 0.3e18);
+
+        assertTrue(_test_transfer2StepOwnership(address(siloFactory), address(this)));
     }
 }

--- a/silo-core/test/foundry/_common/TransferOwnership.sol
+++ b/silo-core/test/foundry/_common/TransferOwnership.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+abstract contract TransferOwnership is Test {
+    function _test_transfer2StepOwnership(address _contract, address _currentOwner) internal returns (bool) {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(_currentOwner);
+        Ownable2StepUpgradeable(_contract).transferOwnership(newOwner);
+
+        assertEq(
+            _currentOwner,
+            Ownable2StepUpgradeable(_contract).owner(),
+            "owner should be dao before 2step is completed"
+        );
+
+        vm.prank(newOwner);
+        Ownable2StepUpgradeable(_contract).acceptOwnership();
+
+        assertEq(newOwner, Ownable2StepUpgradeable(_contract).owner(), "transfer ownership failed");
+
+        return true;
+    }
+}

--- a/silo-core/test/foundry/hook-receivers/GaugeHookReceiver.t.sol
+++ b/silo-core/test/foundry/hook-receivers/GaugeHookReceiver.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.21;
 
 import {Test} from "forge-std/Test.sol";
-import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {GaugeHookReceiver} from "silo-core/contracts/utils/hook-receivers/gauge/GaugeHookReceiver.sol";
 import {IGaugeHookReceiver} from "silo-core/contracts/utils/hook-receivers/gauge/interfaces/IGaugeHookReceiver.sol";
@@ -12,10 +12,12 @@ import {IGaugeLike as IGauge} from "silo-core/contracts/utils/hook-receivers/gau
 import {HookReceiversFactory} from "silo-core/contracts/utils/hook-receivers/HookReceiversFactory.sol";
 
 import {GaugeHookReceiverDeploy} from "silo-core/deploy/GaugeHookReceiverDeploy.s.sol";
-import "../../../deploy/HookReceiversFactoryDeploy.s.sol";
+import {HookReceiversFactoryDeploy} from "../../../deploy/HookReceiversFactoryDeploy.s.sol";
+import {IHookReceiversFactory} from "../../../contracts/utils/hook-receivers/interfaces/IHookReceiversFactory.sol";
+import {TransferOwnership} from  "../_common/TransferOwnership.sol";
 
 // FOUNDRY_PROFILE=core forge test -vv --ffi --mc GaugeHookReceiverTest
-contract GaugeHookReceiverTest is Test {
+contract GaugeHookReceiverTest is Test, TransferOwnership {
     IHookReceiversFactory internal _hookReceiverFactory;
     IGaugeHookReceiver internal _hookReceiver;
 
@@ -73,7 +75,7 @@ contract GaugeHookReceiverTest is Test {
 
         assertEq(
             _dao,
-            OwnableUpgradeable(address(_hookReceiver)).owner(),
+            Ownable2StepUpgradeable(address(_hookReceiver)).owner(),
             "Invalid owner after initialization"
         );
 
@@ -82,6 +84,13 @@ contract GaugeHookReceiverTest is Test {
             address(GaugeHookReceiver(address(_hookReceiver)).shareToken()),
             "Invalid share token after initialization"
         );
+    }
+
+    // forge test -vv --ffi --mt test_HookReceiver_transferOwnership
+    function test_HookReceiver_transferOwnership() public {
+        _initializeHookReceiver();
+
+        assertTrue(_test_transfer2StepOwnership(address(_hookReceiver), _dao));
     }
 
     function testReinitialization() public {


### PR DESCRIPTION
Fixes issue #287 

