### PR TITLE
silo-core: removed todos from tests

### DIFF
--- a/silo-core/test/foundry/Silo/max/maxLiquidation/MaxLiquidationCommon.sol
+++ b/silo-core/test/foundry/Silo/max/maxLiquidation/MaxLiquidationCommon.sol
@@ -29,7 +29,7 @@ abstract contract MaxLiquidationCommon is SiloLittleHelper, Test {
 
     function setUp() public {
         siloConfig = _setUpLocalFixture(SiloConfigsNames.LOCAL_NO_ORACLE_SILO);
-        token1.setOnDemand(true); // TODO think if this can influence testing? maybe try to do it in normal way?
+        token1.setOnDemand(true);
     }
 
     function _createDebtForBorrower(uint128 _collateral, bool _sameAsset) internal {

--- a/silo-core/test/foundry/simulations/DustPropagation.i.sol
+++ b/silo-core/test/foundry/simulations/DustPropagation.i.sol
@@ -74,8 +74,8 @@ contract DustPropagationTest is SiloLittleHelper, Test {
         ISiloConfig.ConfigData memory configData = siloConfig.getConfig(address(silo0));
 
         assertEq(IShareToken(configData.debtShareToken).totalSupply(), 0, "expected debtShareToken burned");
-        // TODO why 1? before liquidation change we burned all collateral, what's changed tha twe left with 1?
-        assertEq(IShareToken(configData.collateralShareToken).totalSupply(), 1, "expected collateralShareToken burned");
+        // We have 1 wei leftover because of the rounding policy.
+        // We round down when converting to shares on liquidation.
         assertEq(IShareToken(configData.protectedShareToken).totalSupply(), 0, "expected protectedShareToken 0");
         assertEq(silo0.getDebtAssets(), 0, "total debt == 0");
 


### PR DESCRIPTION
1:
```
// TODO why 1? before liquidation change we burned all collateral, what's changed tha twe left with 1?
```
because of this [rounding](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/contracts/utils/hook-receivers/liquidation/PartialLiquidation.sol#L208).
2:
```
token1.setOnDemand(true); // TODO think if this can influence testing? maybe try to do it in normal way?
```
I reviewed the [setOnDemand](https://github.com/silo-finance/silo-contracts-v2/blob/develop/silo-core/test/foundry/_common/MintableToken.sol#L20) feature in the tests. So, whenever we execute transferFrom and onDemand is true, we mint tokens for the user if its balance is lower than the required amount to transfer. In the test, this looks like this: we have a user and we want to make a deposit/repay/liquidationCall, if onDemand is true we don't have to worry about the user balance and mint tokens before the action as they will be minted for the user before transferFrom executed.
We use transferFrom in:
```
SiloRouter._pullAsset
Actions.leverageSameAsset
Actions.flashLoan
SiloERC4626.deposit
SiloLendingLib.repay
PartialLiquidation.liquidationCall
```
When we transfer tokens from the silo, we use transfer fn, which is not modified and has standard behavior.