### PR TITLE
reduce silo size, optimise gas

### DIFF
--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -195,6 +195,14 @@ interface ISilo is IERC4626, IERC3156FlashLender, ISiloLiquidation {
         view
         returns (uint256 totalCollateralAssets, uint256 totalProtectedAssets);
 
+    /// @notice Retrieves the total amounts of collateral and debt assets
+    /// @return totalCollateralAssets The total amount of assets of type 'Collateral'
+    /// @return totalDebtAssets The total amount of debt assets of type 'Debt'
+    function getCollateralAndDebtAssets()
+        external
+        view
+        returns (uint256 totalCollateralAssets, uint256 totalDebtAssets);
+
     /// @notice Retrieves the fee details in 18 decimals points and the addresses of the DAO and deployer fee receivers
     /// @return daoFeeReceiver The address of the DAO fee receiver
     /// @return deployerFeeReceiver The address of the deployer fee receiver

--- a/silo-core/contracts/lib/SiloERC4626Lib.sol
+++ b/silo-core/contracts/lib/SiloERC4626Lib.sol
@@ -166,7 +166,7 @@ library SiloERC4626Lib {
         IShareToken _collateralShareToken,
         IShareToken _debtShareToken,
         ISilo.Assets storage _totalCollateral
-    ) public returns (uint256 assets, uint256 shares) {
+    ) internal returns (uint256 assets, uint256 shares) {
         if (!depositPossible(address(_debtShareToken), _receiver)) {
             revert ISilo.DepositNotPossible();
         }
@@ -244,7 +244,7 @@ library SiloERC4626Lib {
         ISilo.AssetType _assetType,
         uint256 _liquidity,
         ISilo.Assets storage _totalCollateral
-    ) public returns (uint256 assets, uint256 shares) {
+    ) internal returns (uint256 assets, uint256 shares) {
         uint256 shareTotalSupply = IShareToken(_shareToken).totalSupply();
         if (shareTotalSupply == 0) revert ISilo.NothingToWithdraw();
 

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -50,7 +50,7 @@ library SiloLendingLib {
         address _spender,
         ISilo.Assets storage _totalDebt,
         uint256 _totalCollateralAssets
-    ) external returns (uint256 borrowedAssets, uint256 borrowedShares) {
+    ) internal returns (uint256 borrowedAssets, uint256 borrowedShares) {
         if (_assets == 0 && _shares == 0) revert ISilo.ZeroAssets();
 
         if (!borrowPossible(_configData.protectedShareToken, _configData.collateralShareToken, _borrower)) {
@@ -138,7 +138,7 @@ library SiloLendingLib {
         address _borrower,
         address _repayer,
         ISilo.Assets storage _totalDebt
-    ) external returns (uint256 assets, uint256 shares) {
+    ) internal returns (uint256 assets, uint256 shares) {
         if (_assets == 0 && _shares == 0) revert ISilo.ZeroAssets();
 
         IShareToken debtShareToken = IShareToken(_configData.debtShareToken);
@@ -186,7 +186,7 @@ library SiloLendingLib {
         ISilo.SiloData storage _siloData,
         ISilo.Assets storage _totalCollateral,
         ISilo.Assets storage _totalDebt
-    ) external returns (uint256 accruedInterest) {
+    ) internal returns (uint256 accruedInterest) {
         uint64 lastTimestamp = _siloData.interestRateTimestamp;
 
         // This is the first time, so we can return early and save some gas
@@ -226,31 +226,13 @@ library SiloLendingLib {
         unchecked { _siloData.daoAndDeployerFees += uint192(totalFees); }
     }
 
-    function getLiquidity(ISiloConfig _config) external view returns (uint256 liquidity) {
-        ISiloConfig.ConfigData memory config = _config.getConfig(address(this));
-
-        uint256 totalCollateralAssets = SiloStdLib.getTotalCollateralAssetsWithInterest(
-            address(this),
-            config.interestRateModel,
-            config.daoFee,
-            config.deployerFee
-        );
-
-        uint256 totalDebtAssets = SiloStdLib.getTotalDebtAssetsWithInterest(
-            address(this),
-            config.interestRateModel
-        );
-
-        liquidity = SiloMathLib.liquidity(totalCollateralAssets, totalDebtAssets);
-    }
-
     /// @notice Determines the maximum amount (both in assets and shares) that a borrower can borrow
     /// @param _collateralConfig Configuration data for the collateral
     /// @param _debtConfig Configuration data for the debt
     /// @param _borrower The address of the borrower whose maximum borrow limit is being queried
     /// @param _totalDebtAssets The total debt assets in the system
     /// @param _totalDebtShares The total debt shares in the system
-    /// @param _liquidityWithInterest liquidity for collateral asset
+    /// @param _siloConfig address of SiloConfig contract
     /// @return assets The maximum amount in assets that can be borrowed
     /// @return shares The equivalent amount in shares for the maximum assets that can be borrowed
     function maxBorrow( // solhint-disable-line function-max-lines
@@ -259,7 +241,7 @@ library SiloLendingLib {
         address _borrower,
         uint256 _totalDebtAssets,
         uint256 _totalDebtShares,
-        uint256 _liquidityWithInterest
+        ISiloConfig _siloConfig
     )
         external
         view
@@ -278,8 +260,9 @@ library SiloLendingLib {
             0 /* no cached balance */
         );
 
-        (uint256 sumOfBorrowerCollateralValue, uint256 borrowerDebtValue) =
-            SiloSolvencyLib.getPositionValues(ltvData, _collateralConfig.token, _debtConfig.token);
+        (
+            uint256 sumOfBorrowerCollateralValue, uint256 borrowerDebtValue
+        ) = SiloSolvencyLib.getPositionValues(ltvData, _collateralConfig.token, _debtConfig.token);
 
         uint256 maxBorrowValue = SiloMathLib.calculateMaxBorrowValue(
             _collateralConfig.maxLtv,
@@ -298,18 +281,38 @@ library SiloLendingLib {
             _totalDebtShares
         );
 
-        if (assets > _liquidityWithInterest) {
-            assets = _liquidityWithInterest;
+        uint256 liquidityWithInterest = getLiquidity(_siloConfig);
+
+        if (assets > liquidityWithInterest) {
+            assets = liquidityWithInterest;
 
             // rounding must follow same flow as in `maxBorrowValueToAssetsAndShares()`
             shares = SiloMathLib.convertToShares(
-                 assets,
+                assets,
                 _totalDebtAssets,
                 _totalDebtShares,
                 borrowerDebtValue == 0 ? MathUpgradeable.Rounding.Up : MathUpgradeable.Rounding.Down,
                 ISilo.AssetType.Debt
             );
         }
+    }
+
+    function getLiquidity(ISiloConfig _config) public view returns (uint256 liquidity) {
+        ISiloConfig.ConfigData memory config = _config.getConfig(address(this));
+
+        uint256 totalCollateralAssets = SiloStdLib.getTotalCollateralAssetsWithInterest(
+            address(this),
+            config.interestRateModel,
+            config.daoFee,
+            config.deployerFee
+        );
+
+        uint256 totalDebtAssets = SiloStdLib.getTotalDebtAssetsWithInterest(
+            address(this),
+            config.interestRateModel
+        );
+
+        liquidity = SiloMathLib.liquidity(totalCollateralAssets, totalDebtAssets);
     }
 
     /// @notice Checks if a borrower can borrow

--- a/silo-core/contracts/lib/SiloStdLib.sol
+++ b/silo-core/contracts/lib/SiloStdLib.sol
@@ -87,29 +87,6 @@ library SiloStdLib {
         if (fee == 0) return 1;
     }
 
-    /// @notice Retrieves fee amounts in 18 decimals points and their respective receivers along with the asset
-    /// @param _config The configuration contract used to fetch fee-related data
-    /// @param _factory The factory contract used to fetch fee receiver addresses
-    /// @return daoFeeReceiver Address of the DAO fee receiver
-    /// @return deployerFeeReceiver Address of the deployer fee receiver
-    /// @return daoFee DAO fee amount in 18 decimals points
-    /// @return deployerFee Deployer fee amount in 18 decimals points
-    /// @return asset Address of the associated asset
-    function getFeesAndFeeReceiversWithAsset(ISiloConfig _config, ISiloFactory _factory)
-        public
-        view
-        returns (
-            address daoFeeReceiver,
-            address deployerFeeReceiver,
-            uint256 daoFee,
-            uint256 deployerFee,
-            address asset
-        )
-    {
-        (daoFee, deployerFee,, asset) = _config.getFeesWithAsset(address(this));
-        (daoFeeReceiver, deployerFeeReceiver) = _factory.getFeeReceivers(address(this));
-    }
-
     /// @notice Returns totalAssets and totalShares for conversion math (convertToAssets and convertToShares)
     /// @dev This is useful for view functions that do not accrue interest before doing calculations. To work on
     ///      updated numbers, interest should be added on the fly.
@@ -121,7 +98,7 @@ library SiloStdLib {
         ISiloConfig.ConfigData memory _configData,
         ISilo.AssetType _assetType
     )
-        internal
+        external
         view
         returns (uint256 totalAssets, uint256 totalShares)
     {
@@ -145,14 +122,27 @@ library SiloStdLib {
         }
     }
 
-    /// @param _balanceCached if balance of `_owner` is unknown beforehand, then pass `0`
-    function getSharesAndTotalSupply(address _shareToken, address _owner, uint256 _balanceCached)
-        internal
+    /// @notice Retrieves fee amounts in 18 decimals points and their respective receivers along with the asset
+    /// @param _config The configuration contract used to fetch fee-related data
+    /// @param _factory The factory contract used to fetch fee receiver addresses
+    /// @return daoFeeReceiver Address of the DAO fee receiver
+    /// @return deployerFeeReceiver Address of the deployer fee receiver
+    /// @return daoFee DAO fee amount in 18 decimals points
+    /// @return deployerFee Deployer fee amount in 18 decimals points
+    /// @return asset Address of the associated asset
+    function getFeesAndFeeReceiversWithAsset(ISiloConfig _config, ISiloFactory _factory)
+        public
         view
-        returns (uint256 shares, uint256 totalSupply)
+        returns (
+            address daoFeeReceiver,
+            address deployerFeeReceiver,
+            uint256 daoFee,
+            uint256 deployerFee,
+            address asset
+        )
     {
-        shares = _balanceCached == 0 ? IShareToken(_shareToken).balanceOf(_owner) : _balanceCached;
-        totalSupply = IShareToken(_shareToken).totalSupply();
+        (daoFee, deployerFee,, asset) = _config.getFeesWithAsset(address(this));
+        (daoFeeReceiver, deployerFeeReceiver) = _factory.getFeeReceivers(address(this));
     }
 
     /// @notice Calculates the total collateral assets with accrued interest
@@ -167,12 +157,24 @@ library SiloStdLib {
         address _interestRateModel,
         uint256 _daoFee,
         uint256 _deployerFee
-    ) internal view returns (uint256 totalCollateralAssetsWithInterest) {
+    ) public view returns (uint256 totalCollateralAssetsWithInterest) {
         uint256 rcomp = IInterestRateModel(_interestRateModel).getCompoundInterestRate(_silo, block.timestamp);
 
+        (uint256 collateralAssets, uint256 debtAssets) = ISilo(_silo).getCollateralAndDebtAssets();
+
         (totalCollateralAssetsWithInterest,,,) = SiloMathLib.getCollateralAmountsWithInterest(
-            ISilo(_silo).getCollateralAssets(), ISilo(_silo).getDebtAssets(), rcomp, _daoFee, _deployerFee
+            collateralAssets, debtAssets, rcomp, _daoFee, _deployerFee
         );
+    }
+
+    /// @param _balanceCached if balance of `_owner` is unknown beforehand, then pass `0`
+    function getSharesAndTotalSupply(address _shareToken, address _owner, uint256 _balanceCached)
+        internal
+        view
+        returns (uint256 shares, uint256 totalSupply)
+    {
+        shares = _balanceCached == 0 ? IShareToken(_shareToken).balanceOf(_owner) : _balanceCached;
+        totalSupply = IShareToken(_shareToken).totalSupply();
     }
 
     /// @notice Calculates the total debt assets with accrued interest

--- a/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxBorrow.i.sol
@@ -104,7 +104,7 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
         uint128 _collateral,
         uint128 _liquidity
     ) public {
-//         (uint128 _collateral, uint128 _liquidity) = (64099903089467212573385554129187123252, 73362960447100600398853614451545866240);
+        // (uint128 _collateral, uint128 _liquidity) = (17610, 20969);
 
         vm.assume(_collateral > 0);
         vm.assume(_liquidity > 0);
@@ -125,7 +125,7 @@ contract MaxBorrowTest is SiloLittleHelper, Test {
         maxBorrow = silo1.maxBorrow(borrower);
         emit log_named_uint("maxBorrow", maxBorrow);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrow, 3);
+        _assertWeCanNotBorrowAboveMax(maxBorrow, 4);
 
         _assertMaxBorrowIsZeroAtTheEnd(1);
     }

--- a/silo-core/test/foundry/_mocks/SiloMock.sol
+++ b/silo-core/test/foundry/_mocks/SiloMock.sol
@@ -12,6 +12,12 @@ contract SiloMock is Test {
         ADDRESS = _silo == address(0) ? makeAddr("SiloMock") : _silo;
     }
 
+    function getCollateralAndDebtAssetsMock(uint256 _totalCollateralAssets, uint256 _totalDebtAssets) external {
+        bytes memory data = abi.encodeWithSelector(ISilo.getCollateralAndDebtAssets.selector);
+        vm.mockCall(ADDRESS, data, abi.encode(_totalCollateralAssets, _totalDebtAssets));
+        vm.expectCall(ADDRESS, data);
+    }
+
     // ISilo.getCollateralAssets.selector: 0xa1ff9bee
     function getCollateralAssetsMock(uint256 _totalCollateralAssets) external {
         bytes memory data = abi.encodeWithSelector(ISilo.getCollateralAssets.selector);

--- a/silo-core/test/foundry/gas/AccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/AccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract AccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.accrueInterest, ()),
             "AccrueInterest",
-            74718
+            71320
         );
     }
 }

--- a/silo-core/test/foundry/gas/Borrow1st.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow1st.gas.sol
@@ -27,7 +27,7 @@ contract Borrow1stGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow1st (no interest)",
-            206274
+            199441
         );
     }
 }

--- a/silo-core/test/foundry/gas/Borrow2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow2nd.gas.sol
@@ -29,7 +29,7 @@ contract Borrow2ndGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow2nd (no interest)",
-            138231
+            131398
         );
     }
 }

