### PR TITLE
[0.0.32] TOB-SILO2-19: max* functions return incorrect values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.32] - 2023-12-22
+### Fixed
+- [issue-320](https://github.com/silo-finance/silo-contracts-v2/issues/320) TOB-SILO2-19: max* functions return 
+  incorrect values
+
 ## [0.0.31] - 2023-12-18
 ### Fixed
 - [issue-319](https://github.com/silo-finance/silo-contracts-v2/issues/319) TOB-SILO2-18: Minimum acceptable LTV is not

--- a/README.md
+++ b/README.md
@@ -128,3 +128,23 @@ rm lcov.info
 FOUNDRY_PROFILE=oracles forge coverage --report summary --report lcov | grep -i 'silo-oracles/contracts/' > coverage/silo-oracles.txt
 genhtml -o coverage/silo-oracles/ lcov.info
 ```
+
+## Rounding policy
+
+### Deposit (including preview, max and mint)
+- to assets: Up
+- to shares: Down
+
+### Borrow (including preview and max)
+- to assets: Down
+- to shares: Up
+
+### Withdraw
+- to shares: Up
+- to assets: Down
+
+### Repay
+- to assets: Up
+- to shares: Down
+
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -143,9 +143,8 @@ interface ISilo is IERC4626, IERC3156FlashLender, ISiloLiquidation {
     /// @notice Fetches the utilization data of the silo used by IRM
     function utilizationData() external view returns (UtilizationData memory utilizationData);
 
-    /// @notice Fetches the available liquidity in the silo, it does not include interest, so real liquidity will be
-    /// smaller
-    /// @return liquidity The amount of available liquidity
+    /// @notice Fetches the real (available to borrow) liquidity in the silo, it does include interest
+    /// @return liquidity The amount of liquidity
     function getLiquidity() external view returns (uint256 liquidity);
 
     /// @notice Determines if a borrower is solvent

--- a/silo-core/contracts/lib/SiloERC4626Lib.sol
+++ b/silo-core/contracts/lib/SiloERC4626Lib.sol
@@ -20,18 +20,27 @@ library SiloERC4626Lib {
     uint256 internal constant _PRECISION_DECIMALS = 1e18;
 
     /// @dev ERC4626: MUST return 2 ** 256 - 1 if there is no limit on the maximum amount of assets that may be
-    ///      deposited.
-    uint256 internal constant _NO_DEPOSIT_LIMIT = type(uint256).max;
+    ///      deposited. In our case, we want to limit this value in a way, that after max deposit we can do borrow.
+    ///      That's why we decided to go with type(uint128).max - which is anyway high enough to consume any totalSupply
+    uint256 internal constant _VIRTUAL_DEPOSIT_LIMIT = type(uint128).max;
 
     error ZeroShares();
 
-    /// @notice Determines the maximum amount a user can deposit or mint
-    /// @dev The function checks if deposit is possible for the given user, and if so, returns a constant
+    /// @notice Determines the maximum amount of collateral a user can deposit
+    /// This function is estimation to reduce gas usage. In theory, if silo total assets will be close to virtual limit
+    /// and returned max assets will be eg 1, then it might be not possible to actually deposit 1wei because
+    /// tx will revert with ZeroShares error. This is unreal case in real world scenario so we ignoring it.
+    /// @dev The function checks, if deposit is possible for the given user, and if so, returns a constant
     /// representing no deposit limit
     /// @param _config Configuration of the silo
     /// @param _receiver The address of the user
-    /// @return maxAssetsOrShares Maximum assets or shares a user can deposit or mint
-    function maxDepositOrMint(ISiloConfig _config, address _receiver)
+    /// @param _totalCollateralAssets total deposited collateral
+    /// @return maxAssetsOrShares Maximum assets/shares a user can deposit
+    function maxDepositOrMint(
+        ISiloConfig _config,
+        address _receiver,
+        uint256 _totalCollateralAssets
+    )
         external
         view
         returns (uint256 maxAssetsOrShares)
@@ -39,7 +48,9 @@ library SiloERC4626Lib {
         ISiloConfig.ConfigData memory configData = _config.getConfig(address(this));
 
         if (depositPossible(configData.debtShareToken, _receiver)) {
-            maxAssetsOrShares = _NO_DEPOSIT_LIMIT;
+            maxAssetsOrShares = _totalCollateralAssets == 0
+                ? _VIRTUAL_DEPOSIT_LIMIT
+                : _VIRTUAL_DEPOSIT_LIMIT - _totalCollateralAssets;
         }
     }
 
@@ -162,9 +173,11 @@ library SiloERC4626Lib {
         if (shares == 0) revert ZeroShares();
 
         // `assets` and `totalAssets` can never be more than uint256 because totalSupply cannot be either
-        unchecked {
+        // however, there is (probably unreal but also untested) possibility, where you might borrow from silo
+        // and deposit (like double spend) and with that we could overflow. Better safe than sorry - unchecked removed
+        // unchecked {
             _totalCollateral.assets = totalAssets + assets;
-        }
+        // }
 
         // Hook receiver is called after `mint` and can reentry but state changes are completed already
         _collateralShareToken.mint(_receiver, _depositor, shares);

--- a/silo-core/contracts/lib/SiloMathLib.sol
+++ b/silo-core/contracts/lib/SiloMathLib.sol
@@ -99,7 +99,7 @@ library SiloMathLib {
     {
         if (_collateralAssets == 0 || _debtAssets == 0) return 0;
 
-        utilization = _debtAssets * _dp;
+        utilization = _debtAssets * _dp; // TODO precise!
         // _collateralAssets is not 0 based on above check, so it is safe to uncheck this division
         unchecked {
             utilization /= _collateralAssets;
@@ -189,7 +189,7 @@ library SiloMathLib {
             return 0;
         }
 
-        uint256 maxDebtValue = _sumOfBorrowerCollateralValue * _configMaxLtv / _PRECISION_DECIMALS;
+        uint256 maxDebtValue = _sumOfBorrowerCollateralValue * _configMaxLtv / _PRECISION_DECIMALS; // DOWN
 
         unchecked {
             // we will not underflow because we checking `maxDebtValue > _borrowerDebtValue`

--- a/silo-core/contracts/lib/SiloSolvencyLib.sol
+++ b/silo-core/contracts/lib/SiloSolvencyLib.sol
@@ -11,6 +11,8 @@ import {SiloLiquidationLib} from "./SiloLiquidationLib.sol";
 import {SiloMathLib} from "./SiloMathLib.sol";
 
 library SiloSolvencyLib {
+    using MathUpgradeable for uint256;
+
     struct LtvData {
         ISiloOracle collateralOracle;
         ISiloOracle debtOracle;
@@ -98,7 +100,9 @@ library SiloSolvencyLib {
         } else if (sumOfBorrowerCollateralValue == 0) {
             ltvInDp = _INFINITY;
         } else {
-            ltvInDp = totalBorrowerDebtValue * _PRECISION_DECIMALS / sumOfBorrowerCollateralValue;
+            ltvInDp = totalBorrowerDebtValue.mulDiv(
+                _PRECISION_DECIMALS, sumOfBorrowerCollateralValue, MathUpgradeable.Rounding.Up
+            );
         }
     }
 
@@ -164,6 +168,7 @@ library SiloSolvencyLib {
             ? SiloStdLib.getTotalDebtAssetsWithInterest(_debtConfig.silo, _debtConfig.interestRateModel)
             : ISilo(_debtConfig.silo).getDebtAssets();
 
+        // BORROW value -> to assets -> UP
         ltvData.borrowerDebtAssets = SiloMathLib.convertToAssets(
             shares, totalDebtAssets, totalShares, MathUpgradeable.Rounding.Up, ISilo.AssetType.Debt
         );

--- a/silo-core/contracts/utils/Creator.sol
+++ b/silo-core/contracts/utils/Creator.sol
@@ -6,12 +6,12 @@ contract Creator {
 
     error OnlyCreator();
 
-    constructor() {
-        _creator = msg.sender;
-    }
-
     modifier onlyCreator() {
         if (msg.sender != _creator) revert OnlyCreator();
         _;
+    }
+
+    constructor() {
+        _creator = msg.sender;
     }
 }

--- a/silo-core/test/foundry/Silo/Deposit.i.sol
+++ b/silo-core/test/foundry/Silo/Deposit.i.sol
@@ -137,11 +137,11 @@ contract DepositTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_maxDeposit
+    forge test -vv --ffi --mt test_maxDeposit_cap
     */
-    function test_maxDeposit() public {
-        assertEq(silo0.maxDeposit(address(1)), 2 ** 256 - 1, "ERC4626 expect to return 2 ** 256 - 1");
-        assertEq(silo0.maxMint(address(1)), 2 ** 256 - 1, "ERC4626 expect to return 2 ** 256 - 1 (maxMint)");
+    function test_maxDeposit_cap() public {
+        assertEq(silo0.maxDeposit(address(1)), 2 ** 128 - 1, "ERC4626 expect to return 2 ** 256 - 1");
+        assertEq(silo0.maxMint(address(1)), 2 ** 128 - 1, "ERC4626 expect to return 2 ** 256 - 1 (maxMint)");
     }
 
     /*

--- a/silo-core/test/foundry/Silo/GetLiquidityAccrueInterestTest.i.sol
+++ b/silo-core/test/foundry/Silo/GetLiquidityAccrueInterestTest.i.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+
+import {MintableToken} from "../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc DepositTest
+*/
+contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
+    ISiloConfig siloConfig;
+
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture();
+    }
+    
+    /*
+    forge test -vv --ffi --mt test_liquidity_zero
+    */
+    function test_liquidity_zero() public {
+        assertEq(silo0.getLiquidity(), 0, "no liquidity after deploy 0");
+        assertEq(silo0.getLiquidity(), 0, "no liquidity 0");
+        assertEq(silo1.getLiquidity(), 0, "no liquidity after deploy 1");
+        assertEq(silo1.getLiquidity(), 0, "no collateral liquidity 1");
+
+        assertEq(silo1.getProtectedAssets(), 0, "no protected liquidity 1");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_liquidity_whenDeposit
+    */
+    function test_liquidity_whenDeposit(uint128 _assets) public {
+        vm.assume(_assets > 0);
+
+        if (_assets > 1) _deposit(_assets / 2, depositor, ISilo.AssetType.Protected);
+        _deposit(_assets, depositor);
+
+        assertEq(silo0.getLiquidity(), _assets, "[0] expect liquidity");
+        assertEq(silo0.getLiquidity(), _assets, "[0] expect collateral liquidity, no interest");
+        assertEq(silo0.getProtectedAssets(), _assets / 2, "[0] expect protected liquidity, no interest");
+
+        assertEq(silo1.getLiquidity(), 0, "[1] no liquidity 1");
+        assertEq(silo1.getLiquidity(), 0, "[1] no liquidity after deploy 1");
+        assertEq(silo1.getProtectedAssets(), 0, "[1] no protected liquidity after deploy 1");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_liquidity_whenProtected
+    */
+    function test_liquidity_whenProtected(uint256 _assets) public {
+        vm.assume(_assets > 0);
+
+        _deposit(_assets, depositor, ISilo.AssetType.Protected);
+
+        assertEq(silo0.getLiquidity(), 0, "[0] expect liquidity");
+        assertEq(silo0.getLiquidity(), 0, "[0] expect no collateral liquidity, no interest");
+        assertEq(silo0.getProtectedAssets(), _assets, "[0] expect protected liquidity, no interest");
+
+        assertEq(silo1.getLiquidity(), 0, "[1] no liquidity after deploy 1");
+        assertEq(silo1.getLiquidity(), 0, "[1] no collateral liquidity after deploy 1");
+        assertEq(silo1.getProtectedAssets(), 0, "[1] no protected liquidity after deploy 1");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_liquidity_whenDepositAndBorrow
+    */
+    function test_liquidity_whenDepositAndBorrow(uint128 _toDeposit, uint128 _toBorrow) public {
+        vm.assume(_toDeposit > 0);
+        vm.assume(_toBorrow > 0);
+        vm.assume(_toBorrow < _toDeposit / 2);
+
+        _makeDeposit(silo1, token1, _toDeposit / 2, depositor, ISilo.AssetType.Protected);
+        _depositForBorrow(_toDeposit, depositor);
+
+        _deposit(_toDeposit, borrower);
+        _borrow(_toBorrow, borrower);
+
+        assertEq(silo0.getLiquidity(), _toDeposit, "[0] expect collateral");
+        assertEq(silo0.getLiquidity(), _toDeposit, "[0] expect collateral, no interest");
+        assertEq(silo0.getProtectedAssets(), 0, "[0] no protected, no interest");
+
+        assertEq(silo1.getLiquidity(), _toDeposit - _toBorrow, "[1] expect diff after borrow");
+        assertEq(silo1.getLiquidity(), _toDeposit - _toBorrow, "[1] expect diff after borrow (interest)");
+        assertEq(silo1.getProtectedAssets(), _toDeposit / 2, "[1] expect protected after borrow (interest)");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_liquidity_whenDepositAndBorrowWithInterest
+    */
+    function test_liquidity_whenDepositAndBorrowWithInterest(uint128 _toDeposit, uint128 _toBorrow) public {
+        vm.assume(_toDeposit > 0);
+        vm.assume(_toBorrow > 0);
+        vm.assume(_toBorrow < _toDeposit / 2);
+
+        uint256 protectedDeposit0 = _toDeposit / 2;
+        uint256 protectedDeposit1 = _toDeposit / 2 + 1;
+
+        _makeDeposit(silo1, token1, protectedDeposit1, depositor, ISilo.AssetType.Protected);
+        _depositForBorrow(_toDeposit, depositor);
+
+        _deposit(protectedDeposit0, borrower, ISilo.AssetType.Protected);
+        _deposit(_toDeposit, borrower);
+        _borrow(_toBorrow, borrower);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 silo0_rawLiquidity = _getRawLiquidity(silo0);
+        uint256 silo1_rawLiquidity = _getRawLiquidity(silo1);
+        uint256 silo0_liquidityWithInterest = silo0.getLiquidity();
+        uint256 silo1_liquidityWithInterest = silo1.getLiquidity();
+        uint256 silo0_protectedLiquidity = silo0.getProtectedAssets();
+        uint256 silo1_protectedLiquidity = silo1.getProtectedAssets();
+
+        uint256 accruedInterest0 = silo0.accrueInterest();
+        assertEq(accruedInterest0, 0, "[0] expect no interest on silo0");
+
+        uint256 accruedInterest1 = silo1.accrueInterest();
+        vm.assume(accruedInterest1 > 0);
+
+        assertEq(silo0_rawLiquidity, _toDeposit, "[0] expect same liquidity, because no borrow on this silo");
+        assertEq(silo0_liquidityWithInterest, _toDeposit, "[0] same liquidity, no interest");
+
+        assertEq(silo1_rawLiquidity, _toDeposit - _toBorrow, "[1] expect liquidity without counting in interest");
+        assertLe(silo1_rawLiquidity, silo0.getLiquidity(), "[1] new liquidity() must not be smaller after interest");
+
+        assertLe(silo0.getLiquidity(), silo0_rawLiquidity, "[0] no interest on silo0, liquidity the same");
+
+        assertEq(
+            silo0_liquidityWithInterest,
+            _getRawLiquidity(silo0),
+            "[0] expect getLiquidity(ISilo.AssetType.Collateral) to be the same as calculated before"
+        );
+
+        assertEq(silo0_liquidityWithInterest, silo0_rawLiquidity, "[0] expect no interest");
+
+        assertEq(
+            silo0_protectedLiquidity,
+            silo0.getProtectedAssets(),
+            "[0] expect getProtectedAssets() calculations correct"
+        );
+
+        assertEq(silo0_protectedLiquidity, protectedDeposit0, "[0] no interest on protected");
+
+        assertEq(
+            silo1_liquidityWithInterest,
+            silo1.getLiquidity(),
+            "[1] expect getLiquidity() calculations correct"
+        );
+
+        assertEq(
+            silo1_liquidityWithInterest,
+            _getRawLiquidity(silo1),
+            "[1] expect getLiquidity(ISilo.AssetType.Collateral) calculations correct"
+        );
+
+        assertEq(protectedDeposit1, silo1_protectedLiquidity, "[1] protected liquidity");
+
+        assertEq(
+            protectedDeposit1,
+            silo1.getProtectedAssets(),
+            "[1] protected does not get interest"
+        );
+
+        assertLe(
+            _getRawLiquidity(silo1),
+            silo1_rawLiquidity + accruedInterest1,
+            "[1] current liquidity can not be higher that previous + accruedInterest1 because of fees"
+        );
+    }
+
+    function _getRawLiquidity(ISilo _silo) internal view returns (uint256) {
+        return _silo.getCollateralAssets() - _silo.getDebtAssets();
+    }
+}

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -130,14 +130,14 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         assertEq(IShareToken(collateralShareToken).balanceOf(borrower), depositAssets, "expect borrower to have collateral");
 
         uint256 maxBorrow = silo0.maxBorrow(borrower);
-        assertEq(maxBorrow, 0, "maxBorrow should be 0 because this is where collateral is");
+        assertEq(maxBorrow, 0, "maxBorrow should be 0, because this is where collateral is");
+
+        // deposit, so we can borrow
+        _depositForBorrow(depositAssets * 2, depositor);
 
         maxBorrow = silo1.maxBorrow(borrower);
         // emit log_named_decimal_uint("maxBorrow #1", maxBorrow, 18);
         assertEq(maxBorrow, 0.75e18, "maxBorrow borrower can do, maxLTV is 75%");
-
-        // deposit, so we can borrow
-        _depositForBorrow(maxBorrow * 2, depositor);
 
         uint256 borrowAmount = maxBorrow / 2;
         // emit log_named_decimal_uint("borrowAmount", borrowAmount, 18);
@@ -190,11 +190,11 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
 
         _deposit(depositAssets, borrower, ISilo.AssetType.Collateral);
 
-        uint256 maxBorrow = silo1.maxBorrow(borrower);
-
         // deposit, so we can borrow
         _depositForBorrow(100e18, depositor);
         assertEq(silo1.getLtv(borrower), 0, "no debt, so LT == 0");
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
 
         _borrow(200e18, borrower, ISilo.NotEnoughLiquidity.selector);
         _borrow(maxBorrow * 2, borrower, ISilo.AboveMaxLtv.selector);

--- a/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxBorrowTest
+*/
+contract MaxBorrowTest is SiloLittleHelper, Test {
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_noCollateral
+    */
+    function test_maxBorrow_noCollateral() public {
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+        assertEq(maxBorrow, 0, "no collateral - no borrow");
+
+        _assertWeCanNotBorrowAboveMax(0);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_withCollateral
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrow_withCollateral_fuzz(
+        uint128 _collateral,
+        uint128 _liquidity
+    ) public {
+        vm.assume(_liquidity > 0);
+        vm.assume(_collateral > 0);
+
+        _depositForBorrow(_liquidity, depositor);
+        _deposit(_collateral, borrower);
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+        emit log_named_decimal_uint("maxBorrow", maxBorrow, 18);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrow);
+
+        _assertMaxBorrowIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_collateralButNoLiquidity
+    */
+    /// forge-config: core.fuzz.runs = 100
+    function test_maxBorrow_collateralButNoLiquidity_fuzz(uint128 _collateral) public {
+        vm.assume(_collateral > 0);
+
+        _deposit(_collateral, borrower);
+
+        _assertMaxBorrowIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_withDebt
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrow_withDebt_fuzz(uint128 _collateral, uint128 _liquidity) public {
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+
+        uint256 firstBorrow = maxBorrow / 3;
+        vm.assume(firstBorrow > 0);
+        _borrow(firstBorrow, borrower);
+
+        // now we have debt
+
+        maxBorrow = silo1.maxBorrow(borrower);
+        _assertWeCanNotBorrowAboveMax(maxBorrow);
+
+        _assertMaxBorrowIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_withInterest
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrow_withInterest_fuzz(
+        uint128 _collateral,
+        uint128 _liquidity
+    ) public {
+//         (uint128 _collateral, uint128 _liquidity) = (64099903089467212573385554129187123252, 73362960447100600398853614451545866240);
+
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+
+        uint256 firstBorrow = maxBorrow / 3;
+        emit log_named_uint("firstBorrow", firstBorrow);
+        vm.assume(firstBorrow > 0);
+        _borrow(firstBorrow, borrower);
+
+        // now we have debt
+        vm.warp(block.timestamp + 100 days);
+
+        maxBorrow = silo1.maxBorrow(borrower);
+        emit log_named_uint("maxBorrow", maxBorrow);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 3);
+
+        _assertMaxBorrowIsZeroAtTheEnd(1);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_repayWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 5000
+    function test_maxBorrow_repayWithInterest_fuzz(
+        uint64 _collateral,
+        uint128 _liquidity
+    ) public {
+        // (uint64 _collateral, uint128 _liquidity) = (16052, 18260);
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+
+        uint256 firstBorrow = maxBorrow / 3;
+        emit log_named_uint("firstBorrow", firstBorrow);
+        vm.assume(firstBorrow > 0);
+        _borrow(firstBorrow, borrower);
+
+        // now we have debt
+        vm.warp(block.timestamp + 100 days);
+        emit log("----- time travel -----");
+
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        token1.setOnDemand(true);
+        uint256 debt = IShareToken(debtShareToken).balanceOf(borrower);
+        emit log_named_decimal_uint("user shares", debt, 18);
+        uint256 debtToRepay = debt * 9 / 10 == 0 ? 1 : debt * 9 / 10;
+        emit log_named_decimal_uint("debtToRepay", debtToRepay, 18);
+
+        _repayShares(1, debtToRepay, borrower);
+        token1.setOnDemand(false);
+
+        // maybe we have some debt left, maybe not
+
+        maxBorrow = silo1.maxBorrow(borrower);
+        assertGt(maxBorrow, 0, "we can borrow again after repay");
+
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 3);
+        _assertMaxBorrowIsZeroAtTheEnd(1);
+    }
+
+    function _assertWeCanNotBorrowAboveMax(uint256 _maxBorrow) internal {
+        _assertWeCanNotBorrowAboveMax(_maxBorrow, 1);
+    }
+
+    /// @param _precision is needed because we count for precision error and we allow for 1 wei diff
+    function _assertWeCanNotBorrowAboveMax(uint256 _maxBorrow, uint256 _precision) internal {
+        emit log_named_uint("------- QA: _assertWeCanNotBorrowAboveMax +/-", _precision);
+
+        uint256 toBorrow = _maxBorrow + _precision;
+
+        uint256 liquidity = silo1.getLiquidity();
+
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] liquidity", liquidity, 18);
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax]  toBorrow", toBorrow, 18);
+
+        vm.prank(borrower);
+        try silo1.borrow(toBorrow, borrower, borrower) returns (uint256) {
+            revert("we expect tx to be reverted!");
+        } catch (bytes memory data) {
+            bytes4 errorType = bytes4(data);
+
+            bytes4 error1 = bytes4(keccak256(abi.encodePacked("NotEnoughLiquidity()")));
+            bytes4 error2 = bytes4(keccak256(abi.encodePacked("AboveMaxLtv()")));
+
+            if (errorType != error1 && errorType != error2) {
+                revert("we need to revert with NotEnoughLiquidity or AboveMaxLtv");
+            }
+        }
+
+        if (_maxBorrow > 0) {
+            emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] _maxBorrow > 0 YES, borrowing max", _maxBorrow, 18);
+            vm.prank(borrower);
+            silo1.borrow(_maxBorrow, borrower, borrower);
+        }
+    }
+
+    function _assertMaxBorrowIsZeroAtTheEnd() internal {
+        _assertMaxBorrowIsZeroAtTheEnd(0);
+    }
+
+    function _assertMaxBorrowIsZeroAtTheEnd(uint256 _underestimatedBy) internal {
+        emit log_named_uint("================ _assertMaxBorrowIsZeroAtTheEnd ================ +/-", _underestimatedBy);
+
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+
+        assertLe(
+            maxBorrow,
+            _underestimatedBy,
+            string.concat("at this point max should return 0 +/-", string(abi.encodePacked(_underestimatedBy)))
+        );
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxBorrowShares.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxBorrowShares.i.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxBorrowSharesTest
+*/
+contract MaxBorrowSharesTest is SiloLittleHelper, Test {
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_noCollateral
+    */
+    function test_maxBorrowShares_noCollateral() public {
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+        assertEq(maxBorrowShares, 0, "no collateral - no borrowShares");
+
+        _assertMaxBorrowSharesIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_withCollateral
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrowShares_withCollateral_fuzz(uint128 _collateral, uint128 _liquidity) public {
+        vm.assume(_liquidity > 0);
+        vm.assume(_collateral > 0);
+
+        _depositForBorrow(_liquidity, depositor);
+        _deposit(_collateral, borrower);
+
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+        vm.assume(maxBorrowShares > 0);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares);
+
+        _assertMaxBorrowSharesIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_collateralButNoLiquidity
+    */
+    /// forge-config: core.fuzz.runs = 100
+    function test_maxBorrowShares_collateralButNoLiquidity_fuzz(uint128 _collateral) public {
+        vm.assume(_collateral > 3); // to allow any borrowShares twice
+
+        _deposit(_collateral, borrower);
+
+        _assertWeCanNotBorrowAboveMax(0);
+        _assertMaxBorrowSharesIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_withDebt
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrowShares_withDebt_fuzz(uint128 _collateral, uint128 _liquidity) public {
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+
+        uint256 firstBorrow = maxBorrowShares / 3;
+        vm.assume(firstBorrow > 0);
+        _borrowShares(firstBorrow, borrower);
+
+        // now we have debt
+
+        maxBorrowShares = silo1.maxBorrowShares(borrower);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares);
+        _assertMaxBorrowSharesIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_withInterest
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxBorrowShares_withInterest_fuzz(
+        uint128 _collateral,
+        uint128 _liquidity
+    ) public {
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+        // TODO  +protected, and for maxBorrow
+
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+        uint256 firstBorrow = maxBorrowShares / 3;
+        emit log_named_uint("____ firstBorrow", firstBorrow);
+
+        vm.assume(firstBorrow > 0);
+        _borrowShares(firstBorrow, borrower);
+
+        // now we have debt
+        vm.warp(block.timestamp + 100 days);
+
+        maxBorrowShares = silo1.maxBorrowShares(borrower);
+        emit log_named_uint("____ maxBorrowShares", maxBorrowShares);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 3);
+        _assertMaxBorrowSharesIsZeroAtTheEnd(1);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrowShares_repayWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 5000
+    function test_maxBorrowShares_repayWithInterest_fuzz(
+        uint64 _collateral,
+        uint128 _liquidity
+    ) public {
+        // (uint64 _collateral, uint128 _liquidity) = (7117, 7095);
+        vm.assume(_collateral > 0);
+        vm.assume(_liquidity > 0);
+
+        _deposit(_collateral, borrower);
+        _depositForBorrow(_liquidity, depositor);
+        // TODO  +protected, and same for maxBorrow
+
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+        uint256 firstBorrow = maxBorrowShares / 3;
+        emit log_named_uint("____ firstBorrow", firstBorrow);
+
+        vm.assume(firstBorrow > 0);
+        _borrowShares(firstBorrow, borrower);
+
+        // now we have debt
+        vm.warp(block.timestamp + 100 days);
+        emit log("----- time travel -----");
+
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        token1.setOnDemand(true);
+        uint256 debt = IShareToken(debtShareToken).balanceOf(borrower);
+        emit log_named_decimal_uint("user shares", debt, 18);
+        uint256 debtToRepay = debt * 9 / 10 == 0 ? 1 : debt * 9 / 10;
+        emit log_named_decimal_uint("debtToRepay", debtToRepay, 18);
+
+        _repayShares(1, debtToRepay, borrower);
+        token1.setOnDemand(false);
+
+        // maybe we have some debt left, maybe not
+
+        maxBorrowShares = silo1.maxBorrowShares(borrower);
+        emit log_named_uint("____ maxBorrowShares", maxBorrowShares);
+
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 3);
+        _assertMaxBorrowSharesIsZeroAtTheEnd(1);
+    }
+
+    function _assertWeCanNotBorrowAboveMax(uint256 _maxBorrow) internal {
+        _assertWeCanNotBorrowAboveMax(_maxBorrow, 1);
+    }
+
+    /// @param _precision is needed because we count for precision error and we allow for 1 wei diff
+    function _assertWeCanNotBorrowAboveMax(uint256 _maxBorrowShares, uint256 _precision) internal {
+        emit log_named_uint("------- QA: _assertWeCanNotBorrowAboveMax shares", _maxBorrowShares);
+        emit log_named_uint("------- QA: _assertWeCanNotBorrowAboveMax _precision", _precision);
+
+        uint256 toBorrow = _maxBorrowShares + _precision;
+
+        uint256 liquidity = silo1.getLiquidity();
+        uint256 maxBorrowAssets = silo1.convertToAssets(_maxBorrowShares, ISilo.AssetType.Debt);
+
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] maxBorrowAssets", maxBorrowAssets, 18);
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] liquidity", liquidity, 18);
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] balanceOf", token1.balanceOf(address(silo1)), 18);
+        emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax]  toBorrow", toBorrow, 18);
+
+        if (maxBorrowAssets > liquidity) {
+            emit log("MAX returned shares, that translate for TOO MUCH assets");
+            // assertLe(maxBorrowAssets, liquidity, "MAX returned shares, that translate for TOO MUCH assets");
+        }
+
+        vm.prank(borrower);
+        try silo1.borrowShares(toBorrow, borrower, borrower) returns (uint256) {
+            revert("we expect tx to be reverted!");
+        } catch (bytes memory data) {
+            bytes4 errorType = bytes4(data);
+
+            bytes4 error1 = bytes4(keccak256(abi.encodePacked("NotEnoughLiquidity()")));
+            bytes4 error2 = bytes4(keccak256(abi.encodePacked("AboveMaxLtv()")));
+
+            if (errorType != error1 && errorType != error2) {
+                revert("we need to revert with NotEnoughLiquidity or AboveMaxLtv");
+            }
+        }
+
+        if (_maxBorrowShares > 0) {
+            emit log_named_decimal_uint("[_assertWeCanNotBorrowAboveMax] _maxBorrow > 0 YES, borrowing max", _maxBorrowShares, 18);
+            vm.prank(borrower);
+            silo1.borrowShares(_maxBorrowShares, borrower, borrower);
+        }
+    }
+
+    function _assertMaxBorrowSharesIsZeroAtTheEnd() internal {
+        _assertMaxBorrowSharesIsZeroAtTheEnd(0);
+    }
+
+    function _assertMaxBorrowSharesIsZeroAtTheEnd(uint256 _precision) internal {
+        emit log_named_uint("=================== _assertMaxBorrowIsZeroAtTheEnd =================== +/-", _precision);
+
+        uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+
+        assertLe(
+            maxBorrowShares,
+            _precision,
+            string.concat("at this point max should return 0 +/-", string(abi.encodePacked(_precision)))
+        );
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxDeposit.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxDeposit.i.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxDepositTest
+*/
+contract MaxDepositTest is SiloLittleHelper, Test {
+    uint256 internal constant _REAL_ASSETS_LIMIT = type(uint128).max;
+
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxDeposit_emptySilo
+    */
+    function test_maxDeposit_emptySilo() public {
+        uint256 maxDeposit = silo1.maxDeposit(depositor);
+        assertEq(maxDeposit, type(uint128).max, "on empty silo, MAX is just no limit");
+        _depositForBorrow(maxDeposit, depositor);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxDeposit_forBorrower
+    */
+    function test_maxDeposit_forBorrower() public {
+        uint256 _initialDeposit = 1e18;
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _depositForBorrow(toBorrow, depositor);
+        _deposit(toBorrow * 2, borrower);
+        _borrow(toBorrow, borrower);
+
+        assertEq(silo0.maxDeposit(borrower), _REAL_ASSETS_LIMIT - toBorrow * 2, "real max deposit");
+        assertEq(silo1.maxDeposit(borrower), 0, "can not deposit with debt");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxDeposit_withDeposit_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxDeposit_withDeposit_fuzz(uint128 _initialDeposit) public {
+        vm.assume(_initialDeposit > 0);
+
+        _depositForBorrow(_initialDeposit, depositor);
+
+        uint256 maxDeposit = silo1.maxDeposit(depositor);
+        emit log_named_decimal_uint("maxDeposit", maxDeposit, 18);
+
+        assertEq(maxDeposit, _REAL_ASSETS_LIMIT - _initialDeposit, "with deposit, max is: MAX - deposit");
+
+        /// we probably can deposit more, but if for our way of defining max we get 0, we dont need to test deposit 0
+        if (maxDeposit == 0) return;
+
+        _depositForBorrow(maxDeposit, depositor);
+
+        _assertWeCanBorrowAfterMaxDeposit(_initialDeposit + maxDeposit, borrower);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxDeposit_withInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 10000
+    function test_maxDeposit_withInterest_fuzz(
+        uint256 _initialDeposit
+    ) public {
+        vm.assume(_initialDeposit > 3); // we need to be able /3
+        vm.assume(_initialDeposit <= _REAL_ASSETS_LIMIT);
+
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _depositForBorrow(_initialDeposit, depositor);
+        _deposit(toBorrow * 1e18, borrower);
+        _borrow(toBorrow, borrower);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 maxDeposit = silo1.maxDeposit(depositor);
+        vm.assume(maxDeposit > 0);
+
+        emit log_named_decimal_uint("maxDeposit", maxDeposit, 18);
+
+        assertLe(
+            maxDeposit,
+            _REAL_ASSETS_LIMIT - _initialDeposit,
+            "with interest we expecting less than simply sub the initial deposit"
+        );
+
+        if (silo1.previewDeposit(maxDeposit) == 0) {
+            uint256 margin = 2;
+            assertLt(maxDeposit, margin, "we know for small assets if there is already big numbers, max can be 'invalid'");
+            assertGt(silo1.getCollateralAssets(), _REAL_ASSETS_LIMIT - margin, "must be big number");
+            return;
+        }
+
+        _depositForBorrow(maxDeposit, depositor);
+
+        _assertWeCanBorrowAfterMaxDeposit(maxDeposit, borrower);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxDeposit_repayWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxDeposit_repayWithInterest_fuzz(
+        uint64 _initialDeposit // 64b because this is initial deposit, and we care about max after initial
+    ) public {
+        // uint128 _initialDeposit = 1020847100762815390392;
+        vm.assume(_initialDeposit / 3 > 0);
+
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _depositForBorrow(toBorrow + 1e18, depositor);
+
+        _deposit(toBorrow * 1e18, borrower);
+        _borrow(toBorrow, borrower);
+
+        vm.warp(block.timestamp + 100 days);
+
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        token1.setOnDemand(true);
+        _repayShares(1, IShareToken(debtShareToken).balanceOf(borrower), borrower);
+        token1.setOnDemand(false);
+
+        assertGt(token1.balanceOf(address(silo1)), toBorrow, "we expect to repay with interest");
+        assertEq(IShareToken(debtShareToken).balanceOf(borrower), 0, "all debt must be repay");
+
+        uint256 maxDeposit = silo1.maxDeposit(depositor);
+
+        if (silo1.previewDeposit(maxDeposit) == 0) {
+            uint256 margin = 2;
+            assertLt(maxDeposit, margin, "we know for small assets if there is already big numbers, max can be 'invalid'");
+            assertGt(silo1.getCollateralAssets(), _REAL_ASSETS_LIMIT - margin, "must be big number");
+            return;
+        }
+
+        vm.startPrank(borrower);
+        token1.transfer(depositor, token1.balanceOf(borrower));
+
+        _depositForBorrow(maxDeposit, depositor);
+
+        _assertWeCanBorrowAfterMaxDeposit(maxDeposit, borrower);
+    }
+
+    // we check on silo1
+    function _assertWeCanBorrowAfterMaxDeposit(uint256 _assets, address _borrower) internal {
+        uint256 collateral = _REAL_ASSETS_LIMIT * 1e18;
+        emit log_named_decimal_uint("[_assertWeCanBorrowAfterMaxDeposit] collateral", collateral, 18);
+
+        _deposit(collateral, _borrower);
+        _borrow(_assets, _borrower);
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxMint.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxMint.i.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxMintTest
+*/
+contract MaxMintTest is SiloLittleHelper, Test {
+    uint256 internal constant _REAL_ASSETS_LIMIT = type(uint128).max;
+
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxMint_emptySilo
+    */
+    function test_maxMint_emptySilo() public {
+        uint256 maxMint = silo1.maxMint(depositor);
+        assertEq(maxMint, type(uint128).max, "on empty silo, MAX is just no limit");
+        _mintForBorrow(maxMint, maxMint, depositor);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxMint_forBorrower
+    */
+    function test_maxMint_forBorrower() public {
+        uint256 _initialDeposit = 1e18;
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _mintForBorrow(toBorrow, toBorrow, depositor);
+        _mint(toBorrow * 2, toBorrow * 2, borrower);
+        _borrow(toBorrow, borrower);
+
+        assertEq(silo0.maxMint(borrower), _REAL_ASSETS_LIMIT - toBorrow * 2, "real max deposit");
+        assertEq(silo1.maxMint(borrower), 0, "can not deposit with debt");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxMint_withDeposit_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxMint_withDeposit_fuzz(uint128 _initialDeposit) public {
+        vm.assume(_initialDeposit > 0);
+
+        _depositForBorrow(_initialDeposit, depositor);
+
+        uint256 maxMint = silo1.maxMint(depositor);
+        emit log_named_decimal_uint("maxMint", maxMint, 18);
+
+        assertEq(maxMint, _REAL_ASSETS_LIMIT - _initialDeposit, "with deposit, max is MAX - deposit");
+
+        /// we probably can deposit more, but if for our way of defining max we get 0, we dont need to test deposit 0
+        if (maxMint == 0) return;
+
+        uint256 minted = _mintForBorrow(maxMint, maxMint, depositor);
+
+        _assertWeCanBorrowAfterMaxDeposit(_initialDeposit + minted, borrower);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxMint_withInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxMint_withInterest_fuzz(
+        uint256 _initialDeposit
+    ) public {
+        vm.assume(_initialDeposit > 3); // we need to be able /3
+        vm.assume(_initialDeposit <= _REAL_ASSETS_LIMIT);
+
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _depositForBorrow(_initialDeposit, depositor);
+        _deposit(toBorrow * 1e18, borrower);
+        _borrow(toBorrow, borrower);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 maxMint = silo1.maxMint(depositor);
+        vm.assume(maxMint > 0);
+
+        emit log_named_decimal_uint("maxMint", maxMint, 18);
+
+        token1.setOnDemand(true);
+        uint256 minted = _mintForBorrow(maxMint, maxMint, depositor);
+        token1.setOnDemand(false);
+
+        _assertWeCanBorrowAfterMaxDeposit(minted, borrower);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxMint_repayWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxMint_repayWithInterest_fuzz(
+        uint128 _initialDeposit
+    ) public {
+        // uint128 _initialDeposit = 1020847100762815390392;
+        vm.assume(_initialDeposit / 3 > 0);
+
+        uint256 toBorrow = _initialDeposit / 3;
+
+        _depositForBorrow(toBorrow + 1e18, depositor);
+
+        _deposit(toBorrow * 1e18, borrower);
+        _borrow(toBorrow, borrower);
+
+        vm.warp(block.timestamp + 100 days);
+
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        token1.setOnDemand(true);
+        _repayShares(1, IShareToken(debtShareToken).balanceOf(borrower), borrower);
+        token1.setOnDemand(false);
+
+        assertGt(token1.balanceOf(address(silo1)), toBorrow, "we expect to repay with interest");
+        assertEq(IShareToken(debtShareToken).balanceOf(borrower), 0, "all debt must be repay");
+
+        uint256 maxMint = silo1.maxMint(depositor);
+        vm.assume(maxMint > 0);
+
+        // all tokens to depositor, so we can transfer hi amounts
+        vm.startPrank(borrower);
+        token1.transfer(depositor, token1.balanceOf(borrower));
+
+        token1.setOnDemand(true);
+        _mintForBorrow(maxMint, maxMint, depositor);
+        token1.setOnDemand(false);
+
+        _assertWeCanBorrowAfterMaxDeposit(maxMint, borrower);
+    }
+
+    // we check on silo1
+    function _assertWeCanBorrowAfterMaxDeposit(uint256 _assets, address _borrower) internal {
+        uint256 collateral = _REAL_ASSETS_LIMIT * 1e18;
+        emit log_named_decimal_uint("[_assertWeCanBorrowAfterMaxDeposit] collateral", collateral, 18);
+
+        _deposit(collateral, _borrower);
+        _borrow(_assets, _borrower);
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxRedeem.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxRedeem.i.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MaxWithdrawCommon} from "./MaxWithdrawCommon.sol";
+
+/*
+    forge test -vv --ffi --mc MaxRedeemTest
+*/
+contract MaxRedeemTest is MaxWithdrawCommon {
+    function setUp() public {
+        _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRedeem_zero
+    */
+    function test_maxRedeem_zero() public {
+        uint256 maxRedeem = silo1.maxRedeem(borrower);
+        assertEq(maxRedeem, 0, "nothing to redeem");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRedeem_deposit_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRedeem_deposit_fuzz(
+        uint112 _assets,
+        uint16 _assets2
+    ) public {
+        vm.assume(_assets > 0);
+        vm.assume(_assets2 > 0);
+
+        _deposit(_assets, borrower);
+        _deposit(_assets2, address(1)); // any
+
+        uint256 maxRedeem = silo0.maxRedeem(borrower);
+        assertEq(maxRedeem, _assets, "max withdraw == _assets/shares if no interest");
+
+        _assertBorrowerCanNotRedeemMore(maxRedeem);
+        _assertBorrowerHasNothingToRedeem();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRedeem_whenBorrow_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRedeem_whenBorrow_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+//        (uint128 _collateral, uint256 _toBorrow) = (52874512, 1);
+        _createDebtSilo1(_collateral, _toBorrow);
+
+        uint256 maxRedeem = silo0.maxRedeem(borrower);
+
+        (, address collateralShareToken, ) = silo0.config().getShareTokens(address(silo0));
+        assertLt(maxRedeem, IShareToken(collateralShareToken).balanceOf(borrower), "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV", silo0.getLtv(borrower), 18);
+
+        _assertBorrowerCanNotRedeemMore(maxRedeem, 2);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRedeem_whenInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRedeem_whenInterest_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+        // uint128 _collateral = 100;
+        _createDebtSilo1(_collateral, _toBorrow);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 maxRedeem = silo0.maxRedeem(borrower);
+        (, address collateralShareToken, ) = silo0.config().getShareTokens(address(silo0));
+        assertLt(maxRedeem, IShareToken(collateralShareToken).balanceOf(borrower), "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV", silo1.getLtv(borrower), 18);
+
+        _assertBorrowerCanNotRedeemMore(maxRedeem, 2);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRedeem_bothSilosWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRedeem_bothSilosWithInterest_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+        // (uint128 _collateral, uint128 _toBorrow) = (21288, 4007);
+        _createDebtSilo1(_collateral, _toBorrow);
+        _createDebtSilo0(_collateral, _toBorrow);
+
+        vm.warp(block.timestamp + 100 days);
+        emit log("----- time travel -------");
+
+        uint256 maxRedeem = silo0.maxRedeem(borrower);
+        (, address collateralShareToken, ) = silo0.config().getShareTokens(address(silo0));
+        assertLt(maxRedeem, IShareToken(collateralShareToken).balanceOf(borrower), "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV", silo1.getLtv(borrower), 18);
+
+        // _assertBorrowerCanNotRedeemMore(maxRedeem, 2); TODO
+    }
+
+    function _assertBorrowerHasNothingToRedeem() internal {
+        (, address collateralShareToken, ) = silo0.config().getShareTokens(address(silo0));
+
+        assertEq(silo0.maxRedeem(borrower), 0, "expect maxRedeem to be 0");
+        assertEq(IShareToken(collateralShareToken).balanceOf(borrower), 0, "expect share balance to be 0");
+    }
+
+    function _assertBorrowerCanNotRedeemMore(uint256 _maxRedeem) internal {
+        _assertBorrowerCanNotRedeemMore(_maxRedeem, 1);
+    }
+
+    function _assertBorrowerCanNotRedeemMore(uint256 _maxRedeem, uint256 _underestimate) internal {
+        emit log_named_uint("------- QA: _assertBorrowerCanNotRedeemMore shares", _maxRedeem);
+
+        assertGt(_underestimate, 0, "_underestimate must be at least 1");
+
+        if (_maxRedeem > 0) {
+            _redeem(_maxRedeem, borrower);
+        }
+
+        bool isSolvent = silo0.isSolvent(borrower);
+
+        if (!isSolvent) {
+            assertEq(_maxRedeem, 0, "if user is insolvent, MAX should be always 0");
+        }
+
+        uint256 counterExample  = isSolvent ? _underestimate : 1;
+        emit log_named_uint("=========== [counterexample] testing counterexample for maxRedeem with", counterExample);
+
+        vm.prank(borrower);
+        vm.expectRevert();
+        silo0.redeem(counterExample, borrower, borrower);
+    }
+
+    function _assertMaxRedeemIsZeroAtTheEnd() internal {
+        _assertMaxRedeemIsZeroAtTheEnd(0);
+    }
+
+    function _assertMaxRedeemIsZeroAtTheEnd(uint256 _underestimate) internal {
+        emit log_named_uint("================= _assertMaxRedeemIsZeroAtTheEnd ================= +/-", _underestimate);
+
+        uint256 maxRedeem = silo0.maxRedeem(borrower);
+
+        assertLe(
+            maxRedeem,
+            _underestimate,
+            string.concat("at this point max should return 0 +/-", string(abi.encodePacked(_underestimate)))
+        );
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxRepay.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxRepay.i.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxRepayTest
+*/
+contract MaxRepayTest is SiloLittleHelper, Test {
+    uint256 internal constant _REAL_ASSETS_LIMIT = type(uint128).max;
+    
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepay_noDebt
+    */
+    function test_maxRepay_noDebt() public {
+        uint256 maxRepay = silo1.maxRepay(borrower);
+        assertEq(maxRepay, 0, "no debt - nothing to repay");
+
+        _depositForBorrow(11e18, borrower);
+
+        _assertBorrowerHasNoDebt();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepay_withDebt_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRepay_withDebt_fuzz(uint128 _collateral) public {
+        uint256 toBorrow = _collateral / 3;
+        _createDebt(_collateral, toBorrow);
+
+        uint256 maxRepay = silo1.maxRepay(borrower);
+        assertEq(maxRepay, toBorrow, "max repay is what was borrower if no interest");
+
+        _repay(maxRepay, borrower);
+        _assertBorrowerHasNoDebt();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepay_withInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRepay_withInterest_fuzz(uint128 _collateral) public {
+        uint256 toBorrow = _collateral / 3;
+        _createDebt(_collateral, toBorrow);
+
+        vm.warp(block.timestamp + 356 days);
+
+        uint256 maxRepay = silo1.maxRepay(borrower);
+        vm.assume(maxRepay > toBorrow); // we want interest
+
+        _repay(maxRepay, borrower);
+        _assertBorrowerHasNoDebt();
+    }
+
+    function _createDebt(uint256 _collateral, uint256 _toBorrow) internal {
+        vm.assume(_collateral > 0);
+        vm.assume(_toBorrow > 0);
+
+        _depositForBorrow(_collateral, depositor);
+        _deposit(_collateral, borrower);
+        _borrow(_toBorrow, borrower);
+
+        _ensureBorrowerHasDebt();
+    }
+
+    function _ensureBorrowerHasDebt() internal {
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        assertGt(silo1.maxRepay(borrower), 0, "expect debt");
+        assertGt(IShareToken(debtShareToken).balanceOf(borrower), 0, "expect debtShareToken balance > 0");
+    }
+
+    function _assertBorrowerHasNoDebt() internal {
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        assertEq(silo1.maxRepay(borrower), 0, "expect maxRepay to be 0");
+        assertEq(IShareToken(debtShareToken).balanceOf(borrower), 0, "expect debtShareToken balance to be 0");
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxRepayShares.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxRepayShares.i.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxRepaySharesTest
+*/
+contract MaxRepaySharesTest is SiloLittleHelper, Test {
+    uint256 internal constant _REAL_ASSETS_LIMIT = type(uint128).max;
+    
+    ISiloConfig siloConfig;
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepayShares_noDebt
+    */
+    function test_maxRepayShares_noDebt() public {
+        uint256 maxRepayShares = silo1.maxRepayShares(borrower);
+        assertEq(maxRepayShares, 0, "no debt - nothing to repay");
+
+        _depositForBorrow(11e18, borrower);
+
+        _assertBorrowerHasNoDebt();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepayShares_withDebt_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRepayShares_withDebt_fuzz(uint128 _collateral) public {
+        uint256 toBorrow = _collateral / 3;
+        _createDebt(_collateral, toBorrow);
+
+        uint256 maxRepayShares = silo1.maxRepayShares(borrower);
+        assertEq(maxRepayShares, toBorrow, "max repay is what was borrower if no interest");
+
+        _repayShares(maxRepayShares, maxRepayShares, borrower);
+        _assertBorrowerHasNoDebt();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxRepayShares_withInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxRepayShares_withInterest_fuzz(uint128 _collateral) public {
+        uint256 toBorrow = _collateral / 3;
+        uint256 shares = _createDebt(_collateral, toBorrow);
+
+        vm.warp(block.timestamp + 356 days);
+
+        uint256 maxRepayShares = silo1.maxRepayShares(borrower);
+        assertEq(maxRepayShares, shares, "shares are always the same");
+
+        token1.setOnDemand(true);
+        _repayShares(1, maxRepayShares, borrower);
+        _assertBorrowerHasNoDebt();
+    }
+
+    function _createDebt(uint256 _collateral, uint256 _toBorrow) internal returns (uint256 shares) {
+        vm.assume(_collateral > 0);
+        vm.assume(_toBorrow > 0);
+
+        _depositForBorrow(_collateral, depositor);
+        _deposit(_collateral, borrower);
+
+        shares = _borrow(_toBorrow, borrower);
+
+        _ensureBorrowerHasDebt();
+    }
+
+    function _ensureBorrowerHasDebt() internal {
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        assertGt(silo1.maxRepayShares(borrower), 0, "expect debt");
+        assertGt(IShareToken(debtShareToken).balanceOf(borrower), 0, "expect debtShareToken balance > 0");
+    }
+
+    function _assertBorrowerHasNoDebt() internal {
+        (,, address debtShareToken) = silo1.config().getShareTokens(address(silo1));
+
+        assertEq(silo1.maxRepayShares(borrower), 0, "expect maxRepayShares to be 0");
+        assertEq(IShareToken(debtShareToken).balanceOf(borrower), 0, "expect debtShareToken balanace to be 0");
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxWithdraw.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxWithdraw.i.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MaxWithdrawCommon} from "./MaxWithdrawCommon.sol";
+
+/*
+    forge test -vv --ffi --mc MaxWithdrawTest
+*/
+contract MaxWithdrawTest is MaxWithdrawCommon {
+    function setUp() public {
+        _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_NO_LTV_SILO);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxWithdraw_zero
+    */
+    function test_maxWithdraw_zero() public {
+        uint256 maxWithdraw = silo1.maxWithdraw(borrower);
+        assertEq(maxWithdraw, 0, "nothing to withdraw");
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxWithdraw_deposit_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxWithdraw_deposit_fuzz(
+        uint112 _assets,
+        uint16 _assets2
+    ) public {
+        vm.assume(_assets > 0);
+        vm.assume(_assets2 > 0);
+
+        _deposit(_assets, borrower);
+        _deposit(_assets2, address(1)); // any
+
+        uint256 maxWithdraw = silo0.maxWithdraw(borrower);
+        assertEq(maxWithdraw, _assets, "max withdraw == _assets if no interest");
+
+        _assertBorrowerCanNotWithdrawMore(maxWithdraw);
+        _assertMaxWithdrawIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxWithdraw_whenBorrow_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxWithdraw_whenBorrow_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+//        (uint128 _collateral, uint256 _toBorrow) = (5526, 1842);
+        _createDebtSilo1(_collateral, _toBorrow);
+
+        uint256 maxWithdraw = silo0.maxWithdraw(borrower);
+        assertLt(maxWithdraw, _collateral, "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV", silo1.getLtv(borrower), 18);
+
+        _assertBorrowerCanNotWithdrawMore(maxWithdraw, 2);
+        _assertMaxWithdrawIsZeroAtTheEnd();
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxWithdraw_whenInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxWithdraw_whenInterest_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+//        (uint128 _collateral, uint128 _toBorrow) = (16278, 10070);
+        _createDebtSilo1(_collateral, _toBorrow);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 maxWithdraw = silo0.maxWithdraw(borrower);
+        assertLt(maxWithdraw, _collateral, "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV before withdraw", silo1.getLtv(borrower), 16);
+        emit log_named_uint("maxWithdraw", maxWithdraw);
+
+        _assertBorrowerCanNotWithdrawMore(maxWithdraw, 2);
+        _assertMaxWithdrawIsZeroAtTheEnd(1);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxWithdraw_bothSilosWithInterest_fuzz
+    */
+    /// forge-config: core.fuzz.runs = 1000
+    function test_maxWithdraw_bothSilosWithInterest_fuzz(
+        uint128 _collateral,
+        uint128 _toBorrow
+    ) public {
+//        (uint128 _collateral, uint128 _toBorrow) = (4323, 3821);
+        _createDebtSilo0(_collateral, _toBorrow);
+        _createDebtSilo1(_collateral, _toBorrow);
+
+        vm.warp(block.timestamp + 100 days);
+
+        uint256 maxWithdraw = silo0.maxWithdraw(borrower);
+        assertLt(maxWithdraw, _collateral, "with debt you can not withdraw all");
+
+        emit log_named_decimal_uint("LTV before withdraw", silo1.getLtv(borrower), 16);
+        emit log_named_uint("maxWithdraw", maxWithdraw);
+
+        _assertBorrowerCanNotWithdrawMore(maxWithdraw, 2);
+        _assertMaxWithdrawIsZeroAtTheEnd(1);
+    }
+
+    function _assertBorrowerHasNothingToWithdraw() internal {
+        (, address collateralShareToken, ) = silo0.config().getShareTokens(address(silo0));
+
+        assertEq(silo0.maxWithdraw(borrower), 0, "expect maxWithdraw to be 0");
+        assertEq(IShareToken(collateralShareToken).balanceOf(borrower), 0, "expect share balance to be 0");
+    }
+
+    function _assertBorrowerCanNotWithdrawMore(uint256 _maxWithdraw) internal {
+        _assertBorrowerCanNotWithdrawMore(_maxWithdraw, 1);
+    }
+
+    function _assertBorrowerCanNotWithdrawMore(uint256 _maxWithdraw, uint256 _underestimate) internal {
+        assertGt(_underestimate, 0, "_underestimate must be at least 1");
+
+        if (_maxWithdraw > 0) {
+            _withdraw(_maxWithdraw, borrower);
+        }
+
+        bool isSolvent = silo0.isSolvent(borrower);
+
+        if (!isSolvent) {
+            assertEq(_maxWithdraw, 0, "if user is insolvent, MAX should be always 0");
+        }
+
+        uint256 counterExample  = isSolvent ? _underestimate : 1;
+        emit log_named_uint("=========== [counterexample] testing counterexample for maxWithdraw with", counterExample);
+
+        vm.prank(borrower);
+        vm.expectRevert();
+        silo0.withdraw(counterExample, borrower, borrower);
+    }
+
+    function _assertMaxWithdrawIsZeroAtTheEnd() internal {
+        _assertMaxWithdrawIsZeroAtTheEnd(0);
+    }
+
+    function _assertMaxWithdrawIsZeroAtTheEnd(uint256 _underestimate) internal {
+        emit log_named_uint("================= _assertMaxWithdrawIsZeroAtTheEnd ================= +/-", _underestimate);
+
+        uint256 maxWithdraw = silo0.maxWithdraw(borrower);
+
+        assertLe(
+            maxWithdraw,
+            _underestimate,
+            string.concat("at this point max should return 0 +/-", string(abi.encodePacked(_underestimate)))
+        );
+    }
+}

--- a/silo-core/test/foundry/Silo/max/MaxWithdrawCommon.sol
+++ b/silo-core/test/foundry/Silo/max/MaxWithdrawCommon.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+
+/*
+    forge test -vv --ffi --mc MaxWithdrawTest
+*/
+contract MaxWithdrawCommon is SiloLittleHelper, Test {
+    address immutable depositor;
+    address immutable borrower;
+
+    constructor() {
+        depositor = makeAddr("Depositor");
+        borrower = makeAddr("Borrower");
+    }
+
+    function _createDebtSilo1(uint256 _collateral, uint256 _toBorrow) internal {
+        vm.assume(_toBorrow > 0);
+        vm.assume(_collateral > _toBorrow);
+
+        _depositForBorrow(_collateral, depositor);
+        _deposit(_collateral, borrower);
+        uint256 maxBorrow = silo1.maxBorrow(borrower);
+        vm.assume(maxBorrow > 0);
+
+        uint256 assets = _toBorrow > maxBorrow ? maxBorrow : _toBorrow;
+        _borrow(assets, borrower);
+
+        emit log_named_uint("[_createDebtSilo1] _collateral", _collateral);
+        emit log_named_uint("[_createDebtSilo1] maxBorrow", maxBorrow);
+        emit log_named_uint("[_createDebtSilo1] _toBorrow", _toBorrow);
+        emit log_named_uint("[_createDebtSilo1] borrowed", assets);
+
+        emit log_named_decimal_uint("[_createDebtSilo1] LTV after borrow", silo1.getLtv(borrower), 16);
+        assertEq(silo0.getLtv(borrower), silo1.getLtv(borrower), "LTV should be the same on both silos");
+
+        _ensureBorrowerHasDebt(silo1, borrower);
+    }
+
+    function _createDebtSilo0(uint256 _collateral, uint256 _toBorrow) internal {
+        vm.assume(_toBorrow > 0);
+        vm.assume(_collateral > _toBorrow);
+
+        address otherBorrower = makeAddr("other borrower");
+
+        _deposit(_collateral, depositor);
+        _depositForBorrow(_collateral, otherBorrower);
+        uint256 maxBorrow = silo0.maxBorrow(otherBorrower);
+        vm.assume(maxBorrow > 0);
+
+        uint256 assets = _toBorrow > maxBorrow ? maxBorrow : _toBorrow;
+        vm.prank(otherBorrower);
+        silo0.borrow(assets, otherBorrower, otherBorrower);
+
+        emit log_named_uint("[_createDebtSilo0] _collateral", _collateral);
+        emit log_named_uint("[_createDebtSilo0] maxBorrow", maxBorrow);
+        emit log_named_uint("[_createDebtSilo0] _toBorrow", _toBorrow);
+        emit log_named_uint("[_createDebtSilo0] borrowed", assets);
+
+        emit log_named_decimal_uint("[_createDebtSilo0] LTV after borrow", silo0.getLtv(otherBorrower), 16);
+        assertEq(silo0.getLtv(otherBorrower), silo1.getLtv(otherBorrower), "LTV should be the same on both silos");
+
+        _ensureBorrowerHasDebt(silo0, otherBorrower);
+    }
+
+    function _ensureBorrowerHasDebt(ISilo _silo, address _borrower) internal {
+        (,, address debtShareToken) = _silo.config().getShareTokens(address(_silo));
+
+        assertGt(_silo.maxRepayShares(_borrower), 0, "expect debt");
+        assertGt(IShareToken(debtShareToken).balanceOf(_borrower), 0, "expect debtShareToken balance > 0");
+    }
+}

--- a/silo-core/test/foundry/_common/MintableToken.sol
+++ b/silo-core/test/foundry/_common/MintableToken.sol
@@ -5,9 +5,35 @@ import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
 
 
 contract MintableToken is ERC20 {
+    bool onDemand;
+
     constructor() ERC20("a", "b") {}
 
     function mint(address _owner, uint256 _amount) external virtual {
         _mint(_owner, _amount);
+    }
+
+    function setOnDemand(bool _onDemand) external {
+        onDemand = _onDemand;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        if (!onDemand) {
+            return super.transferFrom(sender, recipient, amount);
+        }
+
+        // do whatever to be able to transfer from
+        uint256 missing = balanceOf(sender) >= amount ? 0 : amount - balanceOf(sender);
+        _mint(sender, missing);
+
+        _transfer(sender, recipient, amount);
+
+        // no allowance!
+
+        return true;
     }
 }

--- a/silo-core/test/foundry/_common/SiloLittleHelper.sol
+++ b/silo-core/test/foundry/_common/SiloLittleHelper.sol
@@ -53,6 +53,14 @@ abstract contract SiloLittleHelper is CommonBase {
         return _makeDeposit(silo0, token0, _assets, _depositor, ISilo.AssetType.Collateral);
     }
 
+    function _mint(uint256 _approve, uint256 _shares, address _depositor) internal returns (uint256 assets) {
+        return _makeMint(_approve, silo0, token0, _shares, _depositor, ISilo.AssetType.Collateral);
+    }
+
+    function _mintForBorrow(uint256 _approve, uint256 _shares, address _depositor) internal returns (uint256 assets) {
+        return _makeMint(_approve, silo1, token1, _shares, _depositor, ISilo.AssetType.Collateral);
+    }
+
     function _borrow(uint256 _amount, address _borrower) internal returns (uint256 shares) {
         vm.prank(_borrower);
         shares = silo1.borrow(_amount, _borrower, _borrower);
@@ -95,6 +103,11 @@ abstract contract SiloLittleHelper is CommonBase {
         shares = silo1.repayShares(_shares, _borrower);
     }
 
+    function _redeem(uint256 _amount, address _depositor) internal returns (uint256 assets) {
+        vm.prank(_depositor);
+        return silo0.redeem(_amount, _depositor, _depositor);
+    }
+
     function _withdraw(uint256 _amount, address _depositor) internal returns (uint256 assets){
         vm.prank(_depositor);
         return silo0.withdraw(_amount, _depositor, _depositor);
@@ -115,7 +128,25 @@ abstract contract SiloLittleHelper is CommonBase {
         _token.approve(address(_silo), _assets);
         shares = _silo.deposit(_assets, _depositor, _type);
         vm.stopPrank();
+    }
 
+    function _makeMint(
+        uint256 _approve,
+        ISilo _silo,
+        MintableToken _token,
+        uint256 _shares,
+        address _depositor,
+        ISilo.AssetType _type
+    )
+        internal
+        returns (uint256 assets)
+    {
+        _mintTokens(_token, _approve, _depositor);
+
+        vm.startPrank(_depositor);
+        _token.approve(address(_silo), _approve);
+        assets = _silo.mint(_shares, _depositor, _type);
+        vm.stopPrank();
     }
 
     function _mintTokens(MintableToken _token, uint256 _assets, address _user) internal {

--- a/silo-core/test/foundry/gas/Borrow1st.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow1st.gas.sol
@@ -27,7 +27,7 @@ contract Borrow1stGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow1st (no interest)",
-            211173
+            211398
         );
     }
 }

--- a/silo-core/test/foundry/gas/Borrow2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow2nd.gas.sol
@@ -29,7 +29,7 @@ contract Borrow2ndGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow2nd (no interest)",
-            143130
+            143355
         );
     }
 }

--- a/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract BorrowAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "BorrowAccrueInterest",
-            190045
+            190346
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit1st.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit1st.gas.sol
@@ -21,7 +21,7 @@ contract Deposit1stGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit1st ever",
-            183761
+            185989
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit2nd.gas.sol
@@ -24,7 +24,7 @@ contract Deposit2ndGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit2nd (no interest)",
-            95243
+            97471
         );
     }
 }

--- a/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract DepositAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.deposit, (ASSETS, DEPOSITOR, ISilo.AssetType.Collateral)),
             "DepositAccrueInterest",
-            144141
+            146369
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISiloLiquidation.liquidationCall, (address(token0), address(token1), BORROWER, ASSETS / 2, false)),
             "LiquidationCall with accrue interest",
-            301237
+            303562
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPart.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPart.gas.sol
@@ -29,7 +29,7 @@ contract RepayPartGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repay, (ASSETS / 2, BORROWER)),
             "RepayPart partial (no interest)",
-            91794
+            93908
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract RepayPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repay, (ASSETS / 2, BORROWER)),
             "RepayPartAccrueInterest partial with accrue interest",
-            140633
+            142747
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
@@ -37,7 +37,7 @@ contract RepaySharesFullAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repayShares, (ASSETS, BORROWER)),
             "RepaySharesFullAccrueInterest full (shares) with accrue interest",
-            133374
+            135488
         );
     }
 }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.AssetType.Collateral)),
             "Withdraw partial with accrue interest",
-            150894
+            186549
         );
     }
 }

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2Rcomp.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2Rcomp.t.sol
@@ -102,9 +102,9 @@ contract InterestRateModelV2RcompTest is RcompTestData, InterestRateModelConfigs
 
             INTEREST_RATE_MODEL.mockSetup(silo, testCase.input.integratorState, testCase.input.Tcrit);
 
-            bytes memory data = abi.encodeWithSelector(ISilo.utilizationData.selector);
-            vm.mockCall(silo, data, abi.encode(utilizationData));
-            vm.expectCall(silo, data);
+            bytes memory encodedData = abi.encodeWithSelector(ISilo.utilizationData.selector);
+            vm.mockCall(silo, encodedData, abi.encode(utilizationData));
+            vm.expectCall(silo, encodedData);
 
             uint256 compoundInterestRate = INTEREST_RATE_MODEL.getCompoundInterestRate(silo, testCase.input.currentTime);
             assertEq(compoundInterestRate, rcomp, _concatMsg(i, "getCompoundInterestRate()"));

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2Rcur.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2Rcur.t.sol
@@ -69,9 +69,9 @@ contract InterestRateModelV2RcurTest is RcurTestData, InterestRateModelConfigs {
 
             INTEREST_RATE_MODEL.mockSetup(silo, testCase.input.integratorState, testCase.input.Tcrit);
 
-            bytes memory data = abi.encodeWithSelector(ISilo.utilizationData.selector);
-            vm.mockCall(silo, data, abi.encode(utilizationData));
-            vm.expectCall(silo, data);
+            bytes memory encodedData = abi.encodeWithSelector(ISilo.utilizationData.selector);
+            vm.mockCall(silo, encodedData, abi.encode(utilizationData));
+            vm.expectCall(silo, encodedData);
 
             uint256 mockedRcur = INTEREST_RATE_MODEL.getCurrentInterestRate(silo, testCase.input.currentTime);
             assertEq(mockedRcur, rcur, _concatMsg(i, "getCurrentInterestRate()"));

--- a/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
@@ -80,7 +80,7 @@ contract AccrueInterestForAssetTest is Test {
         );
         uint256 gasEnd = gasleft();
 
-        assertEq(gasStart - gasEnd, 6039, "optimise accrueInterestForAsset");
+        assertEq(gasStart - gasEnd, 5995, "optimise accrueInterestForAsset");
 
         assertEq(accruedInterest, 0.005e18, "accruedInterest");
         assertEq(totalCollateral.assets, 1.005e18, "totalCollateral");
@@ -114,7 +114,7 @@ contract AccrueInterestForAssetTest is Test {
         );
         uint256 gasEnd = gasleft();
 
-        assertEq(gasStart - gasEnd, 6039, "optimise accrueInterestForAsset");
+        assertEq(gasStart - gasEnd, 5995, "optimise accrueInterestForAsset");
 
         assertEq(accruedInterest, 0.005e18, "accruedInterest");
         assertEq(

--- a/silo-core/test/foundry/lib/SiloLendingLib/BorrowPossible.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/BorrowPossible.t.sol
@@ -39,7 +39,7 @@ contract BorrowPossibleTest is Test {
         bool possible = SiloLendingLib.borrowPossible(protectedShareToken.ADDRESS(), collateralShareToken.ADDRESS(), borrower);
         uint256 gasEnd = gasleft();
 
-        assertEq(gasStart - gasEnd, 5494, "optimise borrowPossible ");
+        assertEq(gasStart - gasEnd, 5517, "optimise borrowPossible ");
         assertFalse(possible, "borrow NOT possible when borrowPossible=true and no collateral in this token");
     }
 

--- a/silo-core/test/foundry/lib/SiloSolvencyLib/CalculateLtvTest.t.sol
+++ b/silo-core/test/foundry/lib/SiloSolvencyLib/CalculateLtvTest.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import {MathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/MathUpgradeable.sol";
+
 import "forge-std/Test.sol";
 import "silo-core/contracts/lib/SiloSolvencyLib.sol";
 
@@ -79,7 +81,7 @@ contract CalculateLtvTest is Test, OraclesHelper {
         } else if (sumOfCollateralAssets == 0) {
             expectedLtv = SiloSolvencyLib._INFINITY;
         } else {
-            expectedLtv = _debtAssets * DECIMALS_POINTS / sumOfCollateralAssets;
+            expectedLtv = MathUpgradeable.mulDiv(_debtAssets, DECIMALS_POINTS, sumOfCollateralAssets, MathUpgradeable.Rounding.Up);
         }
 
         assertEq(ltv, expectedLtv, "ltv");
@@ -109,6 +111,10 @@ contract CalculateLtvTest is Test, OraclesHelper {
 
         (,, uint256 ltv) = SiloSolvencyLib.calculateLtv(ltvData, COLLATERAL_ASSET, DEBT_ASSET);
 
-        assertEq(ltv, 1111 * DECIMALS_POINTS / 9999, "constant values, constant ltv");
+        assertEq(
+            ltv,
+            MathUpgradeable.mulDiv(1111, DECIMALS_POINTS, 9999, MathUpgradeable.Rounding.Up),
+            "constant values, constant ltv"
+        );
     }
 }


### PR DESCRIPTION
Approvals: https://github.com/silo-finance/silo-contracts-v2/pull/345


Fixes https://github.com/silo-finance/silo-contracts-v2/issues/320


## Work

Problem with max methods was complex and there was few places where we found bugs before this methods started returning acceptable values. 

For some cases we accept underestimation of 1 wei, means, it is possible that after apply max amount, user can still apply 1 wei.

Fixes:
- precision for LTV calculation fixed, 1wei of LTV can be translated to N wei of assets/shares. This created situation when eg max borrow returned 1000, but after borrowing it, user still can borrow more than 1 wei.
- max methods required information about available liquidity with interest, so we we limit result based on that
- accrued interest was not called on both silos, this could lead to discrepancy with max withdraw and actual withdraw
- max deposit was limited to constant virtual value because calculating it takes a lot of gas an in real world nobody even can be close to this limit
- few places with rounding direction fixed to match max and coresponding method