### PR TITLE
silo-core: save 2.4KB by making after transfer hook external

### DIFF
--- a/silo-core/contracts/lib/ShareCollateralTokenLib.sol
+++ b/silo-core/contracts/lib/ShareCollateralTokenLib.sol
@@ -13,26 +13,8 @@ library ShareCollateralTokenLib {
     using CallBeforeQuoteLib for ISiloConfig.ConfigData;
 
     /// @dev Check if sender is solvent after the transfer
-    function afterTokenTransfer(address _sender, address _recipient, uint256 _amount) internal {
-        _afterTokenTransfer(_sender, _recipient, _amount);
-    }
-
-    /// @dev Check if sender is solvent after the transfer
-    /// @notice this is a copy of afterTokenTransfer but set as external
-    function afterTokenTransferExternal(address _sender, address _recipient, uint256 _amount) external {
-        _afterTokenTransfer(_sender, _recipient, _amount);
-    }
-
-    /// @dev Check if sender is solvent after the transfer
-    /// @notice this is a copy of afterTokenTransfer but set as external
-    function _afterTokenTransfer(address _sender, address _recipient, uint256 _amount) private {
-        IShareToken.ShareTokenStorage storage $ = ShareTokenLib.getShareTokenStorage();
-
-        // for minting or burning, Silo is responsible to check all necessary conditions
-        // for transfer make sure that _sender is solvent after transfer
-        if (ShareTokenLib.isTransfer(_sender, _recipient) && $.transferWithChecks) {
-            if (!_isSolventAfterCollateralTransfer(_sender)) revert IShareToken.SenderNotSolventAfterTransfer();
-        }
+    function afterTokenTransfer(address _sender, address _recipient, uint256 _amount) external {
+        if (!_isSolventAfterCollateralTransfer(_sender)) revert IShareToken.SenderNotSolventAfterTransfer();
 
         // note: make sure to call original/inherited method as well when you call this one for collateral
         // ShareTokenLib.afterTokenTransfer(_sender, _recipient, _amount);

--- a/silo-core/contracts/utils/ShareCollateralToken.sol
+++ b/silo-core/contracts/utils/ShareCollateralToken.sol
@@ -27,9 +27,14 @@ abstract contract ShareCollateralToken is ShareToken {
 
     /// @dev Check if sender is solvent after the transfer
     function _afterTokenTransfer(address _sender, address _recipient, uint256 _amount) internal virtual override {
-        // in case Silo size limit, override this method and use:
-        // `ShareCollateralTokenLib.afterTokenTransferExternal`, it will give you 2,4KB of additional space
-        ShareCollateralTokenLib.afterTokenTransfer(_sender, _recipient, _amount);
+        IShareToken.ShareTokenStorage storage $ = ShareTokenLib.getShareTokenStorage();
+
+        // for minting or burning, Silo is responsible to check all necessary conditions
+        // for transfer make sure that _sender is solvent after transfer
+        if (ShareTokenLib.isTransfer(_sender, _recipient) && $.transferWithChecks) {
+            ShareCollateralTokenLib.afterTokenTransfer(_sender, _recipient, _amount);
+        }
+
         ShareToken._afterTokenTransfer(_sender, _recipient, _amount);
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -40,7 +40,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 (address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            441835
+            441599
         );
     }
 }

--- a/silo-core/test/foundry/gas/TransferCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransferCollateral.gas.sol
@@ -33,7 +33,7 @@ contract TransferCollateralTest is Gas, Test {
             address(collateralShareToken),
             abi.encodeCall(IERC20.transfer, (BORROWER, 1)),
             "TransferCollateral (when debt)",
-            145841
+            149033
         );
     }
 }


### PR DESCRIPTION
`| Silo                          |   22,151 |      2,425 |`

This is what we can get if we will use external method. I added copy of internal method so we have option to use it in future if we have no other choice.
