### PR TITLE
[0.0.26] TOB-SILO2-17: Flashloan fee can round down to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.26] - 2023-12-15
+### Fixed
+- [TOB-SILO2-17](https://github.com/silo-finance/silo-contracts-v2/issues/318): Flashloan fee can round down to zero
+
 ## [0.0.25] - 2023-12-15
 ### Fixed
 - [TOB-SILO2-16](https://github.com/silo-finance/silo-contracts-v2/issues/317): Minting zero collateral shares can 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/lib/SiloStdLib.sol
+++ b/silo-core/contracts/lib/SiloStdLib.sol
@@ -73,13 +73,18 @@ library SiloStdLib {
     /// @param _amount for which fee is calculated
     /// @return fee flash fee amount
     function flashFee(ISiloConfig _config, address _token, uint256 _amount) external view returns (uint256 fee) {
+        if (_amount == 0) return 0;
+
         // all user set fees are in 18 decimals points
         (,, uint256 flashloanFee, address asset) = _config.getFeesWithAsset(address(this));
-
         if (_token != asset) revert ISilo.Unsupported();
+        if (flashloanFee == 0) return 0;
 
         fee = _amount * flashloanFee;
         unchecked { fee /= _PRECISION_DECIMALS; }
+
+        // round up
+        if (fee == 0) return 1;
     }
 
     /// @notice Retrieves fee amounts in 18 decimals points and their respective receivers along with the asset

--- a/silo-core/test/foundry/lib/SiloStdLib/FlashFee.t.sol
+++ b/silo-core/test/foundry/lib/SiloStdLib/FlashFee.t.sol
@@ -43,11 +43,14 @@ contract FlashFeeTest is Test {
         feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 0, amount: 1e18, fee: 0});
         feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 0.1e18, amount: 0, fee: 0});
         feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 0, amount: 0, fee: 0});
+        feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 1, amount: 1, fee: 1});
         feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 0.125e18, amount: 1e18, fee: 0.125e18});
         feeTestCases[feeTestCasesIndex++] = FeeTestCase({flashloanFee: 0.65e18, amount: 1e18, fee: 0.65e18});
 
         for (uint256 index = 0; index < feeTestCasesIndex; index++) {
-            SILO_CONFIG.getFeesWithAssetMock(address(this), 0, 0, feeTestCases[index].flashloanFee, _asset);
+            if (feeTestCases[index].amount != 0) {
+                SILO_CONFIG.getFeesWithAssetMock(address(this), 0, 0, feeTestCases[index].flashloanFee, _asset);
+            }
 
             assertEq(SiloStdLib.flashFee(siloConfig, _asset, feeTestCases[index].amount), feeTestCases[index].fee);
         }


### PR DESCRIPTION
Approved: https://github.com/silo-finance/silo-contracts-v2/pull/324

## [0.0.26] - 2023-12-15
### Fixed
- [TOB-SILO2-17](https://github.com/silo-finance/silo-contracts-v2/issues/318): Flashloan fee can round down to zero
