### PR TITLE
[0.0.25] TOB-SILO2-16: avoid minting zero collateral shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.25] - 2023-12-15
+### Fixed
+- [TOB-SILO2-16](https://github.com/silo-finance/silo-contracts-v2/issues/317): Minting zero collateral shares can 
+  inflate share calculation
+
 ## [0.0.24] - 2023-12-15
 ### Fixed
 - [TOB-SILO2-14](https://github.com/silo-finance/silo-contracts-v2/issues/314): Risk of daoAndDeployerFee overflow

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.43",
+  "version": "0.0.25",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/lib/SiloERC4626Lib.sol
+++ b/silo-core/contracts/lib/SiloERC4626Lib.sol
@@ -23,6 +23,8 @@ library SiloERC4626Lib {
     ///      deposited.
     uint256 internal constant _NO_DEPOSIT_LIMIT = type(uint256).max;
 
+    error ZeroShares();
+
     /// @notice Determines the maximum amount a user can deposit or mint
     /// @dev The function checks if deposit is possible for the given user, and if so, returns a constant
     /// representing no deposit limit
@@ -156,6 +158,8 @@ library SiloERC4626Lib {
             MathUpgradeable.Rounding.Down,
             ISilo.AssetType.Collateral
         );
+
+        if (shares == 0) revert ZeroShares();
 
         if (_token != address(0)) {
             // Transfer tokens before minting. No state changes have been made so reentrancy does nothing

--- a/silo-core/test/foundry/Silo/Preview.i.sol
+++ b/silo-core/test/foundry/Silo/Preview.i.sol
@@ -101,11 +101,15 @@ contract PreviewTest is SiloLittleHelper, Test {
             "you can get less shares on silo1 than on silo0, because we have interests here"
         );
 
-        assertEq(
-            previewShares1,
-            _depositForBorrow(_assets, depositor),
-            "previewDeposit with interest on the fly - must be as close but NOT more"
-        );
+        if (previewShares1 == 0) {
+            _depositForBorrowRevert(_assets, depositor, ISilo.ZeroShares.selector);
+        } else {
+            assertEq(
+                previewShares1,
+                _depositForBorrow(_assets, depositor),
+                "previewDeposit with interest on the fly - must be as close but NOT more"
+            );
+        }
 
         silo0.accrueInterest();
         silo1.accrueInterest();
@@ -116,11 +120,17 @@ contract PreviewTest is SiloLittleHelper, Test {
 
         assertLe(previewShares1, _assets, "with interests, we can receive less shares than assets amount");
 
-        assertEq(
-            previewShares1,
-            _depositForBorrow(_assets, depositor),
-            "previewDeposit after accrueInterest() - as close, but NOT more"
-        );
+        emit log_named_uint("previewShares1", previewShares1);
+
+        if (previewShares1 == 0) {
+            _depositForBorrowRevert(_assets, depositor, ISilo.ZeroShares.selector);
+        } else {
+            assertEq(
+                previewShares1,
+                _depositForBorrow(_assets, depositor),
+                "previewDeposit after accrueInterest() - as close, but NOT more"
+            );
+        }
     }
 
     /*

--- a/silo-core/test/foundry/_common/SiloLittleHelper.sol
+++ b/silo-core/test/foundry/_common/SiloLittleHelper.sol
@@ -30,6 +30,17 @@ abstract contract SiloLittleHelper is CommonBase {
         return _localFixture(_configName);
     }
 
+    function _depositForBorrowRevert(uint256 _assets, address _depositor, bytes4 _error) internal {
+        _mintTokens(token1, _assets, _depositor);
+
+        vm.startPrank(_depositor);
+        token1.approve(address(silo1), _assets);
+
+        vm.expectRevert(_error);
+        silo1.deposit(_assets, _depositor);
+        vm.stopPrank();
+    }
+
     function _depositForBorrow(uint256 _assets, address _depositor) internal returns (uint256 shares) {
         return _makeDeposit(silo1, token1, _assets, _depositor, ISilo.AssetType.Collateral);
     }


### PR DESCRIPTION
Approved: https://github.com/silo-finance/silo-contracts-v2/pull/323

## [0.0.25] - 2023-12-15
### Fixed
- [TOB-SILO2-16](https://github.com/silo-finance/silo-contracts-v2/issues/317): Minting zero collateral shares can 
  inflate share calculation