### PR TITLE
[PoC] Remove IRM config address from setup

### DIFF
--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -63,9 +63,9 @@ contract Silo is ISilo, ShareCollateralToken {
     }
 
     /// @inheritdoc ISilo
-    function initialize(ISiloConfig _config, address _modelConfigAddress) external virtual {
+    function initialize(ISiloConfig _config) external virtual {
         // silo initialization
-        address hookReceiver = Actions.initialize(_config, _modelConfigAddress);
+        address hookReceiver = Actions.initialize(_config);
         // silo (vault) share token intialization
         _shareTokenInitialize(this, hookReceiver, uint24(Hook.COLLATERAL_TOKEN));
     }

--- a/silo-core/contracts/SiloFactory.sol
+++ b/silo-core/contracts/SiloFactory.sol
@@ -107,8 +107,8 @@ contract SiloFactory is ISiloFactory, ERC721, Ownable2Step, Creator {
 
         siloConfig = ISiloConfig(address(new SiloConfig(nextSiloId, configData0, configData1)));
 
-        ISilo(configData0.silo).initialize(siloConfig, _initData.interestRateModelConfig0);
-        ISilo(configData1.silo).initialize(siloConfig, _initData.interestRateModelConfig1);
+        ISilo(configData0.silo).initialize(siloConfig);
+        ISilo(configData1.silo).initialize(siloConfig);
 
         _initializeShareTokens(configData0, configData1);
 

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
@@ -73,18 +73,19 @@ contract InterestRateModelV2 is IInterestRateModel, IInterestRateModelV2 {
     /// silo => setup
     mapping (address => Setup) public getSetup;
 
+    IInterestRateModelV2Config public irmConfig;
+
     /// @notice Emitted on config init
-    /// @param silo Silo address for which config should be set
     /// @param config config struct for asset in Silo
-    event Initialized(address indexed silo, address indexed config);
+    event Initialized(address indexed config);
 
-    /// @dev this method creates 1:1 link between silo and config
-    function connect(address _configAddress) external virtual {
+    /// @dev this method sets config address for all Silos that will use this model
+    function initialize(address _configAddress) external virtual {
         if (_configAddress == address(0)) revert AddressZero();
-        if (address(getSetup[msg.sender].config) != address(0)) revert AlreadyConnected();
+        if (address(irmConfig) != address(0)) revert AlreadyConnected();
 
-        getSetup[msg.sender].config = IInterestRateModelV2Config(_configAddress);
-        emit Initialized(msg.sender, _configAddress);
+        irmConfig = IInterestRateModelV2Config(_configAddress);
+        emit Initialized(_configAddress);
     }
 
     /// @inheritdoc IInterestRateModel
@@ -187,7 +188,7 @@ contract InterestRateModelV2 is IInterestRateModel, IInterestRateModelV2 {
 
     function getConfig(address _silo) public view virtual returns (ConfigWithState memory fullConfig) {
         Setup memory setup = getSetup[_silo];
-        Config memory config = setup.config.getConfig();
+        Config memory config = irmConfig.getConfig();
 
         fullConfig.uopt = config.uopt;
         fullConfig.ucrit = config.ucrit;

--- a/silo-core/contracts/interfaces/IInterestRateModel.sol
+++ b/silo-core/contracts/interfaces/IInterestRateModel.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
-
 interface IInterestRateModel {
     /// @dev optional method that can connect silo to it's model state on silo initialization
     /// can be empty by must implement interface.
-    function connect(address _configAddress) external;
+    function initialize(address _configAddress) external;
 
     /// @dev get compound interest rate and update model storage for current block.timestamp
     /// @param _collateralAssets total silo collateral assets

--- a/silo-core/contracts/interfaces/IInterestRateModelV2.sol
+++ b/silo-core/contracts/interfaces/IInterestRateModelV2.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
-import {IInterestRateModelV2Config} from "./IInterestRateModelV2Config.sol";
+import {IInterestRateModel} from "./IInterestRateModel.sol";
 
 // solhint-disable var-name-mixedcase
 
-interface IInterestRateModelV2 {
+interface IInterestRateModelV2 is IInterestRateModel {
     struct Config {
         // uopt ∈ (0, 1) – optimal utilization;
         int256 uopt;
@@ -53,7 +53,6 @@ interface IInterestRateModelV2 {
         int128 ri;
         // Tcrit ≥ 0 - the time during which the utilization exceeds the critical value
         int128 Tcrit;
-        IInterestRateModelV2Config config;
     }
     /* solhint-enable */
 

--- a/silo-core/contracts/interfaces/IInterestRateModelV2ConfigFactory.sol
+++ b/silo-core/contracts/interfaces/IInterestRateModelV2ConfigFactory.sol
@@ -5,17 +5,17 @@ import {IInterestRateModelV2} from "./IInterestRateModelV2.sol";
 import {IInterestRateModelV2Config} from "./IInterestRateModelV2Config.sol";
 
 interface IInterestRateModelV2ConfigFactory {
-    /// @dev config ID and config address should be easily accessible directly from oracle contract
-    event NewInterestRateModelV2Config(bytes32 indexed id, IInterestRateModelV2Config indexed configAddress);
+    event NewInterestRateModelV2Config(bytes32 indexed configHash, address indexed configAddress);
+    event NewInterestRateModelV2(bytes32 indexed configAddress, address indexed irm);
 
     /// @dev verifies config and creates IRM config contract
     /// @notice it can be used in separate tx eg config can be prepared before it will be used for Silo creation
     /// @param _config IRM configuration
-    /// @return id unique ID of the config
-    /// @return configContract deployed (or existing one, depends on ID) contract address
+    /// @return configHash unique ID of the config
+    /// @return irm deployed (or existing one, depends on ID) contract address
     function create(IInterestRateModelV2.Config calldata _config)
         external
-        returns (bytes32 id, IInterestRateModelV2Config configContract);
+        returns (bytes32 configHash, IInterestRateModelV2 irm);
 
     /// @dev DP is 18 decimal points used for integer calculations
     // solhint-disable-next-line func-name-mixedcase

--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -209,8 +209,7 @@ interface ISilo is IERC20, IERC4626, IERC3156FlashLender {
 
     /// @notice Initialize Silo
     /// @param _siloConfig address of ISiloConfig with full config for this Silo
-    /// @param _modelConfigAddress address of a config contract used by IRM
-    function initialize(ISiloConfig _siloConfig, address _modelConfigAddress) external;
+    function initialize(ISiloConfig _siloConfig) external;
 
     /// @notice Update hooks configuration for Silo
     /// @dev This function must be called after the hooks configuration is changed in the hook receiver

--- a/silo-core/contracts/interfaces/ISiloConfig.sol
+++ b/silo-core/contracts/interfaces/ISiloConfig.sol
@@ -31,10 +31,6 @@ interface ISiloConfig is ICrossReentrancyGuard {
         /// @notice Address of the interest rate model
         address interestRateModel0;
 
-        /// @notice Address of the interest rate model configuration. Configuration is a separately deployed contract
-        /// with immutable config that can be resued between multiple IRMs (Interest Rate Models).
-        address interestRateModelConfig0;
-
         /// @notice Maximum LTV for first token. maxLTV is in 18 decimals points and is used to determine,
         /// if borrower can borrow given amount of assets. MaxLtv is in 18 decimals points
         uint256 maxLtv0;
@@ -66,10 +62,6 @@ interface ISiloConfig is ICrossReentrancyGuard {
 
         /// @notice Address of the interest rate model
         address interestRateModel1;
-
-        /// @notice Address of the interest rate model configuration. Configuration is a separately deployed contract
-        /// with immutable config that can be reused between multiple IRMs (Interest Rate Models).
-        address interestRateModelConfig1;
 
         /// @notice Maximum LTV for first token. maxLTV is in 18 decimals points and is used to determine,
         /// if borrower can borrow given amount of assets. maxLtv is in 18 decimals points

--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -52,7 +52,7 @@ library Actions {
         }
     }
 
-    function initialize(ISiloConfig _siloConfig, address _irmConfigAddress) external returns (address hookReceiver) {
+    function initialize(ISiloConfig _siloConfig) external returns (address hookReceiver) {
         IShareToken.ShareTokenStorage storage _sharedStorage = ShareTokenLib.getShareTokenStorage();
 
         if (address(_sharedStorage.siloConfig) != address(0)) revert ISilo.SiloInitialized();
@@ -60,8 +60,6 @@ library Actions {
         ISiloConfig.ConfigData memory configData = _siloConfig.getConfig(address(this));
 
         _sharedStorage.siloConfig = _siloConfig;
-
-        IInterestRateModel(configData.interestRateModel).connect(_irmConfigAddress);
 
         return configData.hookReceiver;
     }


### PR DESCRIPTION
This removes the concept of IRM config address from setting up new Silo. Now, IRM can be configured, deployed and tested before Silo deployment and there is no need to provide "config" address.

`InterestRateModelV2` is cloned for each new config and can be used by unlimited amount of Silos.