### PR TITLE
silo-core: ShareToken. Removed _beforeTokenTransfer hook

### DIFF
--- a/silo-core/contracts/utils/ShareDebtToken.sol
+++ b/silo-core/contracts/utils/ShareDebtToken.sol
@@ -71,6 +71,25 @@ contract ShareDebtToken is IERC20R, ShareToken {
         emit ReceiveApproval(_owner, _recipient, _amount);
     }
 
+    /// @dev Check receive allowance and if recipient is allowed to accept debt from silo
+    function _beforeTokenTransfer(address _sender, address _recipient, uint256 _amount) internal virtual override {
+        // If we are minting or burning, Silo is responsible to check all necessary conditions
+        if (_isTransfer(_sender, _recipient)) {
+            // Silo forbids having two debts and this condition will be checked inside `onDebtTransfer`
+            siloConfig.onDebtTransfer(_sender, _recipient);
+
+            // _recipient must approve debt transfer, _sender does not have to
+            uint256 currentAllowance = receiveAllowance(_sender, _recipient);
+            if (currentAllowance < _amount) revert AmountExceedsAllowance();
+
+            // There can't be an underflow in the subtraction because of the previous check
+            unchecked {
+                // update debt allowance
+                _setReceiveApproval(_sender, _recipient, currentAllowance - _amount);
+            }
+        }
+    }
+
     /// @dev Check if recipient is solvent after debt transfer
     function _afterTokenTransfer(address _sender, address _recipient, uint256 _amount) internal virtual override {
         // debt transfer is such a rare use case and extra gas is worth additional security,

--- a/silo-core/contracts/utils/ShareToken.sol
+++ b/silo-core/contracts/utils/ShareToken.sol
@@ -222,9 +222,16 @@ abstract contract ShareToken is Initializable, ERC20, IShareToken {
 
     /// @inheritdoc ERC20
     function _update(address from, address to, uint256 value) internal virtual override {
+        _beforeTokenTransfer(from, to, value);
+
         ERC20._update(from, to, value);
+
         _afterTokenTransfer(from, to, value);
     }
+
+    /// @dev By default, we do not have any hooks before token transfer. However,
+    /// derived contracts can override this function if they need to execute any logic before token transfer.
+    function _beforeTokenTransfer(address _sender, address _recipient, uint256 _amount) internal virtual {}
 
     /// @dev Call an afterTokenTransfer hook if registered
     function _afterTokenTransfer(address _sender, address _recipient, uint256 _amount) internal virtual {

--- a/silo-core/test/foundry/gas/Borrow1st.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow1st.gas.sol
@@ -27,7 +27,7 @@ contract Borrow1stGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER, false /* sameAsset */)),
             "Borrow1st (no interest)",
-            228399
+            228118
         );
     }
 }

--- a/silo-core/test/foundry/gas/Borrow2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow2nd.gas.sol
@@ -29,7 +29,7 @@ contract Borrow2ndGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER, false /* sameAsset */)),
             "Borrow2nd (no interest)",
-            140070
+            139789
         );
     }
 }

--- a/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract BorrowAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER, false /* sameAsset */)),
             "BorrowAccrueInterest",
-            208316
+            207967
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit1st.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit1st.gas.sol
@@ -24,7 +24,7 @@ contract Deposit1stGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit1st ever",
-            172954
+            172673
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit2nd.gas.sol
@@ -24,7 +24,7 @@ contract Deposit2ndGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "Deposit2nd (no interest)",
-            84436
+            84155
         );
     }
 }

--- a/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract DepositAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.deposit, (ASSETS, DEPOSITOR, ISilo.AssetType.Collateral)),
             "DepositAccrueInterest",
-            134396
+            134047
         );
     }
 }

--- a/silo-core/test/foundry/gas/LeverageSameAsset1st.gas.sol
+++ b/silo-core/test/foundry/gas/LeverageSameAsset1st.gas.sol
@@ -31,7 +31,7 @@ contract LeverageSameAsset1stGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.leverageSameAsset, (depositAssets, ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "LeverageSameAsset 1st (no interest)",
-            279233
+            278558
         );
     }
 }

--- a/silo-core/test/foundry/gas/LeverageSameAsset2nd.gas.sol
+++ b/silo-core/test/foundry/gas/LeverageSameAsset2nd.gas.sol
@@ -31,7 +31,7 @@ contract LeverageSameAsset2ndGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.leverageSameAsset, (depositAssets, ASSETS, BORROWER, ISilo.AssetType.Collateral)),
             "LeverageSameAsset 2nd (no interest)",
-            119486
+            118811
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -37,7 +37,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 (address(silo1), address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            313174
+            312476
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPart.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPart.gas.sol
@@ -29,7 +29,7 @@ contract RepayPartGasTest is Gas, Test {
             address(silo1),
             abi.encodeWithSignature("repay(uint256,address)", ASSETS / 2, BORROWER),
             "RepayPart partial (no interest)",
-            84686
+            84294
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepayPartAccrueInterest.gas.sol
@@ -32,7 +32,7 @@ contract RepayPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeWithSignature("repay(uint256,address)", ASSETS / 2, BORROWER),
             "RepayPartAccrueInterest partial with accrue interest",
-            134466
+            134117
         );
     }
 }

--- a/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/RepaySharesFullAccrueInterest.gas.sol
@@ -37,7 +37,7 @@ contract RepaySharesFullAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeWithSignature("repay(uint256,address)", ASSETS, BORROWER),
             "RepaySharesFullAccrueInterest full (shares) with accrue interest",
-            127166
+            126817
         );
     }
 }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -32,7 +32,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.AssetType.Collateral)),
             "Withdraw partial with accrue interest",
-            178711
+            178362
         );
     }
 }


### PR DESCRIPTION
Reviewed place where we mint [SiloERC4626Lib](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/SiloERC4626Lib.sol#L233), [SiloLendingLib](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/SiloLendingLib.sol#L178), and burn:  [SiloERC4626Lib](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/SiloERC4626Lib.sol#L298), [SiloLendingLib](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/SiloLendingLib.sol#L66). In all cases we do an external call to the token after the silo state updated.