### PR TITLE
silo-core: removed todo from the liquidation test

### DIFF
--- a/silo-core/test/foundry/liquidation/LiquidationCall_1token.i.sol
+++ b/silo-core/test/foundry/liquidation/LiquidationCall_1token.i.sol
@@ -607,7 +607,7 @@ contract LiquidationCall1TokenTest is SiloLittleHelper, Test {
         vm.expectCall(
             collateralConfig.collateralShareToken,
             abi.encodeWithSelector(
-                IShareToken.forwardTransfer.selector, BORROWER, liquidator, COLLATERAL - 1 // TODO why -1?
+                IShareToken.forwardTransfer.selector, BORROWER, liquidator, COLLATERAL - 1
             )
         );
 
@@ -615,13 +615,13 @@ contract LiquidationCall1TokenTest is SiloLittleHelper, Test {
 
         assertEq(
             IShareToken(collateralConfig.collateralShareToken).balanceOf(liquidator),
-            COLLATERAL - 1, // TODO check why
+            COLLATERAL - 1,
             "liquidator should have s-collateral, because of sToken"
         );
 
         assertEq(
             IShareToken(collateralConfig.collateralShareToken).balanceOf(BORROWER),
-            1, // TODO check why
+            1,
             "BORROWER should have NO s-collateral"
         );
     }


### PR DESCRIPTION
From what I see, the reason is that we are losing 2 wei  when calculating a borrower collateral assets [here](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/SiloSolvencyLib.sol#L132).
```
ltvData.borrowerCollateralAssets = SiloMathLib.convertToAssets(
 shares, totalCollateralAssets, totalShares, Rounding.COLLATERAL_TO_ASSETS, ISilo.AssetType.Collateral
);
```
We have the following inputs:
```
  shares 10000000000000000000
  totalCollateralAssets 27154148001939861637
  totalShares 10000000000000000000
  Rounding.COLLATERAL_TO_ASSETS Math.Rounding.Floor
```  
In the SiloMathLib.convertToAssets fn, we execute _commonConvertTo fn, which increases totalCollateralAssets and totalShares by 1.
After that we have assets calculation:
```
assets = _shares.mulDiv(totalAssets, totalShares, _rounding);
```
Where:
```
_shares = 10000000000000000000
totalAssets = 27154148001939861638
totalShares = 10000000000000000001
```
And we receiving:
```
> 10000000000000000000n * 27154148001939861638n / 10000000000000000001n
27154148001939861635n

ltvData.borrowerCollateralAssets == 27154148001939861635
```
After that, the next step in the calculation is in the LiquidationWithdrawLib [here](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/lib/LiquidationWithdrawLib.sol#L142).
```
        // we already accrued interest, so we can work directly on assets
        uint256 shares = SiloMathLib.convertToShares(
            _amountToLiquidate,
            _totalAssets,
            _shareToken.totalSupply(),
            Rounding.LIQUIDATE_TO_SHARES,
            _assetType
        );
```
Where:
```
_amountToLiquidate 27154148001939861635 (borrowerCollateralAssets)
_totalAssets 27154148001939861637
_shareToken.totalSupply() 10000000000000000000
Rounding.LIQUIDATE_TO_SHARES Math.Rounding.Floor
```
In the SiloMathLib.convertToShares fn, we execute _commonConvertTo fn, which increases _totalAssets and _shareToken.totalSupply() by 1.
After that, in the convertToShares fn, we perform calculations
```
_assets.mulDiv(totalShares, totalAssets, _rounding);
```
Where (after 1 was added on a previous step) we have:
```
_assets 27154148001939861635
totalShares 10000000000000000001
totalAssets 27154148001939861638
```
And we receive a result:
```
> 27154148001939861635n * 10000000000000000001n / 27154148001939861638n
9999999999999999999n
```
It is expected behavior.