### PR TITLE
silo-core: PartialLiquidationLib comment

### DIFF
--- a/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationLib.sol
+++ b/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationLib.sol
@@ -30,7 +30,7 @@ library PartialLiquidationLib {
     /// @dev If the ratio of the repay value to the total debt value during liquidation exceeds the 
     /// _DEBT_DUST_LEVEL threshold, a full liquidation is triggered.
     /// For example, if the total debt value is 51 and the dust level is set at 98%, 
-    /// then if we are unable to liquidate 50, we must proceed to liquidate the entire 51.
+    /// then we are unable to liquidate 50, we must proceed to liquidate the entire 51.
     uint256 internal constant _DEBT_DUST_LEVEL = 0.9e18; // 90%
 
     /// @dev debt keeps growing over time, so when dApp use this view to calculate max, tx should never revert


### PR DESCRIPTION
// TODO: adjust commnet to state that _DEBT_DUST_LEVEL is a % of total debt value. If repay value is more than _DEBT_DUST_LEVEL % of total debt value, we will force full liquidation.