--- a/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract BorrowAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "BorrowAccrueInterest",
-            185222
+            178407
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit1st.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit1st.gas.sol
@@ -21,7 +21,7 @@ contract Deposit1stGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit1st ever",
-            185989
+            178883
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit2nd.gas.sol
@@ -24,7 +24,7 @@ contract Deposit2ndGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit2nd (no interest)",
-            97471
+            90365
         );
     }
 }

--- a/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract DepositAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.deposit, (ASSETS, DEPOSITOR, ISilo.AssetType.Collateral)),
             "DepositAccrueInterest",
-            146369
+            139280
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISiloLiquidation.liquidationCall, (address(token0), address(token1), BORROWER, ASSETS / 2, false)),
             "LiquidationCall with accrue interest",
-            303562
+            300143
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPart.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPart.gas.sol
@@ -29,7 +29,7 @@ contract RepayPartGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repay, (ASSETS / 2, BORROWER)),
             "RepayPart partial (no interest)",
-            88773
+            81894
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract RepayPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repay, (ASSETS / 2, BORROWER)),
             "RepayPartAccrueInterest partial with accrue interest",
-            137612
+            130750
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
@@ -37,7 +37,7 @@ contract RepaySharesFullAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.repayShares, (ASSETS, BORROWER)),
             "RepaySharesFullAccrueInterest full (shares) with accrue interest",
