### PR TITLE
remove `getProtectedAssets()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - change visibility of `total` mapping to public
 - ensure total getters returns values with interest
 
+### Removed
+- remove `getProtectedAssets()`
+
 ## [0.2.0] - 2024-02-13
 ### Added
 - Arbitrum and Optimism deployments

--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -131,11 +131,6 @@ contract Silo is Initializable, SiloERC4626, ReentrancyGuardUpgradeable {
     }
 
     /// @inheritdoc ISilo
-    function getProtectedAssets() external view virtual returns (uint256 totalProtectedAssets) {
-        totalProtectedAssets = total[AssetType.Protected].assets;
-    }
-
-    /// @inheritdoc ISilo
     function getCollateralAssets() external view virtual returns (uint256 totalCollateralAssets) {
         ISiloConfig.ConfigData memory thisSiloConfig = config.getConfig(address(this));
 

--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -178,10 +178,6 @@ interface ISilo is IERC4626, IERC3156FlashLender, ISiloLiquidation {
     /// @notice Retrieves the raw total amount of assets based on provided type (direct storage access)
     function total(AssetType _assetType) external view returns (uint256);
 
-    /// @notice Retrieves the total amount of protected (non-borrowable) collateral assets
-    /// @return totalProtectedAssets The total amount of assets of type 'Protected'
-    function getProtectedAssets() external view returns (uint256 totalProtectedAssets);
-
     /// @notice Retrieves the total amount of collateral (borrowable) assets with interest
     /// @return totalCollateralAssets The total amount of assets of type 'Collateral'
     function getCollateralAssets() external view returns (uint256 totalCollateralAssets);

--- a/silo-core/contracts/lib/SiloStdLib.sol
+++ b/silo-core/contracts/lib/SiloStdLib.sol
@@ -105,7 +105,7 @@ library SiloStdLib {
         returns (uint256 totalAssets, uint256 totalShares)
     {
         if (_assetType == ISilo.AssetType.Protected) {
-            totalAssets = ISilo(_configData.silo).getProtectedAssets();
+            totalAssets = ISilo(_configData.silo).total(ISilo.AssetType.Protected);
             totalShares = IShareToken(_configData.protectedShareToken).totalSupply();
         } else if (_assetType == ISilo.AssetType.Collateral) {
             totalAssets = getTotalCollateralAssetsWithInterest(

--- a/silo-core/test/foundry/Silo/Deposit.i.sol
+++ b/silo-core/test/foundry/Silo/Deposit.i.sol
@@ -73,7 +73,7 @@ contract DepositTest is SiloLittleHelper, Test {
 
         assertEq(token0.balanceOf(address(silo0)), assets * 2);
         assertEq(silo0.getCollateralAssets(), assets);
-        assertEq(silo0.getProtectedAssets(), assets);
+        assertEq(silo0.total(ISilo.AssetType.Protected), assets);
         assertEq(silo0.getDebtAssets(), 0);
 
         assertEq(IShareToken(collateral.collateralShareToken).balanceOf(depositor), assets, "collateral shares");
@@ -81,7 +81,7 @@ contract DepositTest is SiloLittleHelper, Test {
 
         assertEq(token1.balanceOf(address(silo1)), assets * 2);
         assertEq(silo1.getCollateralAssets(), assets);
-        assertEq(silo1.getProtectedAssets(), assets);
+        assertEq(silo1.total(ISilo.AssetType.Protected), assets);
         assertEq(silo1.getDebtAssets(), 0);
 
         assertEq(IShareToken(debt.collateralShareToken).balanceOf(depositor), assets, "collateral shares (on other silo)");

--- a/silo-core/test/foundry/Silo/GetLiquidityAccrueInterestTest.i.sol
+++ b/silo-core/test/foundry/Silo/GetLiquidityAccrueInterestTest.i.sol
@@ -37,7 +37,7 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
         assertEq(silo1.getLiquidity(), 0, "no liquidity after deploy 1");
         assertEq(silo1.getLiquidity(), 0, "no collateral liquidity 1");
 
-        assertEq(silo1.getProtectedAssets(), 0, "no protected liquidity 1");
+        assertEq(silo1.total(ISilo.AssetType.Protected), 0, "no protected liquidity 1");
     }
 
     /*
@@ -51,11 +51,11 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
 
         assertEq(silo0.getLiquidity(), _assets, "[0] expect liquidity");
         assertEq(silo0.getLiquidity(), _assets, "[0] expect collateral liquidity, no interest");
-        assertEq(silo0.getProtectedAssets(), _assets / 2, "[0] expect protected liquidity, no interest");
+        assertEq(silo0.total(ISilo.AssetType.Protected), _assets / 2, "[0] expect protected liquidity, no interest");
 
         assertEq(silo1.getLiquidity(), 0, "[1] no liquidity 1");
         assertEq(silo1.getLiquidity(), 0, "[1] no liquidity after deploy 1");
-        assertEq(silo1.getProtectedAssets(), 0, "[1] no protected liquidity after deploy 1");
+        assertEq(silo1.total(ISilo.AssetType.Protected), 0, "[1] no protected liquidity after deploy 1");
     }
 
     /*
@@ -68,11 +68,11 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
 
         assertEq(silo0.getLiquidity(), 0, "[0] expect liquidity");
         assertEq(silo0.getLiquidity(), 0, "[0] expect no collateral liquidity, no interest");
-        assertEq(silo0.getProtectedAssets(), _assets, "[0] expect protected liquidity, no interest");
+        assertEq(silo0.total(ISilo.AssetType.Protected), _assets, "[0] expect protected liquidity, no interest");
 
         assertEq(silo1.getLiquidity(), 0, "[1] no liquidity after deploy 1");
         assertEq(silo1.getLiquidity(), 0, "[1] no collateral liquidity after deploy 1");
-        assertEq(silo1.getProtectedAssets(), 0, "[1] no protected liquidity after deploy 1");
+        assertEq(silo1.total(ISilo.AssetType.Protected), 0, "[1] no protected liquidity after deploy 1");
     }
 
     /*
@@ -91,11 +91,11 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
 
         assertEq(silo0.getLiquidity(), _toDeposit, "[0] expect collateral");
         assertEq(silo0.getLiquidity(), _toDeposit, "[0] expect collateral, no interest");
-        assertEq(silo0.getProtectedAssets(), 0, "[0] no protected, no interest");
+        assertEq(silo0.total(ISilo.AssetType.Protected), 0, "[0] no protected, no interest");
 
         assertEq(silo1.getLiquidity(), _toDeposit - _toBorrow, "[1] expect diff after borrow");
         assertEq(silo1.getLiquidity(), _toDeposit - _toBorrow, "[1] expect diff after borrow (interest)");
-        assertEq(silo1.getProtectedAssets(), _toDeposit / 2, "[1] expect protected after borrow (interest)");
+        assertEq(silo1.total(ISilo.AssetType.Protected), _toDeposit / 2, "[1] expect protected after borrow (interest)");
     }
 
     /*
@@ -122,8 +122,8 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
         uint256 silo1_rawLiquidity = _getRawLiquidity(silo1);
         uint256 silo0_liquidityWithInterest = silo0.getLiquidity();
         uint256 silo1_liquidityWithInterest = silo1.getLiquidity();
-        uint256 silo0_protectedLiquidity = silo0.getProtectedAssets();
-        uint256 silo1_protectedLiquidity = silo1.getProtectedAssets();
+        uint256 silo0_protectedLiquidity = silo0.total(ISilo.AssetType.Protected);
+        uint256 silo1_protectedLiquidity = silo1.total(ISilo.AssetType.Protected);
 
         uint256 accruedInterest0 = silo0.accrueInterest();
         assertEq(accruedInterest0, 0, "[0] expect no interest on silo0");
@@ -149,8 +149,8 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
 
         assertEq(
             silo0_protectedLiquidity,
-            silo0.getProtectedAssets(),
-            "[0] expect getProtectedAssets() calculations correct"
+            silo0.total(ISilo.AssetType.Protected),
+            "[0] expect total(ISilo.AssetType.Protected) calculations correct"
         );
 
         assertEq(silo0_protectedLiquidity, protectedDeposit0, "[0] no interest on protected");
@@ -171,7 +171,7 @@ contract GetLiquidityAccrueInterestTest is SiloLittleHelper, Test {
 
         assertEq(
             protectedDeposit1,
-            silo1.getProtectedAssets(),
+            silo1.total(ISilo.AssetType.Protected),
             "[1] protected does not get interest"
         );
 

--- a/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDebt.i.sol
+++ b/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDebt.i.sol
@@ -67,7 +67,7 @@ contract WithdrawWhenNoDebtTest is SiloLittleHelper, Test {
         assertEq(IShareToken(collateralShareToken).balanceOf(address(this)), 2e18, "collateral burned");
         assertEq(gotShares, sharesBefore, "withdraw all shares");
 
-        assertEq(silo0.getProtectedAssets(), 0, "protected Assets should be withdrawn");
+        assertEq(silo0.total(ISilo.AssetType.Protected), 0, "protected Assets should be withdrawn");
     }
 
     /*
@@ -100,7 +100,7 @@ contract WithdrawWhenNoDebtTest is SiloLittleHelper, Test {
 
         _userWithdrawing();
 
-        assertEq(silo0.getProtectedAssets(), 11e18 + 1, "protected Assets should be withdrawn");
+        assertEq(silo0.total(ISilo.AssetType.Protected), 11e18 + 1, "protected Assets should be withdrawn");
         assertEq(silo0.getCollateralAssets(), 22e18 + 1, "protected Assets should be withdrawn");
     }
 
@@ -133,7 +133,7 @@ contract WithdrawWhenNoDebtTest is SiloLittleHelper, Test {
         _withdraw(address(1), _deposit1 - _deposit1 / 2, ISilo.AssetType.Protected);
         _withdraw(address(1), _deposit1 - _deposit1 / 2, ISilo.AssetType.Collateral);
 
-        assertEq(silo0.getProtectedAssets(), 0, "protected Assets should be withdrawn");
+        assertEq(silo0.total(ISilo.AssetType.Protected), 0, "protected Assets should be withdrawn");
         assertEq(silo0.getCollateralAssets(), 0, "protected Assets should be withdrawn");
     }
 

--- a/silo-core/test/foundry/_common/SiloInvariants.sol
+++ b/silo-core/test/foundry/_common/SiloInvariants.sol
@@ -53,7 +53,7 @@ contract SiloInvariants is Test {
     function siloInvariant_balanceOfSiloMustBeEqToAssets() external {
         assertEq(
             token0.balanceOf(address(silo0)), // this is only true if we do not transfer tokens directly
-            silo0.getCollateralAssets() + silo0.getProtectedAssets(),
+            silo0.getCollateralAssets() + silo0.total(ISilo.AssetType.Protected),
             "balanceOf"
         );
     }
@@ -68,7 +68,7 @@ contract SiloInvariants is Test {
         );
 
         assertEq(
-            silo0.getProtectedAssets(),
+            silo0.total(ISilo.AssetType.Protected),
             IShareToken(collateral.protectedShareToken).totalSupply(),
             "silo0: protected shares == assets"
         );
@@ -86,7 +86,7 @@ contract SiloInvariants is Test {
         );
 
         assertEq(
-            silo1.getProtectedAssets(),
+            silo1.total(ISilo.AssetType.Protected),
             IShareToken(debt.protectedShareToken).totalSupply(),
             "silo1: protected shares == assets"
         );

--- a/silo-core/test/foundry/_mocks/SiloMock.sol
+++ b/silo-core/test/foundry/_mocks/SiloMock.sol
@@ -33,7 +33,7 @@ contract SiloMock is Test {
     }
 
     function getProtectedAssetsMock(uint256 _totalProtectedAssets) external {
-        bytes memory data = abi.encodeWithSelector(ISilo.getProtectedAssets.selector);
+        bytes memory data = abi.encodeWithSelector(ISilo.total.selector, ISilo.AssetType.Protected);
         vm.mockCall(ADDRESS, data, abi.encode(_totalProtectedAssets));
         vm.expectCall(ADDRESS, data);
     }


### PR DESCRIPTION
we have public `total`, so `getProtectedAssets()` make no sense anymore and it will reduce Silo a bit.

Silo  is still oversized   | 24.843  | -0.267

