### PR TITLE
[0.1.7] fix `maxBorrowShares` by using `-1`, same solution as we have for  `maxBorrow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2024-02-12
+### Fixed
+- fix `maxBorrowShares` by using `-1`, same solution as we have for `maxBorrow`
+
 ## [0.1.6] - 2024-02-12
 ### Fixed
 - fix max redeem: include interest for collateral assets

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -544,7 +544,7 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable {
             cachedConfig
         );
 
-        unchecked { if (maxAssets > 0) return maxAssets - 1; }
+        unchecked { if (maxAssets != 0) return maxAssets - 1; }
     }
 
     /// @inheritdoc ISilo
@@ -583,6 +583,8 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable {
         (
             ,maxShares
         ) = _callMaxBorrow(collateralConfig, debtConfig, _borrower, totalDebtAssets, totalDebtShares, cachedConfig);
+
+        unchecked { if (maxShares != 0) return maxShares - 1; }
     }
 
     /// @inheritdoc ISilo

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -95,7 +95,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         uint256 maxBorrow = silo0.maxBorrow(borrower);
         uint256 maxBorrowShares = silo0.maxBorrowShares(borrower);
         assertEq(maxBorrow, 0.85e18 - 1, "invalid maxBorrow");
-        assertEq(maxBorrowShares, 0.85e18, "invalid maxBorrowShares");
+        assertEq(maxBorrowShares, 0.85e18 - 1, "invalid maxBorrowShares");
 
         uint256 borrowToMuch = maxBorrow + 2;
         // emit log_named_uint("borrowToMuch", borrowToMuch);

--- a/silo-core/test/foundry/Silo/max/MaxBorrowShares.i.sol
+++ b/silo-core/test/foundry/Silo/max/MaxBorrowShares.i.sol
@@ -42,7 +42,10 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
     forge test -vv --ffi --mt test_maxBorrowShares_withCollateral
     */
     /// forge-config: core.fuzz.runs = 1000
-    function test_maxBorrowShares_withCollateral_fuzz(uint128 _collateral, uint128 _liquidity) public {
+    function test_maxBorrowShares_withCollateral_fuzz(
+        uint128 _collateral, uint128 _liquidity
+    ) public {
+        // (uint128 _collateral, uint128 _liquidity) = (3, 2);
         vm.assume(_liquidity > 0);
         vm.assume(_collateral > 0);
 
@@ -52,7 +55,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
         vm.assume(maxBorrowShares > 0);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
 
         _assertMaxBorrowSharesIsZeroAtTheEnd();
     }
@@ -91,7 +94,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
 
         maxBorrowShares = silo1.maxBorrowShares(borrower);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
         _assertMaxBorrowSharesIsZeroAtTheEnd();
     }
 
@@ -200,7 +203,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
 
         vm.prank(borrower);
         try silo1.borrowShares(toBorrow, borrower, borrower) returns (uint256) {
-            revert("we expect tx to be reverted!");
+            revert("[borrowShares] we expect tx to be reverted!");
         } catch (bytes memory data) {
             bytes4 errorType = bytes4(data);
 

--- a/silo-core/test/foundry/echidna-findings/EchidnaScenarios.i.sol
+++ b/silo-core/test/foundry/echidna-findings/EchidnaScenarios.i.sol
@@ -74,4 +74,35 @@ Revert NotEnoughLiquidity
         _dumpState(4);
         __maxRedeem_correctMax(4);
     }
+
+    /*
+maxBorrowShares_correctReturnValue(uint8): failed!💥
+Call sequence, shrinking 294/500:
+deposit(1,false,18362350053917916671701463106358)
+previewDeposit_doesNotReturnMoreThanDeposit(44,5021491078257170633099496333274079409660413512867881700899062515742671857130)
+mint(0,false,127287174252953083636439506782)
+maxBorrow_correctReturnValue(21)
+maxWithdraw_correctMax(110)
+previewDeposit_doesNotReturnMoreThanDeposit(2,62718039246364723308705975150828086672) Time delay: 3865 seconds Block delay: 1791
+maxBorrowShares_correctReturnValue(1)
+
+Revert AboveMaxLtv ()
+
+    forge test -vv --ffi --mt test_cover_echidna_scenario_3
+
+    this case covers the bug with maxBorrowShare
+    */
+    function test_cover_echidna_scenario_3() public {
+        __deposit(1,false,18362350053917916671701463106358);
+        __previewDeposit_doesNotReturnMoreThanDeposit(44,5021491078257170633099496333274079409660413512867881700899062515742671857130);
+        __mint(0,false,127287174252953083636439506782);
+        __maxBorrow_correctReturnValue(21);
+        __maxWithdraw_correctMax(110);
+
+        __timeDelay(3865, 1791);
+        // Time delay: 3865 seconds Block delay: 1791
+        __previewDeposit_doesNotReturnMoreThanDeposit(2,62718039246364723308705975150828086672); // Time delay: 3865 seconds Block delay: 1791
+
+        __maxBorrowShares_correctReturnValue(1);
+    }
 }


### PR DESCRIPTION
atm I did not found any other way of fixing it, as to apply same solution that we used before.

test case included.