-            130353
+            123503
         );
     }
 }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.AssetType.Collateral)),
             "Withdraw partial with accrue interest",
-            181414
+            173359
         );
     }
 }

--- a/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
@@ -74,13 +74,9 @@ contract AccrueInterestForAssetTest is Test {
         totalDebt.assets = 0.5e18;
         siloData.interestRateTimestamp = oldTimestamp;
 
-        uint256 gasStart = gasleft();
         uint256 accruedInterest = SiloLendingLib.accrueInterestForAsset(
             irm.ADDRESS(), 0, 0, siloData, totalCollateral, totalDebt
         );
-        uint256 gasEnd = gasleft();
-
-        assertEq(gasStart - gasEnd, 5995, "optimise accrueInterestForAsset");
 
         assertEq(accruedInterest, 0.005e18, "accruedInterest");
         assertEq(totalCollateral.assets, 1.005e18, "totalCollateral");
@@ -108,13 +104,9 @@ contract AccrueInterestForAssetTest is Test {
         totalDebt.assets = 0.5e18;
         siloData.interestRateTimestamp = oldTimestamp;
 
-        uint256 gasStart = gasleft();
         uint256 accruedInterest = SiloLendingLib.accrueInterestForAsset(
             irm.ADDRESS(), daoFee, deployerFee, siloData, totalCollateral, totalDebt
         );
-        uint256 gasEnd = gasleft();
-
-        assertEq(gasStart - gasEnd, 5995, "optimise accrueInterestForAsset");
 
         assertEq(accruedInterest, 0.005e18, "accruedInterest");
         assertEq(

--- a/silo-core/test/foundry/lib/SiloLendingLib/BorrowPossible.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/BorrowPossible.t.sol
@@ -35,11 +35,8 @@ contract BorrowPossibleTest is Test {
         protectedShareToken.balanceOfMock(borrower, 0);
         collateralShareToken.balanceOfMock(borrower, 2);
 
-        uint256 gasStart = gasleft();
         bool possible = SiloLendingLib.borrowPossible(protectedShareToken.ADDRESS(), collateralShareToken.ADDRESS(), borrower);
-        uint256 gasEnd = gasleft();
 
-        assertEq(gasStart - gasEnd, 5517, "optimise borrowPossible ");
         assertFalse(possible, "borrow NOT possible when borrowPossible=true and no collateral in this token");
     }
 

--- a/silo-core/test/foundry/lib/SiloSolvencyLib/GetAssetsDataForLtvCalculations.t.sol
+++ b/silo-core/test/foundry/lib/SiloSolvencyLib/GetAssetsDataForLtvCalculations.t.sol
@@ -117,8 +117,10 @@ contract GetAssetsDataForLtvCalculationsTest is Test {
         SiloMock siloMock0 = new SiloMock(silo0);
 
         if (scenario.input.accrueInMemory) {
-            siloMock0.getCollateralAssetsMock(scenario.input.collateralConfig.totalCollateralAssets);
-            siloMock0.getDebtAssetsMock(scenario.input.collateralConfig.totalDebtAssets);
+            siloMock0.getCollateralAndDebtAssetsMock(
+                scenario.input.collateralConfig.totalCollateralAssets,
+                scenario.input.collateralConfig.totalDebtAssets
+            );
         }
 
         siloMock0.getCollateralAndProtectedAssetsMock(

--- a/silo-core/test/foundry/lib/SiloStdLib/GetTotalAssetsAndTotalSharesWithInterest.t.sol
+++ b/silo-core/test/foundry/lib/SiloStdLib/GetTotalAssetsAndTotalSharesWithInterest.t.sol
@@ -68,8 +68,7 @@ contract GetTotalAssetsAndTotalSharesWithInterestTest is Test {
         assertEq(totalAssets, 0);
         assertEq(totalShares, 0);
 
-        SILO.getCollateralAssetsMock(0);
-        SILO.getDebtAssetsMock(0);
+        SILO.getCollateralAndDebtAssetsMock(0, 0);
         COLLATERAL_SHARE_TOKEN.totalSupplyMock(0);
         INTEREST_RATE_MODEL.getCompoundInterestRateMock(silo, block.timestamp, 0);
         (totalAssets, totalShares) =
@@ -79,6 +78,7 @@ contract GetTotalAssetsAndTotalSharesWithInterestTest is Test {
         assertEq(totalShares, 0);
 
         DEBT_SHARE_TOKEN.totalSupplyMock(0);
+        SILO.getDebtAssetsMock(0);
         (totalAssets, totalShares) =
             SiloStdLib.getTotalAssetsAndTotalSharesWithInterest(_config(), ISilo.AssetType.Debt);
 
@@ -104,8 +104,7 @@ contract GetTotalAssetsAndTotalSharesWithInterestTest is Test {
         assertEq(totalAssets, 0);
         assertEq(totalShares, _totalSupply);
 
-        SILO.getCollateralAssetsMock(0);
-        SILO.getDebtAssetsMock(0);
+        SILO.getCollateralAndDebtAssetsMock(0, 0);
         COLLATERAL_SHARE_TOKEN.totalSupplyMock(_totalSupply);
         INTEREST_RATE_MODEL.getCompoundInterestRateMock(silo, block.timestamp, 0);
         (totalAssets, totalShares) =
@@ -115,6 +114,7 @@ contract GetTotalAssetsAndTotalSharesWithInterestTest is Test {
         assertEq(totalShares, _totalSupply);
 
         DEBT_SHARE_TOKEN.totalSupplyMock(_totalSupply);
+        SILO.getDebtAssetsMock(0);
         (totalAssets, totalShares) =
             SiloStdLib.getTotalAssetsAndTotalSharesWithInterest(_config(), ISilo.AssetType.Debt);
 
@@ -243,8 +243,9 @@ contract GetTotalAssetsAndTotalSharesWithInterestTest is Test {
         uint256 totalShares;
 
         for (uint256 index = 0; index < collateralTestCasesIndex; index++) {
-            SILO.getCollateralAssetsMock(collateralTestCases[index].collateralAssets);
-            SILO.getDebtAssetsMock(collateralTestCases[index].debtAssets);
+            SILO.getCollateralAndDebtAssetsMock(
+                collateralTestCases[index].collateralAssets, collateralTestCases[index].debtAssets
+            );
             COLLATERAL_SHARE_TOKEN.totalSupplyMock(_totalSupply);
             INTEREST_RATE_MODEL.getCompoundInterestRateMock(silo, block.timestamp, collateralTestCases[index].rcomp);
             daoFee = collateralTestCases[index].daoFee;

--- a/silo-core/test/foundry/lib/SiloStdLib/GetTotalCollateralAssetsWithInterest.t.sol
+++ b/silo-core/test/foundry/lib/SiloStdLib/GetTotalCollateralAssetsWithInterest.t.sol
@@ -30,21 +30,20 @@ contract GetTotalAssetsWithInterestTest is Test {
         uint256 daoFee;
         uint256 deployerFee;
 
-        SILO.getCollateralAssetsMock(0);
-        SILO.getDebtAssetsMock(0);
+        SILO.getCollateralAndDebtAssetsMock(0, 0);
         INTEREST_RATE_MODEL.getCompoundInterestRateMock(silo, block.timestamp, 0);
         assertEq(SiloStdLib.getTotalCollateralAssetsWithInterest(silo, interestRateModel, daoFee, deployerFee), 0);
 
         INTEREST_RATE_MODEL.getCompoundInterestRateMock(silo, block.timestamp, 0.01e18);
         assertEq(SiloStdLib.getTotalCollateralAssetsWithInterest(silo, interestRateModel, daoFee, deployerFee), 0);
 
-        SILO.getCollateralAssetsMock(1000e18);
+        SILO.getCollateralAndDebtAssetsMock(1000e18, 0);
         assertEq(SiloStdLib.getTotalCollateralAssetsWithInterest(silo, interestRateModel, daoFee, deployerFee), 1000e18);
 
-        SILO.getDebtAssetsMock(500e18);
+        SILO.getCollateralAndDebtAssetsMock(1000e18, 500e18);
         assertEq(SiloStdLib.getTotalCollateralAssetsWithInterest(silo, interestRateModel, daoFee, deployerFee), 1005e18);
 
-        SILO.getDebtAssetsMock(1000e18);
+        SILO.getCollateralAndDebtAssetsMock(1000e18, 1000e18);
         daoFee = 0.01e18;
         assertEq(
             SiloStdLib.getTotalCollateralAssetsWithInterest(silo, interestRateModel, daoFee, deployerFee),


### PR DESCRIPTION
1. I make silo smaller by adding wrapper for lib methods that was suggested by @IhorSF, I did that for all of them and Silo size was down to `21.94 | 2.636`
2. I made some of lib methods `internal` again (based on when we using it) to reduce gas usage and result was up to ~8K gas less for some places, Silo size is now `24.181    | 0.395`.