### PR TITLE
[0.1.6] fix max redeem: include interest for collateral assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2024-02-12
+### Fixed
+- fix max redeem: include interest for collateral assets
+
 ## [0.1.5] - 2024-02-08
 ### Fixed
 - accrue interest on both silos for borrow

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -1128,7 +1128,7 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable {
             _config,
             _owner,
             _assetType,
-            _total[_assetType].assets,
+            _assetType == AssetType.Protected ? _total[AssetType.Protected].assets : 0, // will be calculated internally
             _assetType == AssetType.Protected ? _total[AssetType.Protected].assets : _callGetLiquidity(_config)
         );
     }

--- a/silo-core/test/foundry/echidna-findings/EchidnaMiddleman.sol
+++ b/silo-core/test/foundry/echidna-findings/EchidnaMiddleman.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+
+import {EchidnaSetup} from "./EchidnaSetup.sol";
+
+contract EchidnaMiddleman is EchidnaSetup {
+    function __depositNeverMintsZeroShares(uint8 _actor, bool _siloZero, uint256 _amount) internal {
+        address actor = _chooseActor(_actor);
+        ISilo silo = __chooseSilo(_siloZero);
+
+        vm.prank(actor);
+        silo.deposit(_amount, actor);
+    }
+
+    function __borrow(uint8 _actor, bool _siloZero, uint256 _amount) internal {
+        address actor = _chooseActor(_actor);
+        ISilo silo = __chooseSilo(_siloZero);
+
+        vm.prank(actor);
+        silo.borrow(_amount, actor, actor);
+    }
+
+    function __previewDeposit_doesNotReturnMoreThanDeposit(uint8 _actor, uint256 _assets)
+        internal
+        returns (uint256 shares)
+    {
+        address actor = _chooseActor(_actor);
+        vm.startPrank(actor);
+
+        uint256 depositShares = silo0.previewDeposit(_assets);
+        shares = silo0.deposit(_assets, actor);
+        assertEq(depositShares, shares, "previewDeposit fail");
+
+        vm.stopPrank();
+    }
+
+    function __maxBorrow_correctReturnValue(uint8 _actor) internal returns (uint256 maxAssets, uint256 shares) {
+        address actor = _chooseActor(_actor);
+        maxAssets = silo0.maxBorrow(actor);
+
+        vm.prank(actor);
+        shares = silo0.borrow(maxAssets, actor, actor); // should not revert!
+    }
+
+    function __mint(uint8 _actor, bool _siloZero, uint256 _shares) internal {
+        address actor = _chooseActor(_actor);
+        ISilo silo = __chooseSilo(_siloZero);
+
+        vm.prank(actor);
+        silo.mint(_shares, actor);
+    }
+
+    function __maxBorrowShares_correctReturnValue(uint8 _actor) internal returns (uint256 maxBorrow, uint256 shares) {
+        address actor = _chooseActor(_actor);
+
+        maxBorrow = silo0.maxBorrowShares(actor);
+        assertGt(maxBorrow, 0, "in echidna scenarios we exclude zeros, so we should not get it here as well");
+
+        vm.prank(actor);
+        shares = silo0.borrowShares(maxBorrow, actor, actor);
+    }
+
+    function __maxLiquidation_correctReturnValue(uint8 _actor) internal {
+        address actor = _chooseActor(_actor);
+        vm.startPrank(actor);
+
+        (bool isSolvent, ISilo siloWithDebt) = _invariant_insolventHasDebt(actor);
+        assertFalse(isSolvent, "expect not solvent user");
+
+        (, uint256 debtToRepay) = siloWithDebt.maxLiquidation(actor);
+
+        (address collateral, address debt) = __liquidationTokens(address(siloWithDebt));
+
+        siloWithDebt.liquidationCall(debt, collateral, actor, debtToRepay, false);
+
+        vm.stopPrank();
+    }
+
+    function __maxWithdraw_correctMax(uint8 _actor) internal {
+        address actor = _chooseActor(_actor);
+        uint256 maxWithdraw = silo0.maxWithdraw(actor);
+        _withdraw(maxWithdraw, actor);
+    }
+
+    function __deposit(uint8 _actor, bool _siloZero, uint256 _amount) internal {
+        address actor = _chooseActor(_actor);
+        vm.startPrank(actor);
+
+        __chooseSilo(_siloZero).deposit(_amount, actor);
+    }
+
+    function __transitionCollateral_doesNotResultInMoreShares(
+        uint8 _actor,
+        bool _siloZero,
+        uint256 _amount,
+        uint8 _type
+    ) internal returns (uint256) {
+        address actor = _chooseActor(_actor);
+
+        ISilo vault = __chooseSilo(_siloZero);
+        bool noInterest = _invariant_checkForInterest(vault);
+
+        vm.prank(actor);
+        return vault.transitionCollateral(_amount, actor, ISilo.AssetType(_type));
+    }
+
+    function __cannotPreventInsolventUserFromBeingLiquidated(
+        uint8 _actor,
+        bool _siloZero,
+        bool _receiveShares
+    ) internal {
+        ISilo vault = __chooseSilo(_siloZero);
+        address actor = _chooseActor(_actor);
+
+        (bool isSolvent, ISilo siloWithDebt) = _invariant_insolventHasDebt(actor);
+        assertFalse(isSolvent, "expect not solvent user");
+
+        (, uint256 debtToRepay) = siloWithDebt.maxLiquidation(actor);
+        (address collateral, address debt) = __liquidationTokens(address(siloWithDebt));
+
+        siloWithDebt.liquidationCall(debt, collateral, actor, debtToRepay, _receiveShares);
+    }
+
+    function __debtSharesNeverLargerThanDebt() internal {
+        uint256 debt0 = silo0.getDebtAssets();
+        uint256 debt1 = silo1.getDebtAssets();
+
+        (, , address debtShareToken0) = siloConfig.getShareTokens(address(silo0));
+        (, , address debtShareToken1) = siloConfig.getShareTokens(address(silo1));
+
+        uint256 debtShareBalance0 = IShareToken(debtShareToken0).totalSupply();
+        uint256 debtShareBalance1 = IShareToken(debtShareToken1).totalSupply();
+
+        assertGe(debt0, debtShareBalance0, "[debt] assets0 must be >= shares0");
+        assertGe(debt1, debtShareBalance1, "[debt] assets1 must be >= shares1");
+    }
+
+    function __borrowShares(uint8 _actorIndex, bool _siloZero, uint256 _shares) internal {
+        address actor = _chooseActor(_actorIndex);
+        ISilo silo = __chooseSilo(_siloZero);
+
+        vm.prank(actor);
+        silo.borrowShares(_shares, actor, actor);
+    }
+
+    function __maxRedeem_correctMax(uint8 _actorIndex) internal {
+        address actor = _chooseActor(_actorIndex);
+
+        // you need to repay when debt is?!
+        uint256 maxShares = silo0.maxRedeem(address(actor));
+        (, address collShareToken, ) = siloConfig.getShareTokens(address(silo0));
+        assertGt(IShareToken(collShareToken).balanceOf(actor), 0, "No deposits");
+        assertGt(maxShares, 0, "Zero shares to withdraw");
+
+        emit log_named_decimal_uint("Max Shares to redeem", maxShares, 18);
+
+        vm.prank(actor);
+        silo0.redeem(maxShares, actor, actor); // expect not to fail!
+    }
+
+    function __chooseSilo(bool _siloZero) private returns (ISilo) {
+        return _siloZero ? silo0 : silo1;
+    }
+
+    function __liquidationTokens(address _siloWithDebt) private returns (address collateral, address debt) {
+        (collateral, debt) = _siloWithDebt == address(silo0)
+            ? (address(token0), address(token1))
+            : (address(token1), address(token0));
+    }
+
+    function __timeDelay(uint256 _t) internal {
+        vm.warp(block.timestamp + _t);
+    }
+
+    function __timeDelay(uint256 _t, uint256 _roll) internal {
+        vm.warp(block.timestamp + _t);
+        vm.roll(block.number + _roll);
+    }
+}

