### PR TITLE
silo-core: use `_totalAssets` for `getCollateralAssets`

### DIFF
--- a/silo-core/contracts/Silo.sol
+++ b/silo-core/contracts/Silo.sol
@@ -99,7 +99,7 @@ contract Silo is ISilo, ShareCollateralToken {
 
     /// @inheritdoc ISilo
     function getCollateralAssets() external view virtual returns (uint256 totalCollateralAssets) {
-        totalCollateralAssets = Views.getCollateralAssets();
+        totalCollateralAssets = _totalAssets();
     }
 
     /// @inheritdoc ISilo
@@ -136,10 +136,7 @@ contract Silo is ISilo, ShareCollateralToken {
 
     /// @inheritdoc IERC4626
     function totalAssets() external view virtual returns (uint256 totalManagedAssets) {
-        (totalManagedAssets,) = SiloStdLib.getTotalAssetsAndTotalSharesWithInterest(
-            ShareTokenLib.getConfig(),
-            AssetType.Collateral
-        );
+        totalManagedAssets = _totalAssets();
     }
 
     /// @inheritdoc IERC4626
@@ -668,6 +665,13 @@ contract Silo is ISilo, ShareCollateralToken {
     /// @inheritdoc ISilo
     function getTotalAssetsStorage(uint256 _assetType) external view returns (uint256 totalAssetsByType) {
         totalAssetsByType = SiloStorageLib.getSiloStorage().totalAssets[_assetType];
+    }
+
+    function _totalAssets() internal view virtual returns (uint256 totalManagedAssets) {
+        (totalManagedAssets,) = SiloStdLib.getTotalAssetsAndTotalSharesWithInterest(
+            ShareTokenLib.getConfig(),
+            AssetType.Collateral
+        );
     }
 
     function _convertToAssets(uint256 _shares, AssetType _assetType) internal view virtual returns (uint256 assets) {

--- a/silo-core/contracts/lib/Views.sol
+++ b/silo-core/contracts/lib/Views.sol
@@ -110,17 +110,6 @@ library Views {
         });
     }
 
-    function getCollateralAssets() internal view returns (uint256 totalCollateralAssets) {
-        ISiloConfig.ConfigData memory thisSiloConfig = ShareTokenLib.getConfig();
-
-        totalCollateralAssets = SiloStdLib.getTotalCollateralAssetsWithInterest(
-            thisSiloConfig.silo,
-            thisSiloConfig.interestRateModel,
-            thisSiloConfig.daoFee,
-            thisSiloConfig.deployerFee
-        );
-    }
-
     function getDebtAssets() internal view returns (uint256 totalDebtAssets) {
         ISiloConfig.ConfigData memory thisSiloConfig = ShareTokenLib.getConfig();
 


### PR DESCRIPTION
[TODO: replace with totalAssets() implementation](https://github.com/silo-finance/silo-contracts-v2/pull/736/files#diff-9c1209fd65200679f366ede130c1690c968f2deaa281675b8bc5fc41b98e5926R108)