### PR TITLE
fix division by zero for max liquidation

### DIFF
--- a/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationExecLib.sol
+++ b/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationExecLib.sol
@@ -90,14 +90,14 @@ library PartialLiquidationExecLib {
             uint256 sumOfCollateralValue, uint256 debtValue
         ) = SiloSolvencyLib.getPositionValues(ltvData, collateralConfig.token, debtConfig.token);
 
-        uint256 ltvInDp = SiloSolvencyLib.ltvMath(debtValue, sumOfCollateralValue);
-        if (ltvInDp <= collateralConfig.lt) return (0, 0); // user solvent
-
         uint256 sumOfCollateralAssets;
         // safe because we adding same token, so it is under same total supply
         unchecked { sumOfCollateralAssets = ltvData.borrowerProtectedAssets + ltvData.borrowerCollateralAssets; }
 
         if (sumOfCollateralValue == 0) return (sumOfCollateralAssets, ltvData.borrowerDebtAssets);
+
+        uint256 ltvInDp = SiloSolvencyLib.ltvMath(debtValue, sumOfCollateralValue);
+        if (ltvInDp <= collateralConfig.lt) return (0, 0); // user solvent
 
         return PartialLiquidationLib.maxLiquidation(
             sumOfCollateralAssets,


### PR DESCRIPTION
in case `sumOfCollateralValue` is `0`, we revert with `panic: division or modulo by zero`