### PR TITLE
TOB-SILO2-19: max* functions - underestimate `maxBorrow` more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.0.36] - 2023-12-27
+### Fixed
+- [issue-320](https://github.com/silo-finance/silo-contracts-v2/issues/320) TOB-SILO2-19: max* functions return
+  incorrect values: underestimate `maxBorrow` more, to cover big amounts
+
 ## [0.0.35] - 2023-12-27
 ### Fixed
 - [issue-320](https://github.com/silo-finance/silo-contracts-v2/issues/320) TOB-SILO2-19: max* functions return

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -571,6 +571,8 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable {
             totalDebtShares,
             SiloLendingLib.getLiquidity(cachedConfig)
         );
+
+        unchecked { if (maxAssets > 0) return maxAssets - 1; }
     }
 
     /// @inheritdoc ISilo

--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -276,7 +276,9 @@ interface ISilo is IERC4626, IERC3156FlashLender, ISiloLiquidation {
 
     /// @notice Calculates the maximum amount of assets that can be borrowed by the given address
     /// @param _borrower Address of the potential borrower
-    /// @return maxAssets Maximum amount of assets that the borrower can borrow
+    /// @return maxAssets Maximum amount of assets that the borrower can borrow, this value is underestimated
+    /// That means, in some cases when you borrow maxAssets, you will be able to borrow again eg. up to 2wei
+    /// Reason for underestimation is to return value that will not cause borrow revert
     function maxBorrow(address _borrower) external view returns (uint256 maxAssets);
 
     /// @notice Previews the amount of shares equivalent to the given asset amount for borrowing

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -94,10 +94,10 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
 
         uint256 maxBorrow = silo0.maxBorrow(borrower);
         uint256 maxBorrowShares = silo0.maxBorrowShares(borrower);
-        assertEq(maxBorrow, 0.85e18, "invalid maxBorrow");
+        assertEq(maxBorrow, 0.85e18 - 1, "invalid maxBorrow");
         assertEq(maxBorrowShares, 0.85e18, "invalid maxBorrowShares");
 
-        uint256 borrowToMuch = maxBorrow + 1;
+        uint256 borrowToMuch = maxBorrow + 2;
         // emit log_named_uint("borrowToMuch", borrowToMuch);
 
         vm.expectRevert(ISilo.AboveMaxLtv.selector);
@@ -135,7 +135,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         // deposit, so we can borrow
         _depositForBorrow(depositAssets * 2, depositor);
 
-        maxBorrow = silo1.maxBorrow(borrower);
+        maxBorrow = silo1.maxBorrow(borrower) + 1; // +1 to balance out underestimation
         // emit log_named_decimal_uint("maxBorrow #1", maxBorrow, 18);
         assertEq(maxBorrow, 0.75e18, "maxBorrow borrower can do, maxLTV is 75%");
 
@@ -155,7 +155,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         assertEq(gotShares, convertToShares, "convertToShares returns same result");
         assertEq(borrowAmount, silo1.convertToAssets(gotShares), "convertToAssets returns borrowAmount");
 
-        borrowAmount = silo1.maxBorrow(borrower);
+        borrowAmount = silo1.maxBorrow(borrower) + 1; // +1 to balance out underestimation
         // emit log_named_decimal_uint("borrowAmount #2", borrowAmount, 18);
         assertEq(borrowAmount, 0.75e18 / 2, "~");
 
@@ -194,7 +194,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         _depositForBorrow(100e18, depositor);
         assertEq(silo1.getLtv(borrower), 0, "no debt, so LT == 0");
 
-        uint256 maxBorrow = silo1.maxBorrow(borrower);
+        uint256 maxBorrow = silo1.maxBorrow(borrower) + 1; // +1 to balance out underestimation
 
         _borrow(200e18, borrower, ISilo.NotEnoughLiquidity.selector);
         _borrow(maxBorrow * 2, borrower, ISilo.AboveMaxLtv.selector);

--- a/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
@@ -39,7 +39,7 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_maxBorrow_withCollateral
+    forge test -vv --ffi --mt test_maxBorrow_withCollateral_fuzz
     */
     /// forge-config: core.fuzz.runs = 1000
     function test_maxBorrow_withCollateral_fuzz(
@@ -55,8 +55,7 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
         uint256 maxBorrow = silo1.maxBorrow(borrower);
         emit log_named_decimal_uint("maxBorrow", maxBorrow, 18);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrow);
-
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 2);
         _assertMaxBorrowIsZeroAtTheEnd();
     }
 
@@ -92,7 +91,7 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
         // now we have debt
 
         maxBorrow = silo1.maxBorrow(borrower);
-        _assertWeCanNotBorrowAboveMax(maxBorrow);
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 2);
 
         _assertMaxBorrowIsZeroAtTheEnd();
     }
@@ -173,8 +172,56 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
         maxBorrow = silo1.maxBorrow(borrower);
         assertGt(maxBorrow, 0, "we can borrow again after repay");
 
-        _assertWeCanNotBorrowAboveMax(maxBorrow, 3);
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 4);
         _assertMaxBorrowIsZeroAtTheEnd(1);
+    }
+
+    /*
+    forge test -vv --ffi --mt test_maxBorrow_maxOut
+    */
+    function test_maxBorrow_maxOut() public {
+        address user0 = makeAddr("user0");
+        address user1 = makeAddr("user1");
+        address user2 = makeAddr("user2");
+
+        emit log("User 1 deposits 54901887191424375183106916902 assets into Silo 2");
+        _depositForBorrow(54901887191424375183106916902, user1);
+
+        emit log("User 0 deposits 37778931862957161709569 assets into Silo 1");
+        _deposit(37778931862957161709569, user0);
+
+        emit log("User 2 mints 57553484963063775982514231325194206610732636 shares from Silo 2");
+
+        token1.setOnDemand(true);
+        _mintForBorrow(1, 57553484963063775982514231325194206610732636, user2);
+        token1.setOnDemand(false);
+
+        emit log_named_uint("User 1 max borrow on silo1", silo0.maxBorrow(user1));
+        emit log_named_uint("User 1 max borrow on silo2", silo1.maxBorrow(user1));
+
+        emit log("User 1 borrows the maximum returned from maxBorrow from Silo 1");
+        vm.startPrank(user1);
+        silo0.borrow(silo0.maxBorrow(user1), user1, user1);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 41);
+
+        emit log("Timestamp is increased by 41 seconds");
+
+        emit log("User 0 deposits 115792089237316195417293883273301227089434195242432897623355228563449095127042 assets into Silo 1");
+        _deposit(115792089237316195417293883273301227089434195242432897623355228563449095127042, user0);
+
+        uint256 liquidity = silo0.getLiquidity();
+        emit log_named_uint("liquidity on the fly", liquidity);
+        silo0.accrueInterest();
+        assertEq(liquidity, silo0.getLiquidity());
+
+        uint256 maxBorrow = silo0.maxBorrow(user2);
+        emit log_named_uint("user2 maxBorrow", maxBorrow);
+
+        emit log("User 2 attempts to borrow maxBorrow assets, it fails with AboveMaxLtv()");
+        vm.prank(user2);
+        silo0.borrow(maxBorrow, user2, user2);
     }
 
     function _assertWeCanNotBorrowAboveMax(uint256 _maxBorrow) internal {


### PR DESCRIPTION
Fixes https://github.com/silo-finance/silo-contracts-v2/issues/320


## [0.0.36] - 2023-12-27
### Fixed
- TOB-SILO2-19: max* functions return incorrect values: underestimate `maxBorrow` more, to cover big amounts
