### PR TITLE
UniswapV3Oracle contract implementation is left uninitialized

### DIFF
--- a/silo-oracles/contracts/uniswapV3/UniswapV3Oracle.sol
+++ b/silo-oracles/contracts/uniswapV3/UniswapV3Oracle.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.7.6;
 pragma abicoder v2;
 
-import {Initializable} from  "openzeppelin-contracts-upgradeable@v3.4.2/proxy/Initializable.sol";
 import {OracleLibrary} from  "uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol";
 import {IUniswapV3Pool} from  "uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
@@ -12,7 +11,7 @@ import {RevertBytes} from  "../lib/RevertBytes.sol";
 import {IUniswapV3Oracle} from "../interfaces/IUniswapV3Oracle.sol";
 import {UniswapV3OracleConfig} from "./UniswapV3OracleConfig.sol";
 
-contract UniswapV3Oracle is ISiloOracle, IUniswapV3Oracle, Initializable {
+contract UniswapV3Oracle is ISiloOracle, IUniswapV3Oracle {
     using RevertBytes for bytes;
 
     /// @dev Uniswap can revert with "Old" error when begin of TWAP period is older than oldest observation.
@@ -29,10 +28,16 @@ contract UniswapV3Oracle is ISiloOracle, IUniswapV3Oracle, Initializable {
     /// @dev deployment with configuration setup, can not be immutable because it is initialized
     UniswapV3OracleConfig public oracleConfig;
 
-    /// @param _configAddress UniswapV3OracleConfig address
-    function initialize(UniswapV3OracleConfig _configAddress) external virtual initializer {
-        oracleConfig = _configAddress;
+    constructor() {
+        // disable initializer
+        oracleConfig = UniswapV3OracleConfig(address(this));
+    }
 
+    /// @param _configAddress UniswapV3OracleConfig address
+    function initialize(UniswapV3OracleConfig _configAddress) external virtual {
+        if (address(oracleConfig) != address(0)) revert("Initializable: contract is already initialized");
+
+        oracleConfig = _configAddress;
         emit UniswapV3ConfigDeployed(_configAddress);
     }
 

--- a/silo-oracles/test/foundry/uniswapV3/UniswapV3Oracle.t.sol
+++ b/silo-oracles/test/foundry/uniswapV3/UniswapV3Oracle.t.sol
@@ -9,7 +9,7 @@ import "../../../contracts/uniswapV3/UniswapV3OracleFactory.sol";
 import "../_common/UniswapPools.sol";
 
 /*
-    FOUNDRY_PROFILE=silo-oracles forge test -vv --match-contract UniswapV3OracleTest
+    FOUNDRY_PROFILE=oracles forge test -vv --match-contract UniswapV3OracleTest
 */
 contract UniswapV3OracleTest is UniswapPools {
     UniswapV3OracleFactory public immutable ORACLE_FACTORY;
@@ -34,7 +34,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_price_Overflow
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_price_Overflow
     */
     function test_UniswapV3Oracle_price_Overflow() public {
         vm.expectRevert("Overflow");
@@ -42,7 +42,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_revert_whenPriceZero
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_revert_whenPriceZero
     */
     function test_UniswapV3Oracle_revert_whenPriceZero() public {
         vm.expectRevert(bytes("ZeroQuote"));
@@ -50,7 +50,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_revert_onQuoteQuote
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_revert_onQuoteQuote
     */
     function test_UniswapV3Oracle_revert_onQuoteQuote() public {
         vm.expectRevert("UseBaseAmount");
@@ -58,7 +58,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_invalidBaseToken
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_invalidBaseToken
     */
     function test_UniswapV3Oracle_invalidBaseToken() public {
         vm.expectRevert(bytes("ZeroQuote"));
@@ -66,7 +66,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_supportOLDError
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_supportOLDError
     */
     function test_UniswapV3Oracle_supportOLDError() public {
         // at block 17977506:
@@ -93,7 +93,7 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_oldestTimestamp
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_oldestTimestamp
     */
     function test_UniswapV3Oracle_oldestTimestamp() public {
         // last one is 1692794747
@@ -102,14 +102,14 @@ contract UniswapV3OracleTest is UniswapPools {
     }
 
     /*
-        FOUNDRY_PROFILE=silo-oracles forge test -vvv --mt test_UniswapV3Oracle_price_gas
+        FOUNDRY_PROFILE=oracles forge test -vvv --mt test_UniswapV3Oracle_price_gas
     */
     function test_UniswapV3Oracle_price_gas() public {
         uint256 gasStart = gasleft();
         uint256 priceView = PRICE_PROVIDER.quote(1e18, address(tokens["WETH"]));
         uint256 gasSpend = gasStart - gasleft();
         emit log_named_uint("gasSpend", gasSpend);
-        assertEq(gasSpend, 80825, "expect optimised gas #1");
+        assertEq(gasSpend, 80775, "expect optimised gas #1");
 
         assertEq(priceView, 1641_609559, "expect ETH price in USDC");
 
@@ -132,7 +132,7 @@ contract UniswapV3OracleTest is UniswapPools {
         gasSpend = gasStart - gasleft();
         emit log_named_uint("at block", otherBlock);
         emit log_named_uint("gasSpend", gasSpend);
-        assertEq(gasSpend, 50307, "expect optimised gas #1");
+        assertEq(gasSpend, 50257, "expect optimised gas #1");
 
         assertEq(priceView, 1657_278376, "expect ETH price in USDC");
     }

--- a/silo-oracles/test/foundry/uniswapV3/UniswapV3OracleFactory.t.sol
+++ b/silo-oracles/test/foundry/uniswapV3/UniswapV3OracleFactory.t.sol
@@ -12,7 +12,7 @@ import "../_common/UniswapPools.sol";
 import "../../../contracts/uniswapV3/UniswapV3OracleFactory.sol";
 
 /*
-    FOUNDRY_PROFILE=oracles forge test -vv --match-contract UniswapV3OracleFactoryTest
+    FOUNDRY_PROFILE=oracles forge test -vv --mc UniswapV3OracleFactoryTest
 */
 contract UniswapV3OracleFactoryTest is UniswapPools {
     uint256 constant TEST_BLOCK = 17970874;
@@ -205,7 +205,7 @@ contract UniswapV3OracleFactoryTest is UniswapPools {
         uint256 gasEnd = gasleft();
 
         emit log_named_uint("gas", gasStart - gasEnd);
-        assertEq(gasStart - gasEnd, 237206, "optimise gas");
+        assertEq(gasStart - gasEnd, 236243, "optimise gas");
 
         UniswapV3Oracle oracle2 =  UNISWAPV3_ORACLE_FACTORY.create(cfg);
 
@@ -217,7 +217,10 @@ contract UniswapV3OracleFactoryTest is UniswapPools {
     */
     function test_UniswapV3OracleFactory_create_whenImplementationInitialised() public {
         UniswapV3Oracle implementation = UniswapV3Oracle(UNISWAPV3_ORACLE_FACTORY.ORACLE_IMPLEMENTATION());
-        implementation.initialize(new UniswapV3OracleConfig(creationConfig, 1800 * 10 / 120));
+
+        UniswapV3OracleConfig validConfig = new UniswapV3OracleConfig(creationConfig, 1800 * 10 / 120);
+        vm.expectRevert("Initializable: contract is already initialized");
+        implementation.initialize(validConfig);
 
         UniswapV3Oracle oracle = UNISWAPV3_ORACLE_FACTORY.create(IUniswapV3Oracle.UniswapV3DeploymentConfig(
             pools["CRV_ETH"],


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/255

Old openenzeppelin contracts does not have disabeling option, so we did that manually.