### PR TITLE
[0.0.35] TOB-SILO2-19: max* functions - add liquidity limit when user has no debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.35] - 2023-12-27
+### Fixed
+- [issue-320](https://github.com/silo-finance/silo-contracts-v2/issues/320) TOB-SILO2-19: max* functions return
+  incorrect values: add liquidity limit when user has no debt
+
 ## [0.0.34] - 2023-12-22
 ### Fixed
 - [TOB-SILO2-10](https://github.com/silo-finance/silo-contracts-v2/issues/300): Incorrect rounding direction in preview

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/test/foundry/Silo/max/MaxRedeem.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxRedeem.i.sol
@@ -54,7 +54,7 @@ contract MaxRedeemTest is MaxWithdrawCommon {
         uint128 _toBorrow
     ) public {
 //        (uint128 _collateral, uint256 _toBorrow) = (52874512, 1);
-        _createDebtSilo1(_collateral, _toBorrow);
+        _createDebtOnSilo1(_collateral, _toBorrow);
 
         uint256 maxRedeem = silo0.maxRedeem(borrower);
 
@@ -75,7 +75,7 @@ contract MaxRedeemTest is MaxWithdrawCommon {
         uint128 _toBorrow
     ) public {
         // uint128 _collateral = 100;
-        _createDebtSilo1(_collateral, _toBorrow);
+        _createDebtOnSilo1(_collateral, _toBorrow);
 
         vm.warp(block.timestamp + 100 days);
 
@@ -97,8 +97,8 @@ contract MaxRedeemTest is MaxWithdrawCommon {
         uint128 _toBorrow
     ) public {
         // (uint128 _collateral, uint128 _toBorrow) = (21288, 4007);
-        _createDebtSilo1(_collateral, _toBorrow);
-        _createDebtSilo0(_collateral, _toBorrow);
+        _createDebtOnSilo1(_collateral, _toBorrow);
+        _createDebtOnSilo0(_collateral, _toBorrow);
 
         vm.warp(block.timestamp + 100 days);
         emit log("----- time travel -------");

--- a/silo-core/test/foundry/Silo/max/MaxWithdrawCommon.sol
+++ b/silo-core/test/foundry/Silo/max/MaxWithdrawCommon.sol
@@ -23,7 +23,7 @@ contract MaxWithdrawCommon is SiloLittleHelper, Test {
         borrower = makeAddr("Borrower");
     }
 
-    function _createDebtSilo1(uint256 _collateral, uint256 _toBorrow) internal {
+    function _createDebtOnSilo1(uint256 _collateral, uint256 _toBorrow) internal {
         vm.assume(_toBorrow > 0);
         vm.assume(_collateral > _toBorrow);
 
@@ -46,7 +46,7 @@ contract MaxWithdrawCommon is SiloLittleHelper, Test {
         _ensureBorrowerHasDebt(silo1, borrower);
     }
 
-    function _createDebtSilo0(uint256 _collateral, uint256 _toBorrow) internal {
+    function _createDebtOnSilo0(uint256 _collateral, uint256 _toBorrow) internal {
         vm.assume(_toBorrow > 0);
         vm.assume(_collateral > _toBorrow);
 


### PR DESCRIPTION
Fixes: https://github.com/silo-finance/silo-contracts-v2/issues/320

## Work

Added liquidity limit when user has no debt to ensure we will not revert on withdraw.