### PR TITLE
silo-core: explain when liquidation reverts

### DIFF
--- a/silo-core/contracts/interfaces/IPartialLiquidation.sol
+++ b/silo-core/contracts/interfaces/IPartialLiquidation.sol
@@ -45,7 +45,7 @@ interface IPartialLiquidation {
     /// @dev this method reverts when:
     /// - `_maxDebtToCover` is zero
     /// - `_collateralAsset` is not `_user` collateral token (note, that user can have both tokens in Silo, but only one
-    ///   is for back up debt
+    ///   is for backing debt
     /// - `_debtAsset` is not a token that `_user` borrow
     /// - `_user` is solvent and there is no debt to cover
     /// - `_maxDebtToCover` is set to cover only part of the debt but full liquidation is required


### PR DESCRIPTION
- [TODO: add comment about how and why function reverts](https://github.com/silo-finance/silo-contracts-v2/pull/736/files#diff-2b6855742bee0cf175ce8388360a6bf50c365122e3335583a763c78096cd6d2fR44)
- [TODO: add comment about reverting if debtToCover is more than liquidator specified](https://github.com/silo-finance/silo-contracts-v2/pull/736/files#diff-2b6855742bee0cf175ce8388360a6bf50c365122e3335583a763c78096cd6d2fR54)