### PR TITLE
TOB-SILO2-12: Risk of depricated Chainlink oracles locking user funds

### DIFF
--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -143,7 +143,8 @@ interface ISilo is IERC4626, IERC3156FlashLender, ISiloLiquidation {
     /// @notice Fetches the utilization data of the silo used by IRM
     function utilizationData() external view returns (UtilizationData memory utilizationData);
 
-    /// @notice Fetches the available liquidity in the silo
+    /// @notice Fetches the available liquidity in the silo, it does not include interest, so real liquidity will be
+    /// smaller
     /// @return liquidity The amount of available liquidity
     function getLiquidity() external view returns (uint256 liquidity);
 

--- a/silo-core/test/foundry/Silo/OracleThrows.i.sol
+++ b/silo-core/test/foundry/Silo/OracleThrows.i.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../_common/SiloLittleHelper.sol";
+import {SiloFixture, SiloConfigOverride} from "../_common/fixtures/SiloFixture.sol";
+import {DummyOracle} from "../_common/DummyOracle.sol";
+
+/*
+    forge test -vv --ffi --mc OracleThrowsTest
+*/
+contract OracleThrowsTest is SiloLittleHelper, Test {
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    DummyOracle immutable solvencyOracle0;
+    DummyOracle immutable maxLtvOracle0;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+
+        token0 = new MintableToken();
+        token1 = new MintableToken();
+
+        solvencyOracle0 = new DummyOracle(1e18, address(token1));
+        maxLtvOracle0 = new DummyOracle(1e18, address(token1));
+
+        solvencyOracle0.setExpectBeforeQuote(true);
+        maxLtvOracle0.setExpectBeforeQuote(true);
+
+        SiloConfigOverride memory overrides;
+        overrides.token0 = address(token0);
+        overrides.token1 = address(token1);
+        overrides.solvencyOracle0 = address(solvencyOracle0);
+        overrides.maxLtvOracle0 = address(maxLtvOracle0);
+        overrides.configName = SiloConfigsNames.LOCAL_BEFORE_CALL;
+
+        SiloFixture siloFixture = new SiloFixture();
+        (, silo0, silo1,,) = siloFixture.deploy_local(overrides);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_throwing_oracle
+    */
+    function test_throwing_oracle() public {
+        uint256 depositAmount = 100e18;
+        uint256 borrowAmount = 50e18;
+
+        _deposit(depositAmount, borrower);
+        _depositForBorrow(depositAmount, depositor);
+
+        _borrow(borrowAmount, borrower);
+
+        assertEq(token0.balanceOf(borrower), 0);
+        assertEq(token0.balanceOf(depositor), 0);
+        assertEq(token0.balanceOf(address(silo0)), 100e18, "borrower collateral");
+
+        assertEq(token1.balanceOf(borrower), 50e18, "borrower debt");
+        assertEq(token1.balanceOf(depositor), 0);
+        assertEq(token1.balanceOf(address(silo1)), 50e18, "depositor's deposit");
+
+        vm.warp(block.timestamp + 100 days);
+        silo1.accrueInterest();
+
+        solvencyOracle0.breakOracle();
+        maxLtvOracle0.breakOracle();
+
+
+        assertTrue(_withdrawAll(), "expect all tx to be executed till the end");
+
+
+        assertEq(token0.balanceOf(borrower), 100e18, "borrower got all collateral");
+        assertEq(token0.balanceOf(depositor), 0, "depositor didnt had token1");
+        assertEq(token0.balanceOf(address(silo0)), 0);
+
+        assertEq(token1.balanceOf(borrower), 0, "borrower repay all debt");
+        assertEq(token1.balanceOf(depositor), 100e18 + 726118608081294262, "depositor got deposit + interest");
+        assertEq(token1.balanceOf(address(silo1)), 1, "everyone got collateral and fees, rounding policy left");
+
+        assertEq(silo0.getLiquidity(), 0, "silo0.getLiquidity");
+        assertEq(silo1.getLiquidity(), 1, "silo1.getLiquidity");
+    }
+
+    function _withdrawAll() internal returns (bool success) {
+        vm.prank(borrower);
+        vm.expectRevert("beforeQuote: oracle is broken");
+        silo0.redeem(1, borrower, borrower);
+        assertEq(token0.balanceOf(borrower), 0, "borrower can not withdraw even 1 wei when oracle broken");
+
+        uint256 silo1Balance = token1.balanceOf(address(silo1));
+        uint256 silo1Liquidity = silo1.getLiquidity();
+        emit log_named_decimal_uint("silo1Balance", silo1Balance, 18);
+        emit log_named_decimal_uint("silo1Liquidity", silo1Liquidity, 18);
+        assertGt(silo1Balance, 0, "expect tokens in silo");
+        assertGt(silo1Balance, silo1Liquidity, "we need case with interest");
+
+        vm.prank(depositor);
+        vm.expectRevert();
+        silo1.withdraw(silo1Liquidity + 1, depositor, depositor);
+        assertEq(token1.balanceOf(depositor), 0, "silo has only X tokens available, withdraw for depositor will fail");
+
+        vm.prank(depositor);
+        silo1.withdraw(silo1Liquidity, depositor, depositor);
+        assertEq(token1.balanceOf(depositor), silo1Liquidity, "depositor can withdraw up to liquidity without oracle");
+        assertEq(token1.balanceOf(address(silo1)), silo1Balance - silo1Liquidity, "no available tokens left in silo");
+
+        _repay(10, borrower);
+        assertEq(token1.balanceOf(address(silo1)), silo1Balance - silo1Liquidity + 10, "repay without oracle");
+
+        (, address collateralShareToken1, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+        uint256 borrowerDebtShares = IShareToken(debtShareToken).balanceOf(borrower);
+
+        _repayShares(silo1.previewRepayShares(borrowerDebtShares), borrowerDebtShares, borrower);
+        assertEq(IShareToken(debtShareToken).balanceOf(borrower), 0, "repay all without oracle - expect no share debt");
+
+        (, address collateralShareToken,) = silo0.config().getShareTokens(address(silo0));
+
+        vm.startPrank(borrower);
+        silo0.redeem(IShareToken(collateralShareToken).balanceOf(borrower), borrower, borrower);
+
+        vm.startPrank(depositor);
+        silo1.redeem(IShareToken(collateralShareToken1).balanceOf(depositor), depositor, depositor);
+
+        silo1.withdrawFees();
+
+        vm.stopPrank();
+        success = true;
+    }
+}

--- a/silo-core/test/foundry/_common/DummyOracle.sol
+++ b/silo-core/test/foundry/_common/DummyOracle.sol
@@ -8,6 +8,7 @@ contract DummyOracle is ISiloOracle {
     address public quoteToken;
 
     bool _expectBeforeQuote;
+    bool _oracleBroken;
 
     constructor(uint256 _price, address _quoteToken) {
         price = _price;
@@ -15,8 +16,9 @@ contract DummyOracle is ISiloOracle {
     }
 
     function beforeQuote(address _baseToken) external view {
-        if (_baseToken == quoteToken) revert("beforeQuote(): wrong base token");
-        if (!_expectBeforeQuote) revert("beforeQuote() was not expected, but was called anyway");
+        if (_baseToken == quoteToken) revert("beforeQuote: wrong base token");
+        if (_oracleBroken) revert("beforeQuote: oracle is broken");
+        if (!_expectBeforeQuote) revert("beforeQuote: was not expected, but was called anyway");
     }
 
     function setExpectBeforeQuote(bool _expect) external {
@@ -24,8 +26,17 @@ contract DummyOracle is ISiloOracle {
     }
 
     function quote(uint256 _baseAmount, address _baseToken) external view returns (uint256 quoteAmount) {
-        if (_baseToken == quoteToken) revert("wrong base token");
+        if (_baseToken == quoteToken) revert("quote: wrong base token");
+        if (_oracleBroken) revert("quote: oracle is broken");
 
         quoteAmount = _baseAmount * price / 1e18;
+    }
+
+    function breakOracle() external {
+        _oracleBroken = true;
+    }
+
+    function fixOracle() external {
+        _oracleBroken = false;
     }
 }

--- a/silo-core/test/foundry/_mocks/OracleMock.sol
+++ b/silo-core/test/foundry/_mocks/OracleMock.sol
@@ -18,4 +18,21 @@ contract OracleMock is Test {
         vm.mockCall(ADDRESS, data, abi.encode(_quoteAmount));
         vm.expectCall(ADDRESS, data);
     }
+
+    function expectQuote(uint256 _baseAmount, address _baseToken) external {
+        bytes memory data = abi.encodeWithSelector(ISiloOracle.quote.selector, _baseAmount, _baseToken);
+        vm.expectCall(ADDRESS, data);
+    }
+
+    // ISiloOracle.beforeQuote.selector: 0xf9fa619a
+    function beforeQuoteMock(address _baseToken) external {
+        bytes memory data = abi.encodeWithSelector(ISiloOracle.beforeQuote.selector, _baseToken);
+        vm.mockCall(ADDRESS, data, abi.encode());
+        vm.expectCall(ADDRESS, data);
+    }
+
+    function expectBeforeQuote(address _baseToken) external {
+        bytes memory data = abi.encodeWithSelector(ISiloOracle.beforeQuote.selector, _baseToken);
+        vm.expectCall(ADDRESS, data);
+    }
 }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.AssetType.Collateral)),
             "Withdraw partial with accrue interest",
-            158820
+            150894
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/312


Silo adjustment was done, to allow users withdraw tokens even when oracle is not working:
- if user has no debt we do not perform any checks related to solvency
- if user has debt, he need to repay (oracle is not needed for repay) before he can withdraw anything

Final result is that only liquidation and borrow will not work. We are fine with borrow not working. Liquidation is not blocking users to withdraw all available collateral.

Integration test for broken oracle included.

## New founding
Note: bug with `getLiquidity()` was discovered during tests - it return invalid result when there are interest.
