### PR TITLE
[0.0.31] TOB-SILO2-18: Minimum acceptable LTV is not enforced for liquidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.31] - 2023-12-18
+### Fixed
+- [issue-319](https://github.com/silo-finance/silo-contracts-v2/issues/319) TOB-SILO2-18: Minimum acceptable LTV is not
+  enforced for full liquidation
+
 ## [0.0.30] - 2023-12-18
 ### Fixed
-- [issue-286](https://github.com/silo-finance/silo-contracts-v2/issues/286) TOB-SILO2-3: Flash Loans cannot be performed through the SiloRouter contract
+- [issue-286](https://github.com/silo-finance/silo-contracts-v2/issues/286) TOB-SILO2-3: Flash Loans cannot be performed 
+  through the SiloRouter contract
 
 ## [0.0.29] - 2023-12-18
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -926,7 +926,7 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable, Leverag
         }
     }
 
-    // solhint-disable-next-line function-max-lines
+    // solhint-disable-next-line function-max-lines, code-complexity
     function _withdraw(
         uint256 _assets,
         uint256 _shares,

--- a/silo-core/contracts/lib/SiloLiquidationLib.sol
+++ b/silo-core/contracts/lib/SiloLiquidationLib.sol
@@ -5,6 +5,18 @@ import {ISiloConfig} from "../interfaces/ISiloConfig.sol";
 import {ISiloLiquidation} from "../interfaces/ISiloLiquidation.sol";
 
 library SiloLiquidationLib {
+    struct LiquidationPreviewParams {
+        uint256 collateralLt;
+        address collateralConfigAsset;
+        address debtConfigAsset;
+        uint256 debtToCover;
+        uint256 liquidationFee;
+        bool selfLiquidation;
+    }
+
+    /// @dev this is basically LTV == 100%
+    uint256 internal constant _BAD_DEBT = 1e18;
+
     uint256 internal constant _PRECISION_DECIMALS = 1e18;
 
     /// @dev when user is insolvent with some LT, we will allow to liquidate to some minimal level of ltv
@@ -48,70 +60,92 @@ library SiloLiquidationLib {
         debtToRepay = valueToAssetsByRatio(repayValue, _borrowerDebtAssets, _borrowerDebtValue);
     }
 
-    /// @notice this method does not care about ltv, it will calculate based on any values, this is just a pure math
-    /// if ltv is over 100% this method should not be called, it should be full liquidation right away
-    /// This function never reverts
-    /// This function unchecks LTV calculations. Uncheck is safe only when we already calculate LTV before
-    /// @param _debtToCover amount of debt token to use for repay
-    /// @return collateralAssetsToLiquidate this is how much collateral liquidator will get
-    /// @return debtAssetsToRepay this is how much debt had been repay, it might be less or eq than `_debtToCover`
-    /// @return ltvAfterLiquidation if 0, means this is full liquidation
-    function calculateExactLiquidationAmounts(
-        uint256 _debtToCover,
-        uint256 _sumOfBorrowerCollateralAssets,
-        uint256 _sumOfBorrowerCollateralValue,
-        uint256 _totalBorrowerDebtAssets,
-        uint256 _totalBorrowerDebtValue,
-        uint256 _liquidationFee
+    /// @dev in case of self liquidation or in case of bad debt, we do not apply any restrictions.
+    /// We do not have restriction how much user need to repay, so there is no point of having restrictions on self
+    /// liquidation, the only rule is - we do not apply fee, because in some cases it can lead to increasing LTV
+    /// In case of bad debt, liquidation without restriction will be possible only in case of receiving underlying
+    /// tokens, because sToken transfer fail when we leave user insolvent
+    /// @notice might revert when one of this values will be zero:
+    /// `_sumOfCollateralValue`, `_borrowerDebtAssets`, `_borrowerDebtValue`
+    function liquidationPreview( // solhint-disable-line function-max-lines
+        uint256 _ltvBefore,
+        uint256 _sumOfCollateralAssets,
+        uint256 _sumOfCollateralValue,
+        uint256 _borrowerDebtAssets,
+        uint256 _borrowerDebtValue,
+        LiquidationPreviewParams memory _params
+    )
+        external
+        pure
+        returns (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter)
+    {
+        uint256 collateralValueToLiquidate;
+        uint256 debtValueToRepay;
+
+        if (_params.selfLiquidation || _ltvBefore >= _BAD_DEBT) {
+            // in case of self liquidation OR when we have bad debt, we allow for any amount
+            debtToRepay = _params.debtToCover > _borrowerDebtAssets ? _borrowerDebtAssets : _params.debtToCover;
+            debtValueToRepay = valueToAssetsByRatio(debtToRepay, _borrowerDebtValue, _borrowerDebtAssets);
+        } else {
+            uint256 maxRepayValue = estimateMaxRepayValue(
+                _borrowerDebtValue,
+                _sumOfCollateralValue,
+                minAcceptableLTV(_params.collateralLt),
+                _params.liquidationFee
+            );
+
+            if (maxRepayValue == _borrowerDebtValue) {
+                // forced full liquidation
+                debtToRepay = _borrowerDebtAssets;
+                debtValueToRepay = _borrowerDebtValue;
+            } else {
+                // partial liquidation
+                uint256 maxDebtToRepay = valueToAssetsByRatio(maxRepayValue, _borrowerDebtAssets, _borrowerDebtValue);
+                debtToRepay = _params.debtToCover > maxDebtToRepay ? maxDebtToRepay : _params.debtToCover;
+                debtValueToRepay = valueToAssetsByRatio(debtToRepay, _borrowerDebtValue, _borrowerDebtAssets);
+            }
+        }
+
+        collateralValueToLiquidate = calculateCollateralToLiquidate(
+            debtValueToRepay, _sumOfCollateralValue, _params.selfLiquidation ? 0 : _params.liquidationFee
+        );
+
+        collateralToLiquidate = valueToAssetsByRatio(
+            collateralValueToLiquidate,
+            _sumOfCollateralAssets,
+            _sumOfCollateralValue
+        );
+
+        ltvAfter = calculateLtvAfter(
+            _sumOfCollateralValue, _borrowerDebtValue, collateralValueToLiquidate, debtValueToRepay
+        );
+    }
+
+    function calculateLtvAfter(
+        uint256 _sumOfCollateralValue,
+        uint256 _totalDebtValue,
+        uint256 _collateralValueToLiquidate,
+        uint256 _debtValueToCover
     )
         internal
         pure
-        returns (uint256 collateralAssetsToLiquidate, uint256 debtAssetsToRepay, uint256 ltvAfterLiquidation)
+        returns (uint256 ltvAfterLiquidation)
     {
-        if (_sumOfBorrowerCollateralValue == 0) { // we need to support this weird case to not revert on /0
-            return (_sumOfBorrowerCollateralAssets, _debtToCover, 0);
+        if (_sumOfCollateralValue == _collateralValueToLiquidate || _totalDebtValue == _debtValueToCover) {
+            return 0;
         }
 
-        if (_debtToCover == 0 || _totalBorrowerDebtValue == 0 || _totalBorrowerDebtAssets == 0) {
-            return (0, 0, _ltvAfter(_sumOfBorrowerCollateralValue, _totalBorrowerDebtValue));
-        }
-
-        // full on dust OR when _debtToCover higher then total assets
-        // keeping _debtToCover to original value and do math on _totalBorrowerDebtAssets prevents overflow on hi values
-        if (_debtToCover > _POSITION_DUST_LEVEL * _totalBorrowerDebtAssets / _PRECISION_DECIMALS) {
-            uint256 liquidationValue = calculateCollateralToLiquidate(
-                _totalBorrowerDebtValue, _sumOfBorrowerCollateralValue, _liquidationFee
+        unchecked { // all subs are safe because this values are chunks of total, so we will not underflow
+            ltvAfterLiquidation = _ltvAfter(
+                _sumOfCollateralValue - _collateralValueToLiquidate,
+                _totalDebtValue - _debtValueToCover
             );
-
-            collateralAssetsToLiquidate = valueToAssetsByRatio(
-                liquidationValue, _sumOfBorrowerCollateralAssets, _sumOfBorrowerCollateralValue
-            );
-
-            return (collateralAssetsToLiquidate, _totalBorrowerDebtAssets, 0);
-        }
-
-        debtAssetsToRepay = _debtToCover;
-        uint256 collateralValueToLiquidate;
-        uint256 debtValueToCover = _totalBorrowerDebtValue * debtAssetsToRepay / _totalBorrowerDebtAssets;
-
-        (collateralAssetsToLiquidate, collateralValueToLiquidate) = calculateCollateralsToLiquidate(
-            debtValueToCover, _sumOfBorrowerCollateralValue, _sumOfBorrowerCollateralAssets, _liquidationFee
-        );
-
-        if (_sumOfBorrowerCollateralValue == collateralValueToLiquidate) {
-            ltvAfterLiquidation = 0;
-        } else {
-            unchecked { // all subs are safe because this values are chunks of total, so we will not underflow
-                ltvAfterLiquidation = _ltvAfter(
-                    _sumOfBorrowerCollateralValue - collateralValueToLiquidate,
-                    _totalBorrowerDebtValue - debtValueToCover
-                );
-            }
         }
     }
 
     /// @notice reverts on `_totalValue` == 0
     /// @dev calculate assets based on ratio: assets = (value, totalAssets, totalValue)
+    /// to calculate assets => value, use it like: value = (assets, totalValue, totalAssets)
     function valueToAssetsByRatio(uint256 _value, uint256 _totalAssets, uint256 _totalValue)
         internal
         pure
@@ -195,11 +229,14 @@ library SiloLiquidationLib {
     /// @dev the math is based on: (Dv - x)/(Cv - (x + xf)) = LT
     /// where Dv: debt value, Cv: collateral value, LT: expected LT, f: liquidation fee, x: is value we looking for
     /// x = (Dv - LT * Cv) / (DP - LT - LT * f)
+    /// result also take into consideration the dust
     /// @notice protocol does not uses this method, because in protocol our input is debt to cover in assets
     /// however this is useful to figure out what is max debt to cover.
     /// @param _totalBorrowerCollateralValue regular and protected
     /// @param _ltvAfterLiquidation % of `repayValue` that liquidator will use as profit from liquidating
-    function estimateMaxRepayValue(
+    /// @return repayValue max repay value that is allowed for partial liquidation. if this value equals
+    /// `_totalBorrowerDebtValue`, that means dust threshold was triggered and result force to do full liquidation
+    function estimateMaxRepayValue( // solhint-disable-line code-complexity
         uint256 _totalBorrowerDebtValue,
         uint256 _totalBorrowerCollateralValue,
         uint256 _ltvAfterLiquidation,
@@ -209,17 +246,13 @@ library SiloLiquidationLib {
         if (_liquidityFee >= _PRECISION_DECIMALS) return 0;
 
         // this will cover case, when _totalBorrowerCollateralValue == 0
-        if (_totalBorrowerDebtValue >= _totalBorrowerCollateralValue) {
-            return _totalBorrowerDebtValue;
-        }
-
-        if (_ltvAfterLiquidation == 0) { // full liquidation
-            return _totalBorrowerDebtValue;
-        }
+        if (_totalBorrowerDebtValue >= _totalBorrowerCollateralValue) return _totalBorrowerDebtValue;
+        if (_ltvAfterLiquidation == 0) return _totalBorrowerDebtValue; // full liquidation
 
         // x = (Dv - LT * Cv) / (DP - LT - LT * f) ==> (Dv - LT * Cv) / (DP - (LT + LT * f))
         uint256 ltCv = _ltvAfterLiquidation * _totalBorrowerCollateralValue;
-        unchecked { ltCv /= _PRECISION_DECIMALS; }
+        // to lose as low precision as possible, instead of `ltCv/1e18`, we increase precision of DebtValue
+        _totalBorrowerDebtValue *= _PRECISION_DECIMALS;
 
         // negative value means our current LT is lower than _ltvAfterLiquidation
         if (ltCv >= _totalBorrowerDebtValue) return 0;
@@ -234,13 +267,18 @@ library SiloLiquidationLib {
             dividerR = _ltvAfterLiquidation + _ltvAfterLiquidation * _liquidityFee / _PRECISION_DECIMALS;
         }
 
+        // now we can go back to proper precision
+        unchecked { _totalBorrowerDebtValue /= _PRECISION_DECIMALS; }
+
         // if dividerR is more than 100%, means it is impossible to go down to _ltvAfterLiquidation, return all
         if (dividerR >= _PRECISION_DECIMALS) {
-            return _totalBorrowerDebtValue;
+             return _totalBorrowerDebtValue;
         }
 
-        repayValue *= _PRECISION_DECIMALS;
         unchecked { repayValue /= (_PRECISION_DECIMALS - dividerR); }
+
+        // early return so we do not have to check for dust
+        if (repayValue > _totalBorrowerDebtValue) return _totalBorrowerDebtValue;
 
         // here is weird case, sometimes it is impossible to go down to target LTV, however math can calculate it
         // eg with negative numerator and denominator and result will be positive, that's why we simply return all

--- a/silo-core/test/foundry/_common/SiloLiquidationExecLibImpl.sol
+++ b/silo-core/test/foundry/_common/SiloLiquidationExecLibImpl.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.0;
 
 import {SiloSolvencyLib} from "silo-core/contracts/lib/SiloSolvencyLib.sol";
+import {SiloLiquidationLib} from "silo-core/contracts/lib/SiloLiquidationLib.sol";
 import {SiloLiquidationExecLib} from "silo-core/contracts/lib/SiloLiquidationExecLib.sol";
 
 contract SiloLiquidationExecLibImpl {
     function liquidationPreview(
         SiloSolvencyLib.LtvData memory _ltvData,
-        SiloLiquidationExecLib.LiquidationPreviewParams memory _params
+        SiloLiquidationLib.LiquidationPreviewParams memory _params
     )
         external
         view

--- a/silo-core/test/foundry/data-readers/GetExactLiquidationAmountsTestData.sol
+++ b/silo-core/test/foundry/data-readers/GetExactLiquidationAmountsTestData.sol
@@ -110,8 +110,9 @@ contract GetExactLiquidationAmountsTestData {
         data[i].input.debtToCover = 99999e18;
         data[i].input.selfLiquidation = true;
 
+        // on self liquidation, when we repay all, we receive all collateral back
         data[i].output.fromProtected = 1e18;
-        data[i].output.fromCollateral = 0.59e18;
+        data[i].output.fromCollateral = 1e18;
         data[i].output.repayDebtAssets = 1.59e18;
     }
 

--- a/silo-core/test/foundry/data-readers/LiquidationPreviewTestData.sol
+++ b/silo-core/test/foundry/data-readers/LiquidationPreviewTestData.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract CalculateExactLiquidationAmountsTestData {
+contract LiquidationPreviewTestData {
     struct Input {
+        uint256 lt;
         uint256 debtToCover;
         uint256 totalBorrowerDebtValue;
         uint256 totalBorrowerDebtAssets;
@@ -28,6 +29,7 @@ contract CalculateExactLiquidationAmountsTestData {
 
         data[i++] = CELAData({ // #0
             input: Input({
+                lt: 1,
                 debtToCover: 0,
                 totalBorrowerDebtValue: 1,
                 totalBorrowerDebtAssets: 1,
@@ -35,7 +37,7 @@ contract CalculateExactLiquidationAmountsTestData {
                 totalBorrowerCollateralAssets: 1,
                 liquidationFee: 0
             }),
-            output: Output({
+            output: Output({ // FULL liquidation forced
                 collateralAssetsToLiquidate: 0,
                 debtAssetsToRepay: 0,
                 ltvAfterLiquidation: 1e18
@@ -44,22 +46,7 @@ contract CalculateExactLiquidationAmountsTestData {
 
         data[i++] = CELAData({ // #1
             input: Input({
-                debtToCover: 0,
-                totalBorrowerDebtValue: 1,
-                totalBorrowerDebtAssets: 1,
-                totalBorrowerCollateralValue: 1,
-                totalBorrowerCollateralAssets: 1,
-                liquidationFee: 0
-            }),
-            output: Output({
-                collateralAssetsToLiquidate: 0,
-                debtAssetsToRepay: 0,
-                ltvAfterLiquidation: 1e18
-            })
-        });
-
-        data[i++] = CELAData({ // #2
-            input: Input({
+                lt: 1,
                 debtToCover: 0,
                 totalBorrowerDebtValue: 1,
                 totalBorrowerDebtAssets: 1,
@@ -74,8 +61,9 @@ contract CalculateExactLiquidationAmountsTestData {
             })
         });
 
-        data[i++] = CELAData({ // #3
+        data[i++] = CELAData({ // #2
             input: Input({
+                lt: 0.79e18,
                 debtToCover: 0,
                 totalBorrowerDebtValue: 1e18,
                 totalBorrowerDebtAssets: 1e18,
@@ -90,8 +78,9 @@ contract CalculateExactLiquidationAmountsTestData {
             })
         });
 
-        data[i++] = CELAData({ // #4
+        data[i++] = CELAData({ // #3
             input: Input({
+                lt: 0.0099e18,
                 debtToCover: 1,
                 totalBorrowerDebtValue: 1e18,
                 totalBorrowerDebtAssets: 1e18,
@@ -102,12 +91,13 @@ contract CalculateExactLiquidationAmountsTestData {
             output: Output({
                 collateralAssetsToLiquidate: 1,
                 debtAssetsToRepay: 1,
-                ltvAfterLiquidation: 9999999999999999 // (1e18 - 1) / (100e18 - 1)
+                ltvAfterLiquidation: 0.009999999999999999e18 // (1e18 - 1) / (100e18 - 1)
             })
         });
 
-        data[i++] = CELAData({ // #5
+        data[i++] = CELAData({ // #4
             input: Input({
+                lt: 0.01e18,
                 debtToCover: 100,
                 totalBorrowerDebtValue: 1e18,
                 totalBorrowerDebtAssets: 1e18,
@@ -122,25 +112,27 @@ contract CalculateExactLiquidationAmountsTestData {
             })
         });
 
-        data[i++] = CELAData({ // #6
+        data[i++] = CELAData({ // #5
             input: Input({
+                lt: 0.80e18,
                 debtToCover: 0.5e18, // the value is 40e18 + fee => 44e18 in value
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerDebtAssets: 1e18,
                 totalBorrowerCollateralValue: 100e18,
                 totalBorrowerCollateralAssets: 10e18,
-                liquidationFee: 0.1e18
+                liquidationFee: 0.10e18
             }),
             output: Output({
-                collateralAssetsToLiquidate: 44e18 / 10,
-                debtAssetsToRepay: 0.5e18,
-                ltvAfterLiquidation: 7142_85714285714285
+                collateralAssetsToLiquidate: 4230769230769230767,
+                debtAssetsToRepay: 480769230769230769,
+                ltvAfterLiquidation: 720000000000000000 // this is minimal acceptable LTV
             })
         });
 
         // this is just before full liquidation because of "dust"
-        data[i++] = CELAData({ // #7
+        data[i++] = CELAData({ // #6
             input: Input({
+                lt: 0.001e18,
                 debtToCover: 0.90e18, // the value is 72e18 + fee => 79.2e18 in value
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerDebtAssets: 1e18,
@@ -149,19 +141,19 @@ contract CalculateExactLiquidationAmountsTestData {
                 liquidationFee: 0.1e18
             }),
             output: Output({
-                collateralAssetsToLiquidate: 79.2e18 / 900,
-                debtAssetsToRepay: 0.90e18,
+                collateralAssetsToLiquidate: 87964862992139996, // 79.2e18 / 900 => 0.88,
+                debtAssetsToRepay: 0.899640644237795417e18,
                 // (80e18 - 72e18) / (9_000e18 - 72e18 - 72e18 * 0.1) = 0.000896780557797507
-                ltvAfterLiquidation: 896780557797506
+                ltvAfterLiquidation: 0.000900000000000000e18
             })
         });
 
         // this will do full liquidation because of dust
         // input values are made up and looks like we have huge collateral
-        // but the math in this method does not care about ltv and logic, it just calculates
-        data[i++] = CELAData({ // #8
+        data[i++] = CELAData({ // #7
             input: Input({
-                debtToCover: 0.91e18, // the value is 72.8e18, but this is over "dust" margin, so it will be full
+                lt: 0.0088e18,
+                debtToCover: 0.91e18, // the value is 72.8e18, but this is too much anyway, it will be lowered by math
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerDebtAssets: 1e18, // 1debt token == 80 in value
                 totalBorrowerCollateralValue: 9_000e18,
@@ -169,7 +161,26 @@ contract CalculateExactLiquidationAmountsTestData {
                 liquidationFee: 0.01e18
             }),
             output: Output({
-                collateralAssetsToLiquidate: uint256(80e18 + 80e18 * 0.01e18 / 1e18) / 900,
+                collateralAssetsToLiquidate: 9864687385108739,
+                debtAssetsToRepay: 109878943646013188,
+                ltvAfterLiquidation: 7920000000000000
+            })
+        });
+
+        // this will do full liquidation because of dust
+        // input values are made up and looks like we have huge collateral
+        data[i++] = CELAData({ // #8
+            input: Input({
+                lt: 0.08e18,
+                debtToCover: 0.91e18, // the value is 72.8e18, but this is over "dust" margin, so it will be full
+                totalBorrowerDebtValue: 80e18,
+                totalBorrowerDebtAssets: 1e18, // 1debt token == 80 in value
+                totalBorrowerCollateralValue: 90e18,
+                totalBorrowerCollateralAssets: 10e18, // 1token == 9 in value
+                liquidationFee: 0.01e18
+            }),
+            output: Output({
+                collateralAssetsToLiquidate: uint256(80e18 + 80e18 * 0.01e18 / 1e18) / 9,
                 debtAssetsToRepay: 1e18,
                 ltvAfterLiquidation: 0
             })
@@ -178,6 +189,7 @@ contract CalculateExactLiquidationAmountsTestData {
         // if we expect ltv to be 0, we need full liquidation
         data[i++] = CELAData({ // #9
             input: Input({
+                lt: 0.08e18,
                 debtToCover: 160e18,
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerDebtAssets: 160e18,
@@ -194,6 +206,7 @@ contract CalculateExactLiquidationAmountsTestData {
 
         data[i++] = CELAData({ // #10
             input: Input({
+                lt: 0.08e18,
                 debtToCover: 10e18,
                 totalBorrowerDebtValue: 180e18,
                 totalBorrowerDebtAssets: 180e18,
@@ -211,6 +224,7 @@ contract CalculateExactLiquidationAmountsTestData {
         // we have bad debt and we will cover everything
         data[i++] = CELAData({ // #11
             input: Input({
+                lt: 0.99e18,
                 debtToCover: 100e18,
                 totalBorrowerDebtValue: 12e18,
                 totalBorrowerDebtAssets: 12e18,
@@ -228,7 +242,8 @@ contract CalculateExactLiquidationAmountsTestData {
         // we have bad debt and we will cover everything #2
         data[i++] = CELAData({ // #12
             input: Input({
-                debtToCover: 100e18,
+                lt: 0.99e18,
+                debtToCover: 1000000e18,
                 totalBorrowerDebtValue: 12e18,
                 totalBorrowerDebtAssets: 18e18,
                 totalBorrowerCollateralValue: 10e18,

--- a/silo-core/test/foundry/data-readers/MaxLiquidationPreviewTestData.sol
+++ b/silo-core/test/foundry/data-readers/MaxLiquidationPreviewTestData.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 contract MaxLiquidationPreviewTestData {
     struct Input {
+        uint256 lt;
         uint256 totalBorrowerDebtValue;
         uint256 totalBorrowerCollateralValue;
         uint256 ltvAfterLiquidation;
@@ -27,6 +28,7 @@ contract MaxLiquidationPreviewTestData {
         // no debt no liquidation
         data[i++] = MLPData({
             input: Input({
+                lt: 0.8e18,
                 totalBorrowerDebtValue: 0,
                 totalBorrowerCollateralValue: 1e18,
                 ltvAfterLiquidation: 0.7e18,
@@ -42,21 +44,23 @@ contract MaxLiquidationPreviewTestData {
         // when bad debt
         data[i++] = MLPData({
             input: Input({
+                lt: 0.8e18,
                 totalBorrowerDebtValue: 180e18,
                 totalBorrowerCollateralValue: 100e18,
-                ltvAfterLiquidation: 0.7e18,
+                ltvAfterLiquidation: 0,
                 liquidityFee: 0.05e18
             }),
                 output: Output({
                 collateralValueToLiquidate: 100e18,
                 repayValue: 180e18,
-                targetLtvPossible: false
+                targetLtvPossible: true
             })
         });
 
         // if we expect ltv to be 0, we need full liquidation
         data[i++] = MLPData({
             input: Input({
+                lt: 0.05e18,
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0,
@@ -72,6 +76,7 @@ contract MaxLiquidationPreviewTestData {
         // if we over 100% with fee, then we return all
         data[i++] = MLPData({
             input: Input({
+                lt: 0.8e18,
                 totalBorrowerDebtValue: 98e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.97e18,
@@ -84,10 +89,11 @@ contract MaxLiquidationPreviewTestData {
             })
         });
 
-        // if we over 100% with fee, then we return all - COUNTEREXAMPLE
+        // "if we over 100% with fee, then we return all" - COUNTEREXAMPLE to above case
         // but we caught dust, so again full liquidation
         data[i++] = MLPData({
             input: Input({
+                lt: 0.8e18,
                 totalBorrowerDebtValue: 98e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.97e18,
@@ -103,6 +109,7 @@ contract MaxLiquidationPreviewTestData {
         // example from excel simulation
         data[i++] = MLPData({
             input: Input({
+                lt: uint256(0.7e18) * 1e18 / 0.9e18, // ~77,77%
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.7e18,

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISiloLiquidation.liquidationCall, (address(token0), address(token1), BORROWER, ASSETS / 2, false)),
             "LiquidationCall with accrue interest",
-            296418
+            301237
         );
     }
 }

--- a/silo-core/test/foundry/lib/SiloLiquidationExecLib/GetExactLiquidationAmounts.t.sol
+++ b/silo-core/test/foundry/lib/SiloLiquidationExecLib/GetExactLiquidationAmounts.t.sol
@@ -160,6 +160,7 @@ contract GetExactLiquidationAmountsTest is GetExactLiquidationAmountsHelper {
 
             P_SHARE_TOKEN_A.balanceOfMock(testData.input.user, testData.mocks.protectedUserSharesBalanceOf);
             P_SHARE_TOKEN_A.totalSupplyMock(testData.mocks.protectedSharesTotalSupply);
+
             SILO_A.getCollateralAndProtectedAssetsMock(
                 testData.mocks.siloTotalCollateralAssets,
                 testData.mocks.siloTotalProtectedAssets
@@ -193,7 +194,7 @@ contract GetExactLiquidationAmountsTest is GetExactLiquidationAmountsHelper {
     forge test -vv --mt test_getExactLiquidationAmounts_selfLiquidation_fuzz
     make sure self-liquidation can not make user insolvent
     */
-    /// forge-config: core.fuzz.runs = 10000
+    /// forge-config: core.fuzz.runs = 8000
     function test_getExactLiquidationAmounts_selfLiquidation_fuzz(
         uint128 _debtToCover,
         uint128 _collateralUserBalanceOf,

--- a/silo-core/test/foundry/lib/SiloLiquidationLib/MaxLiquidation.t.sol
+++ b/silo-core/test/foundry/lib/SiloLiquidationLib/MaxLiquidation.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloLiquidation} from "silo-core/contracts/interfaces/ISiloLiquidation.sol";
+import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
+import {SiloSolvencyLib} from "silo-core/contracts/lib/SiloSolvencyLib.sol";
+import {SiloLiquidationExecLib} from "silo-core/contracts/lib/SiloLiquidationExecLib.sol";
+import {SiloLiquidationLib} from "silo-core/contracts/lib/SiloLiquidationLib.sol";
+
+import {OraclesHelper} from "../../_common/OraclesHelper.sol";
+import {OracleMock} from "../../_mocks/OracleMock.sol";
+import {SiloLiquidationExecLibImpl} from "../../_common/SiloLiquidationExecLibImpl.sol";
+import "../SiloLiquidationLib/MaxRepayRawMath.sol";
+
+// forge test -vv --mc MaxLiquidationTest
+contract MaxLiquidationTest is Test, MaxRepayRawMath {
+    /// @dev _LT_LIQUIDATION_MARGIN must match value from SiloLiquidationLib
+    uint256 internal constant _LT_LIQUIDATION_MARGIN = 0.9e18; // 90%
+    uint256 internal constant _DECIMALS_POINTS = 1e18; // 90%
+
+    /*
+    forge test -vv --mt test_maxLiquidation_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 5000
+    function test_maxLiquidation_fuzz(
+        uint128 _sumOfCollateralAssets,
+        uint128 _sumOfCollateralValue,
+        uint128 _borrowerDebtAssets,
+        uint64 _liquidityFee
+    ) public {
+        vm.assume(_liquidityFee < 0.40e18); // some reasonable fee
+        vm.assume(_sumOfCollateralAssets > 0);
+        // for tiny assets we doing full liquidation because it is to small to get down to expected minimal LTV
+        vm.assume(_sumOfCollateralValue > 1);
+        vm.assume(_borrowerDebtAssets > 1);
+
+        // prevent overflow revert in test
+        vm.assume(uint256(_borrowerDebtAssets) * _liquidityFee < type(uint128).max);
+
+        uint256 lt = 0.85e18;
+        uint256 borrowerDebtValue = _borrowerDebtAssets; // assuming quote is debt token, so value is 1:1
+        uint256 ltvBefore = borrowerDebtValue * 1e18 / _sumOfCollateralValue;
+
+        // if ltv will be less, then this math should not be executed in contract
+        vm.assume(ltvBefore >= lt);
+
+        (
+            uint256 collateralToLiquidate, uint256 debtToRepay
+        ) = SiloLiquidationLib.maxLiquidation(
+            _sumOfCollateralAssets,
+            _sumOfCollateralValue,
+            _borrowerDebtAssets,
+            borrowerDebtValue,
+            lt,
+            _liquidityFee
+        );
+
+        emit log_named_decimal_uint("collateralToLiquidate", collateralToLiquidate, 18);
+        emit log_named_decimal_uint("debtToRepay", debtToRepay, 18);
+
+        uint256 minExpectedLtv = SiloLiquidationLib.minAcceptableLTV(lt);
+        emit log_named_decimal_uint("minExpectedLtv", minExpectedLtv, 16);
+        emit log_named_decimal_uint("ltvBefore", ltvBefore, 16);
+
+        uint256 raw = _estimateMaxRepayValueRaw(borrowerDebtValue, _sumOfCollateralValue, minExpectedLtv, _liquidityFee);
+        emit log_named_decimal_uint("raw", raw, 18);
+
+        uint256 deviation = raw > debtToRepay
+            ? raw * _DECIMALS_POINTS / debtToRepay
+            : debtToRepay * _DECIMALS_POINTS / raw;
+
+        emit log_named_decimal_uint("deviation on raw calculation", deviation, 18);
+
+        if (debtToRepay == _borrowerDebtAssets) {
+            assertLe(deviation, 1.112e18, "[full] raw calculations - I'm accepting some % deviation (and dust)");
+        } else {
+            if (debtToRepay > 100) {
+                assertLe(deviation, 1.065e18, "[partial] raw calculations - I'm accepting some % deviation");
+            } else {
+                assertLe(deviation, 2.0e18, "[partial] raw calculations - on tiny values we can have big deviation");
+            }
+        }
+
+        uint256 ltvAfter = _ltv(
+            _sumOfCollateralAssets,
+            _sumOfCollateralValue,
+            _borrowerDebtAssets,
+            collateralToLiquidate,
+            debtToRepay
+        );
+
+        emit log_named_decimal_uint("ltvAfter", ltvAfter, 16);
+
+        if (debtToRepay == _borrowerDebtAssets) {
+            emit log("full liquidation");
+            // there is not really a way to verify this part other than check RAW result, what was done above
+        } else {
+            emit log("partial liquidation");
+
+            assertLt(
+                ltvAfter,
+                lt,
+                "we can not expect to be wei precise. as long as we below LT, it is OK"
+            );
+        }
+    }
+
+    function _ltv(
+        uint256 _sumOfCollateralAssets,
+        uint256 _sumOfCollateralValue,
+        uint256 _borrowerDebtAssets,
+        uint256 _collateralToLiquidate,
+        uint256 _debtToRepay
+    ) internal pure returns (uint256 ltv) {
+        uint256 collateralLeft = _sumOfCollateralAssets - _collateralToLiquidate;
+        uint256 collateralValueAfter = uint256(_sumOfCollateralValue) * collateralLeft / _sumOfCollateralAssets;
+        if (collateralValueAfter == 0) return 0;
+
+        uint256 debtLeft = _borrowerDebtAssets - _debtToRepay;
+        ltv = debtLeft * 1e18 / collateralValueAfter;
+    }
+}

--- a/silo-core/test/foundry/lib/SiloLiquidationLib/MaxRepayRawMath.sol
+++ b/silo-core/test/foundry/lib/SiloLiquidationLib/MaxRepayRawMath.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+// forge test -vv --mc MaxLiquidationTest
+contract MaxRepayRawMath {
+    uint256 private constant _DECIMALS_POINTS = 1e18;
+
+    /// @dev the math is based on: (Dv - x)/(Cv - (x + xf)) = LT
+    /// where Dv: debt value, Cv: collateral value, LT: expected LT, f: liquidation fee, x: is value we looking for
+    /// x = (Dv - LT * Cv) / (DP - LT - LT * f)
+    function _estimateMaxRepayValueRaw(
+        uint256 _totalBorrowerDebtValue,
+        uint256 _totalBorrowerCollateralValue,
+        uint256 _ltvAfterLiquidation,
+        uint256 _liquidityFee
+    )
+        internal pure returns (uint256 repayValue)
+    {
+        uint256 tmp = _ltvAfterLiquidation * _liquidityFee / _DECIMALS_POINTS;
+        if (_ltvAfterLiquidation + tmp > _DECIMALS_POINTS) return _totalBorrowerDebtValue;
+
+        uint256 divider =
+            _DECIMALS_POINTS - _ltvAfterLiquidation - _ltvAfterLiquidation * _liquidityFee / _DECIMALS_POINTS;
+
+        if (divider == 0) return 0;
+
+        repayValue = (
+            _totalBorrowerDebtValue - _ltvAfterLiquidation * _totalBorrowerCollateralValue / _DECIMALS_POINTS
+        ) * _DECIMALS_POINTS / divider;
+
+        return repayValue > _totalBorrowerDebtValue ? _totalBorrowerDebtValue : repayValue;
+    }
+}


### PR DESCRIPTION
Approval: https://github.com/silo-finance/silo-contracts-v2/pull/335


## Work

Turns out there was not simple fix for the case where we need to limit `debtToCover` and make sure we follow all liquidation requirements. To make it all work this changes were apply: 
- fix precision error in `maxLiquidation` by moving division further in code, this precision error could create unnecessary full liquidation instead of partial, because of not precise math results
- `calculateExactLiquidationAmounts` was removed and replaced by `liquidationPreview` - main difference here is that `calculateExactLiquidationAmounts` method was doing calculation based on user input and at the end we were trying to apply rules. `liquidationPreview` has rules build in into math and after that we only need to check if used input fit the preview result for debt covering
- `liquidationPreview` is not new code, it is based on `maxLiquidation` and other methods that were already there, so in general nothing changes to the math - we changed data flow.
- in order to have less complexity and be able fix this bug with minimal effort, this conditions was added:
  - on self liquidation and bad debt we do not apply any restrictions, minimal LTV and dust settings not apply


## QA

- Test case described in a ticked were added to `test_liquidationCall_partial` 
- A lot of tests were adjusted, mostly because of`calculateExactLiquidationAmounts` method was removed. Tests for this method were adjusted to fit `liquidationPreview` and reused.


## [0.0.31] - 2023-12-18
### Fixed
- [issue-319](https://github.com/silo-finance/silo-contracts-v2/issues/319) TOB-SILO2-18: Minimum acceptable LTV is not
  enforced for full liquidation