--- a/silo-core/test/foundry/echidna-findings/EchidnaScenarios.i.sol
+++ b/silo-core/test/foundry/echidna-findings/EchidnaScenarios.i.sol
@@ -1,45 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
 import {Strings} from "openzeppelin-contracts/utils/Strings.sol";
-
 import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
-import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
-import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
-
-import {MintableToken} from "../_common/MintableToken.sol";
-import {SiloLittleHelper} from "../_common/SiloLittleHelper.sol";
-import {SiloFixture, SiloConfigOverride} from "../_common/fixtures/SiloFixture.sol";
+import {EchidnaMiddleman} from "./EchidnaMiddleman.sol";
 
 /*
     forge test -vv --ffi --mc EchidnaScenariosTest
 */
-contract EchidnaScenariosTest is SiloLittleHelper, Test {
-    uint256 constant ACTORS_COUNT = 3;
-    mapping (uint256 index => address actor) actors;
-
-    ISiloConfig siloConfig;
-
-    constructor() {
-        actors[0] = makeAddr("Index 0");
-        actors[1] = makeAddr("Index 1");
-        actors[2] = makeAddr("Index 2");
-    }
-
-    function setUp() public {
-        siloConfig = _setUpLocalFixture("Echidna_MOCK");
-
-        assertTrue(siloConfig.getConfig(address(silo0)).maxLtv != 0, "we need borrow to be allowed");
-
-        token0.setOnDemand(true);
-        token1.setOnDemand(true);
-
-        // same block and time as for E2E Echidna
-        vm.warp(1706745600);
-        vm.roll(17336000);
-    }
-
+contract EchidnaScenariosTest is EchidnaMiddleman {
     /*
 mint(uint8,bool,uint256): passing
 maxBorrow_correctReturnValue(uint8): failed!💥
@@ -62,53 +31,47 @@ error Revert AboveMaxLtv ()
 error Revert AboveMaxLtv ()
 
     forge test -vv --ffi --mt test_cover_echidna_scenario_1
+
+    this test case covers the bug we had in maxBorrow
     */
     function test_cover_echidna_scenario_1() public {
-        //        depositNeverMintsZeroShares(0,false,39962600816669483677151)
-        vm.prank(_chooseActor(0));
-        silo1.deposit(39962600816669483677151, _chooseActor(0));
-        //        depositNeverMintsZeroShares(161,true,22168924613129761549643809883710869859261573373213864899764932836300336298504)
-        vm.prank(_chooseActor(161));
-        silo0.deposit(22168924613129761549643809883710869859261573373213864899764932836300336298504, _chooseActor(161));
-        //        borrow(2,false,39858486983777211695540)
-        vm.prank(_chooseActor(2));
-        silo1.borrow(39858486983777211695540, _chooseActor(2), _chooseActor(2));
+        __depositNeverMintsZeroShares(0,false,39962600816669483677151);
+        __depositNeverMintsZeroShares(161,true,22168924613129761549643809883710869859261573373213864899764932836300336298504);
+        __borrow(2,false,39858486983777211695540);
+
         //        *wait* Time delay: 1 seconds Block delay: 1
         vm.warp(block.timestamp + 1);
-        //        maxBorrow_correctReturnValue(0)
 
-        address actor = _chooseActor(0);
-        uint256 maxAssets = silo0.maxBorrow(actor);
+        (uint256 maxAssets, uint256 shares) = __maxBorrow_correctReturnValue(0);
 
-        (address protected, address collateral, ) = siloConfig.getShareTokens(address(silo1));
-        emit log_named_decimal_uint("collateral shares", IShareToken(collateral).balanceOf(actor), 18);
-        emit log_named_decimal_uint("maxAssets", maxAssets, 18);
-        // assertEq(maxAssets, 339682116, "maxAssets from echidna simulation"); // TODO why echidna shows 339682116?
-
-        vm.prank(actor);
-        silo0.borrow(maxAssets, actor, actor); // should not revert!
+        assertEq(maxAssets, 33968211591454069532969, "echidna borrow amount (339682116)");
     }
 
-    function _chooseActor(
-        uint256 value
-    ) internal returns (address) {
-        uint256 low = 0;
-        uint256 high = ACTORS_COUNT - 1;
+    /*
+maxRedeem_correctMax(uint8): failed!💥
+  Call sequence, shrinking 316/500:
+    mint(220,true,39843190113244004124792096928447682291)
+    depositNeverMintsZeroShares(2,false,22786647965505400975764605899155696411742225287612091359740640699919114746382)
+    borrowShares(32,true,20769187434139310514121985316880385)
+    debtSharesNeverLargerThanDebt() Time delay: 2369 seconds Block delay: 4358
+    maxRedeem_correctMax(4)
 
-        if (value < low || value > high) {
-            uint ans = low + (value % (high - low + 1));
-            string memory valueStr = Strings.toString(value);
-            string memory ansStr = Strings.toString(ans);
-            bytes memory message = abi.encodePacked(
-                "Clamping value ",
-                valueStr,
-                " to ",
-                ansStr
-            );
-            emit log(string(message));
-            return actors[ans];
-        }
+Revert NotEnoughLiquidity
 
-        return actors[value];
+    forge test -vv --ffi --mt test_cover_echidna_scenario_2
+
+    this case covers the bug with maxRedeem
+    */
+    function test_cover_echidna_scenario_2() public {
+        __mint(220,true,39843190113244004124792096928447682291);
+        __depositNeverMintsZeroShares(2,false,22786647965505400975764605899155696411742225287612091359740640699919114746382);
+        __borrowShares(32,true,20769187434139310514121985316880385);
+
+        __timeDelay(2369, 4358);
+
+        __debtSharesNeverLargerThanDebt(); // Time delay: 2369 seconds Block delay: 4358
+
+        _dumpState(4);
+        __maxRedeem_correctMax(4);
     }
 }

--- a/silo-core/test/foundry/echidna-findings/EchidnaSetup.sol
+++ b/silo-core/test/foundry/echidna-findings/EchidnaSetup.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {Strings} from "openzeppelin-contracts/utils/Strings.sol";
+
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+
+import {MintableToken} from "../_common/MintableToken.sol";
+import {SiloLittleHelper} from "../_common/SiloLittleHelper.sol";
+import {SiloFixture, SiloConfigOverride} from "../_common/fixtures/SiloFixture.sol";
+
+// setup must match what was set for `EchidnaE2E`
+contract EchidnaSetup is SiloLittleHelper, Test {
+    uint256 constant ACTORS_COUNT = 3;
+    mapping (uint256 index => address actor) actors;
+
+    ISiloConfig siloConfig;
+
+    constructor() {
+        actors[0] = makeAddr("Actor 0");
+        actors[1] = makeAddr("Actor 1");
+        actors[2] = makeAddr("Actor 2");
+    }
+
+    function setUp() public {
+        siloConfig = _setUpLocalFixture("Echidna_MOCK");
+
+        assertTrue(siloConfig.getConfig(address(silo0)).maxLtv != 0, "we need borrow to be allowed");
+
+        token0.setOnDemand(true);
+        token1.setOnDemand(true);
+
+        // same block and time as for E2E Echidna
+        vm.warp(1706745600);
+        vm.roll(17336000);
+    }
+
+    function _chooseActor(uint256 value) internal returns (address) {
+        uint256 low = 0;
+        uint256 high = ACTORS_COUNT - 1;
+
+        if (value < low || value > high) {
+            uint ans = low + (value % (high - low + 1));
+            string memory valueStr = Strings.toString(value);
+            string memory ansStr = Strings.toString(ans);
+            bytes memory message = abi.encodePacked(
+                "Clamping value ",
+                valueStr,
+                " to ",
+                ansStr
+            );
+            emit log(string(message));
+            return actors[ans];
+        }
+
+        return actors[value];
+    }
+
+    function _invariant_checkForInterest(ISilo _silo) internal returns (bool noInterest) {
+        (, uint256 interestRateTimestamp) = _silo.siloData();
+        noInterest = block.timestamp == interestRateTimestamp;
+
+        if (noInterest) assertEq(_silo.accrueInterest(), 0, "no interest should be applied");
+    }
+
+    function _invariant_insolventHasDebt(address _user)
+        internal
+        returns (bool isSolvent, ISilo _siloWithDebt)
+    {
+        _dumpState(_user);
+
+        isSolvent = silo0.isSolvent(_user);
+        if (isSolvent) return (isSolvent, ISilo(address(0)));
+
+        (,, address debtShareToken0 ) = siloConfig.getShareTokens(address(silo0));
+        (,, address debtShareToken1 ) = siloConfig.getShareTokens(address(silo1));
+
+        uint256 balance0 = IShareToken(debtShareToken0).balanceOf(_user);
+        uint256 balance1 = IShareToken(debtShareToken1).balanceOf(_user);
+
+        assertEq(balance0 * balance1, 0, "[_invariant_insolventHasDebt] one balance must be 0");
+        assertGt(balance0 + balance1, 0, "user should have debt if he is insolvent");
+
+        return (isSolvent, balance0 > 0 ? silo0 : silo1);
+    }
+
+
+    function _dumpState(uint256 _actorIndex) internal {
+        _dumpState(_chooseActor(_actorIndex));
+    }
+
+    function _dumpState(address _actor) internal {
+        emit log_named_uint("block.number:", block.number);
+        emit log_named_uint("block.timestamp:", block.timestamp);
+
+        (uint256 collectedFees0, uint256 irmTimestamp0) = silo0.siloData();
+        (uint256 collectedFees1, uint256 irmTimestamp1) = silo1.siloData();
+
+        emit log_named_decimal_uint("collectedFees0:", collectedFees0, 18);
+        emit log_named_uint("irmTimestamp0:", irmTimestamp0);
+        emit log_named_decimal_uint("collectedFees1:", collectedFees1, 18);
+        emit log_named_uint("irmTimestamp1:", irmTimestamp1);
+
+        emit log_named_decimal_uint("LTV0:", silo0.getLtv(_actor), 16);
+        emit log_named_decimal_uint("LTV1:", silo1.getLtv(_actor), 16);
+
+        (address protectedToken0, address collateralToken0, address debtShareToken0) = siloConfig.getShareTokens(address(silo0));
+        (address protectedToken1, address collateralToken1,  address debtShareToken1 ) = siloConfig.getShareTokens(address(silo1));
+
+        emit log_named_decimal_uint("protectedToken0.balanceOf:", IShareToken(debtShareToken0).balanceOf(_actor), 18);
+        emit log_named_decimal_uint("collateralToken0.balanceOf:", IShareToken(collateralToken0).balanceOf(_actor), 18);
+        emit log_named_decimal_uint("debtShareToken0.balanceOf:", IShareToken(debtShareToken0).balanceOf(_actor), 18);
+
+        emit log_named_decimal_uint("protectedToken1.balanceOf:", IShareToken(debtShareToken1).balanceOf(_actor), 18);
+        emit log_named_decimal_uint("collateralToken1.balanceOf:", IShareToken(collateralToken1).balanceOf(_actor), 18);
+        emit log_named_decimal_uint("debtShareToken1.balanceOf:", IShareToken(debtShareToken1).balanceOf(_actor), 18);
+
+        emit log_named_decimal_uint("maxWithdraw0:", silo0.maxWithdraw(_actor), 18);
+        emit log_named_decimal_uint("maxWithdraw1:", silo1.maxWithdraw(_actor), 18);
+
+        uint256 maxBorrow0 = silo0.maxBorrow(_actor);
+        uint256 maxBorrow1 = silo1.maxBorrow(_actor);
+        emit log_named_decimal_uint("maxBorrow0:", maxBorrow0, 18);
+        emit log_named_decimal_uint("maxBorrow1:", maxBorrow1, 18);
+
+        emit log_named_decimal_uint("convertToShares(maxBorrow0):", silo0.convertToShares(maxBorrow0, ISilo.AssetType.Debt), 18);
+        emit log_named_decimal_uint("convertToShares(maxBorrow1):", silo1.convertToShares(maxBorrow1, ISilo.AssetType.Debt), 18);
+
+        emit log_named_decimal_uint("maxBorrowShares0:", silo0.maxBorrowShares(_actor), 18);
+        emit log_named_decimal_uint("maxBorrowShares1:", silo1.maxBorrowShares(_actor), 18);
+
+        emit log_named_decimal_uint("liquidity0", silo0.getLiquidity(), 18);
+        emit log_named_decimal_uint("liquidity1", silo1.getLiquidity(), 18);
+    }
+}


### PR DESCRIPTION
We did not include interest when we were using `total` for collateral assets.

Test for cover bug case included.
