### PR TITLE
[0.1.2]  ensure we can not deposit shares with `0` assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - ensure we can not borrow shares with `0` assets
 
+## [0.1.2] - 2024-01-31
+### Fixed
+- ensure we can not deposit shares with `0` assets
+
 ## [0.1.0] - 2024-01-03
 - code after first audit + develop changes
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/lib/SiloERC4626Lib.sol
+++ b/silo-core/contracts/lib/SiloERC4626Lib.sol
@@ -24,8 +24,6 @@ library SiloERC4626Lib {
     ///      That's why we decided to go with type(uint128).max - which is anyway high enough to consume any totalSupply
     uint256 internal constant _VIRTUAL_DEPOSIT_LIMIT = type(uint128).max;
 
-    error ZeroShares();
-
     /// @notice Determines the maximum amount of collateral a user can deposit
     /// This function is estimation to reduce gas usage. In theory, if silo total assets will be close to virtual limit
     /// and returned max assets will be eg 1, then it might be not possible to actually deposit 1wei because
@@ -183,7 +181,8 @@ library SiloERC4626Lib {
             ISilo.AssetType.Collateral
         );
 
-        if (shares == 0) revert ZeroShares();
+        if (shares == 0) revert ISilo.ZeroShares();
+        if (assets == 0) revert ISilo.ZeroAssets();
 
         // `assets` and `totalAssets` can never be more than uint256 because totalSupply cannot be either
         // however, there is (probably unreal but also untested) possibility, where you might borrow from silo

--- a/silo-core/test/foundry/Silo/Deposit.i.sol
+++ b/silo-core/test/foundry/Silo/Deposit.i.sol
@@ -165,7 +165,7 @@ contract DepositTest is SiloLittleHelper, Test {
 
         vm.startPrank(anyAddress);
         token1.approve(address(silo1), 1);
-        vm.expectRevert(SiloERC4626Lib.ZeroShares.selector);
+        vm.expectRevert(ISilo.ZeroShares.selector);
         silo1.deposit(1, anyAddress);
         vm.stopPrank();
     }


### PR DESCRIPTION
This hotfix is only because certora can find a case for it. I does not looks real, but because this is just `if` we can afort it.