### PR TITLE
silo-core: remove redundant check for `callBeforeQuote`

### DIFF
--- a/silo-core/contracts/lib/Views.sol
+++ b/silo-core/contracts/lib/Views.sol
@@ -164,7 +164,7 @@ library Views {
         configData0.deployerFee = _initData.deployerFee;
         configData0.liquidationFee = _initData.liquidationFee0;
         configData0.flashloanFee = _initData.flashloanFee0;
-        configData0.callBeforeQuote = _initData.callBeforeQuote0 && configData0.maxLtvOracle != address(0);
+        configData0.callBeforeQuote = _initData.callBeforeQuote0;
 
         configData1.hookReceiver = _initData.hookReceiver;
         configData1.token = _initData.token1;
@@ -179,6 +179,6 @@ library Views {
         configData1.deployerFee = _initData.deployerFee;
         configData1.liquidationFee = _initData.liquidationFee1;
         configData1.flashloanFee = _initData.flashloanFee1;
-        configData1.callBeforeQuote = _initData.callBeforeQuote1 && configData1.maxLtvOracle != address(0);
+        configData1.callBeforeQuote = _initData.callBeforeQuote1;
     }
 }


### PR DESCRIPTION
[TODO: && configData0.maxLtvOracle != address(0); is redundant](https://github.com/silo-finance/silo-contracts-v2/pull/736/files#diff-a212dcbba5465412a880a8cac2b071852018672f65026f86bbea55d5734bdad2R191)