### PR TITLE
silo-core: rename `liquidityFee` to `liquidationFee`

### DIFF
--- a/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationLib.sol
+++ b/silo-core/contracts/utils/hook-receivers/liquidation/lib/PartialLiquidationLib.sol
@@ -43,7 +43,7 @@ library PartialLiquidationLib {
         uint256 _borrowerDebtAssets,
         uint256 _borrowerDebtValue,
         uint256 _liquidationTargetLTV,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     )
         internal
         pure
@@ -55,7 +55,7 @@ library PartialLiquidationLib {
             _sumOfCollateralValue,
             _borrowerDebtValue,
             _liquidationTargetLTV,
-            _liquidityFee
+            _liquidationFee
         );
 
         collateralToLiquidate = valueToAssetsByRatio(
@@ -183,26 +183,26 @@ library PartialLiquidationLib {
         uint256 _totalBorrowerCollateralValue,
         uint256 _totalBorrowerDebtValue,
         uint256 _ltvAfterLiquidation,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     ) internal pure returns (uint256 collateralValueToLiquidate, uint256 repayValue) {
         repayValue = estimateMaxRepayValue(
-            _totalBorrowerDebtValue, _totalBorrowerCollateralValue, _ltvAfterLiquidation, _liquidityFee
+            _totalBorrowerDebtValue, _totalBorrowerCollateralValue, _ltvAfterLiquidation, _liquidationFee
         );
 
         collateralValueToLiquidate = calculateCollateralToLiquidate(
-            repayValue, _totalBorrowerCollateralValue, _liquidityFee
+            repayValue, _totalBorrowerCollateralValue, _liquidationFee
         );
     }
 
     /// @param _maxDebtToCover assets or value, but must be in sync with `_totalCollateral`
     /// @param _sumOfCollateral assets or value, but must be in sync with `_maxDebtToCover`
     /// @return toLiquidate depends on inputs, it might be collateral value or collateral assets
-    function calculateCollateralToLiquidate(uint256 _maxDebtToCover, uint256 _sumOfCollateral, uint256 _liquidityFee)
+    function calculateCollateralToLiquidate(uint256 _maxDebtToCover, uint256 _sumOfCollateral, uint256 _liquidationFee)
         internal
         pure
         returns (uint256 toLiquidate)
     {
-        uint256 fee = _maxDebtToCover * _liquidityFee / _PRECISION_DECIMALS;
+        uint256 fee = _maxDebtToCover * _liquidationFee / _PRECISION_DECIMALS;
 
         toLiquidate = _maxDebtToCover + fee;
 
@@ -225,10 +225,10 @@ library PartialLiquidationLib {
         uint256 _totalBorrowerDebtValue,
         uint256 _totalBorrowerCollateralValue,
         uint256 _ltvAfterLiquidation,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     ) internal pure returns (uint256 repayValue) {
         if (_totalBorrowerDebtValue == 0) return 0;
-        if (_liquidityFee >= _PRECISION_DECIMALS) return 0;
+        if (_liquidationFee >= _PRECISION_DECIMALS) return 0;
 
         // this will cover case, when _totalBorrowerCollateralValue == 0
         if (_totalBorrowerDebtValue >= _totalBorrowerCollateralValue) return _totalBorrowerDebtValue;
@@ -247,9 +247,9 @@ library PartialLiquidationLib {
         unchecked {
             // safe because of above `LTCv >= _totalBorrowerDebtValue`
             repayValue = _totalBorrowerDebtValue - ltCv;
-            // we checked at begin `_liquidityFee >= _PRECISION_DECIMALS`
+            // we checked at begin `_liquidationFee >= _PRECISION_DECIMALS`
             // mul on DP will not overflow on uint256, div is safe
-            dividerR = _ltvAfterLiquidation + _ltvAfterLiquidation * _liquidityFee / _PRECISION_DECIMALS;
+            dividerR = _ltvAfterLiquidation + _ltvAfterLiquidation * _liquidationFee / _PRECISION_DECIMALS;
         }
 
         // now we can go back to proper precision

--- a/silo-core/test/foundry/data-readers/EstimateMaxRepayValueTestData.sol
+++ b/silo-core/test/foundry/data-readers/EstimateMaxRepayValueTestData.sol
@@ -6,7 +6,7 @@ contract EstimateMaxRepayValueTestData {
         uint256 totalBorrowerDebtValue;
         uint256 totalBorrowerCollateralValue;
         uint256 ltvAfterLiquidation;
-        uint256 liquidityFee;
+        uint256 liquidationFee;
     }
 
     struct EMRVData {
@@ -24,7 +24,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 0,
                 totalBorrowerCollateralValue: 1e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             repayValue: 0
         });
@@ -35,7 +35,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 1e18,
                 totalBorrowerCollateralValue: 2e18,
                 ltvAfterLiquidation: 0.5001e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             repayValue: 0
         });
@@ -46,7 +46,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.79e18,
-                liquidityFee: 0.2659e18
+                liquidationFee: 0.2659e18
             }),
             repayValue: 80e18 // we repay all because we never get as low as 79%
         });
@@ -57,7 +57,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.79e18, // impossible to get here with such high fee
-                liquidityFee: 0.2658e18
+                liquidationFee: 0.2658e18
             }),
             repayValue: 80e18
         });
@@ -68,7 +68,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 180e18,
                 totalBorrowerCollateralValue: 180e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.0001e18
+                liquidationFee: 0.0001e18
             }),
             repayValue: 180e18
         });
@@ -79,7 +79,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             repayValue: 80e18
         });
@@ -90,7 +90,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             repayValue: 37735849056603773584
         });
@@ -101,7 +101,7 @@ contract EstimateMaxRepayValueTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 112e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             repayValue: 6037735849056603773
         });

--- a/silo-core/test/foundry/data-readers/MaxLiquidationPreviewTestData.sol
+++ b/silo-core/test/foundry/data-readers/MaxLiquidationPreviewTestData.sol
@@ -7,7 +7,7 @@ contract MaxLiquidationPreviewTestData {
         uint256 totalBorrowerDebtValue;
         uint256 totalBorrowerCollateralValue;
         uint256 ltvAfterLiquidation;
-        uint256 liquidityFee;
+        uint256 liquidationFee;
     }
 
     struct Output {
@@ -32,7 +32,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 0,
                 totalBorrowerCollateralValue: 1e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             output: Output({
                 collateralValueToLiquidate: 0,
@@ -48,7 +48,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 180e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
                 output: Output({
                 collateralValueToLiquidate: 100e18,
@@ -64,7 +64,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             output: Output({
                 collateralValueToLiquidate: 80e18 + 80e18 * 500 / 1e4,
@@ -80,7 +80,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 98e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.97e18,
-                liquidityFee: 0.031e18
+                liquidationFee: 0.031e18
             }),
             output: Output({
                 collateralValueToLiquidate: 100e18,
@@ -97,7 +97,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 98e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.97e18,
-                liquidityFee: 0.0204e18 // 205-310 all produces collateral over 100%
+                liquidationFee: 0.0204e18 // 205-310 all produces collateral over 100%
             }),
             output: Output({ // result is 9791 LTV not 9700, but this are extreme input data
                 collateralValueToLiquidate: (98e18 + 98e18 * 0.0204e18 / 1e18), // 99999200000000000000
@@ -113,7 +113,7 @@ contract MaxLiquidationPreviewTestData {
                 totalBorrowerDebtValue: 80e18,
                 totalBorrowerCollateralValue: 100e18,
                 ltvAfterLiquidation: 0.7e18,
-                liquidityFee: 0.05e18
+                liquidationFee: 0.05e18
             }),
             output: Output({
                 collateralValueToLiquidate: 39622641509433962263,

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxLiquidation.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxLiquidation.t.sol
@@ -22,11 +22,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 _sumOfCollateralAssets,
         uint128 _sumOfCollateralValue,
         uint128 _borrowerDebtAssets,
-        uint64 _liquidityFee,
+        uint64 _liquidationFee,
         uint64 _liquidationTargetLtv
     ) public {
         _test_maxLiquidation(
-            _sumOfCollateralAssets, _sumOfCollateralValue, _borrowerDebtAssets, _liquidityFee, _liquidationTargetLtv
+            _sumOfCollateralAssets, _sumOfCollateralValue, _borrowerDebtAssets, _liquidationFee, _liquidationTargetLtv
         );
     }
 
@@ -37,11 +37,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1000;
         uint128 sumOfCollateralValue = 1000;
         uint128 borrowerDebtAssets = 900;
-        uint64 liquidityFee;
+        uint64 liquidationFee;
         uint64 liquidationTargetLtv = 0.5e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 798, "collateralToLiquidate");
@@ -58,11 +58,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1000;
         uint128 sumOfCollateralValue = 1000;
         uint128 borrowerDebtAssets = 900;
-        uint64 liquidityFee = 0.01e18;
+        uint64 liquidationFee = 0.01e18;
         uint64 liquidationTargetLtv = 0.5e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 814, "collateralToLiquidate");
@@ -79,11 +79,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee;
+        uint64 liquidationFee;
         uint64 liquidationTargetLtv = 0.5e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 799999999999999998, "collateralToLiquidate");
@@ -100,11 +100,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee = 0.01e18;
+        uint64 liquidationFee = 0.01e18;
         uint64 liquidationTargetLtv = 0.5e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 816161616161616158, "collateralToLiquidate");
@@ -121,11 +121,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee;
+        uint64 liquidationFee;
         uint64 liquidationTargetLtv = 0.7e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 666666666666666664, "collateralToLiquidate");
@@ -142,11 +142,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee = 0.05e18;
+        uint64 liquidationFee = 0.05e18;
         uint64 liquidationTargetLtv = 0.7e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 792452830188679242, "collateralToLiquidate");
@@ -163,11 +163,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee;
+        uint64 liquidationFee;
         uint64 liquidationTargetLtv = 0.1e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 899999999999999998, "collateralToLiquidate");
@@ -184,11 +184,11 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 sumOfCollateralAssets = 1e18;
         uint128 sumOfCollateralValue = 1e18;
         uint128 borrowerDebtAssets = 0.9e18;
-        uint64 liquidityFee = 0.3e18;
+        uint64 liquidationFee = 0.3e18;
         uint64 liquidationTargetLtv = 0.1e18;
 
         (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) = _test_maxLiquidation(
-            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidityFee, liquidationTargetLtv
+            sumOfCollateralAssets, sumOfCollateralValue, borrowerDebtAssets, liquidationFee, liquidationTargetLtv
         );
 
         assertEq(collateralToLiquidate, 999999999999999998, "collateralToLiquidate");
@@ -205,17 +205,17 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         uint128 _sumOfCollateralAssets,
         uint128 _sumOfCollateralValue,
         uint128 _borrowerDebtAssets,
-        uint64 _liquidityFee,
+        uint64 _liquidationFee,
         uint64 _liquidationTargetLtv
     ) internal returns (uint256 collateralToLiquidate, uint256 debtToRepay, uint256 ltvAfter) {
-        vm.assume(_liquidityFee < 0.40e18); // some reasonable fee
+        vm.assume(_liquidationFee < 0.40e18); // some reasonable fee
         vm.assume(_sumOfCollateralAssets > 0);
         // for tiny assets we doing full liquidation because it is to small to get down to expected minimal LTV
         vm.assume(_sumOfCollateralValue > 1);
         vm.assume(_borrowerDebtAssets > 1);
 
         // prevent overflow revert in test
-        vm.assume(uint256(_borrowerDebtAssets) * _liquidityFee < type(uint128).max);
+        vm.assume(uint256(_borrowerDebtAssets) * _liquidationFee < type(uint128).max);
 
         vm.assume(_liquidationTargetLtv < _LT);
 
@@ -233,7 +233,7 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
             _borrowerDebtAssets,
             borrowerDebtValue,
             _liquidationTargetLtv,
-            _liquidityFee
+            _liquidationFee
         );
 
         emit log_named_decimal_uint("collateralToLiquidate", collateralToLiquidate, 18);
@@ -242,7 +242,7 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
         emit log_named_decimal_uint("minExpectedLtv", _liquidationTargetLtv, 16);
         emit log_named_decimal_uint("ltvBefore", ltvBefore, 16);
 
-        uint256 raw = _estimateMaxRepayValueRaw(borrowerDebtValue, _sumOfCollateralValue, _liquidationTargetLtv, _liquidityFee);
+        uint256 raw = _estimateMaxRepayValueRaw(borrowerDebtValue, _sumOfCollateralValue, _liquidationTargetLtv, _liquidationFee);
         emit log_named_decimal_uint("raw", raw, 18);
 
         uint256 deviation = raw > debtToRepay

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxRepayRawMath.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxRepayRawMath.sol
@@ -12,15 +12,15 @@ contract MaxRepayRawMath {
         uint256 _totalBorrowerDebtValue,
         uint256 _totalBorrowerCollateralValue,
         uint256 _ltvAfterLiquidation,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     )
         internal pure returns (uint256 repayValue)
     {
-        uint256 tmp = _ltvAfterLiquidation * _liquidityFee / _DECIMALS_POINTS;
+        uint256 tmp = _ltvAfterLiquidation * _liquidationFee / _DECIMALS_POINTS;
         if (_ltvAfterLiquidation + tmp > _DECIMALS_POINTS) return _totalBorrowerDebtValue;
 
         uint256 divider =
-            _DECIMALS_POINTS - _ltvAfterLiquidation - _ltvAfterLiquidation * _liquidityFee / _DECIMALS_POINTS;
+            _DECIMALS_POINTS - _ltvAfterLiquidation - _ltvAfterLiquidation * _liquidationFee / _DECIMALS_POINTS;
 
         if (divider == 0) return 0;
 

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/PartialLiquidationLib.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/PartialLiquidationLib.t.sol
@@ -24,7 +24,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
     forge test -vv --mt test_PartialLiquidationLib_collateralToLiquidate
     */
     function test_PartialLiquidationLib_collateralToLiquidate() public pure {
-        // uint256 _maxDebtToCover, uint256 _totalCollateral, uint256 _liquidityFee
+        // uint256 _maxDebtToCover, uint256 _totalCollateral, uint256 _liquidationFee
         assertEq(PartialLiquidationLib.calculateCollateralToLiquidate(0, 0, 0), 0);
         assertEq(PartialLiquidationLib.calculateCollateralToLiquidate(1, 1, 0), 1);
         assertEq(PartialLiquidationLib.calculateCollateralToLiquidate(1, 1, 0.0001e18), 1);
@@ -123,7 +123,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
                 data[i].input.totalBorrowerDebtValue,
                 data[i].input.totalBorrowerCollateralValue,
                 data[i].input.ltvAfterLiquidation,
-                data[i].input.liquidityFee
+                data[i].input.liquidationFee
             );
 
             console.log("repayValue %s", repayValue);
@@ -173,7 +173,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
                 data[i].input.totalBorrowerCollateralValue,
                 data[i].input.totalBorrowerDebtValue,
                 data[i].input.ltvAfterLiquidation,
-                data[i].input.liquidityFee
+                data[i].input.liquidationFee
             );
 
             assertEq(
@@ -196,7 +196,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
                 collateralConfigAsset: address(0),
                 debtConfigAsset: address(0),
                 maxDebtToCover: _assetsChunk(data[i].input.totalBorrowerDebtValue, totalBorrowerDebtAssets, repayValue),
-                liquidationFee: data[i].input.liquidityFee,
+                liquidationFee: data[i].input.liquidationFee,
                 liquidationTargetLtv: data[i].input.ltvAfterLiquidation
             });
 
@@ -418,10 +418,10 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
         uint128 _debtAmount,
         uint128 _collateralAmount,
         uint16 _targetLT,
-        uint16 _liquidityFee
+        uint16 _liquidationFee
     ) public {
         vm.assume(_targetLT <= 1e18);
-        vm.assume(_liquidityFee <= 1e18);
+        vm.assume(_liquidationFee <= 1e18);
 
         // prices here are arbitrary
         uint256 debtValue = uint256(_debtAmount) * 50_000;
@@ -431,7 +431,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
             collateralValue,
             debtValue,
             uint256(_targetLT),
-            uint256(_liquidityFee)
+            uint256(_liquidationFee)
         );
 
         emit log_string("PartialLiquidationLib.calculateLiquidationValues PASS");
@@ -439,7 +439,7 @@ contract PartialLiquidationLibTest is Test, MaxRepayRawMath {
         (
             uint256 repayValue2, uint256 receiveCollateral2
         ) = PartialLiquidationLibChecked.maxLiquidationPreview(
-            collateralValue, debtValue, _targetLT, _liquidityFee
+            collateralValue, debtValue, _targetLT, _liquidationFee
         );
 
         assertEq(repayValue, repayValue2, "repay must match value with safe math");

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/PartialLiquidationLibChecked.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/PartialLiquidationLibChecked.sol
@@ -35,7 +35,7 @@ library PartialLiquidationLibChecked {
         uint256 _borrowerDebtAssets,
         uint256 _borrowerDebtValue,
         uint256 _liquidationTargetLTV,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     )
         internal
         pure
@@ -47,7 +47,7 @@ library PartialLiquidationLibChecked {
             _sumOfCollateralValue,
             _borrowerDebtValue,
             _liquidationTargetLTV,
-            _liquidityFee
+            _liquidationFee
         );
 
         collateralToLiquidate = valueToAssetsByRatio(
@@ -175,26 +175,26 @@ library PartialLiquidationLibChecked {
         uint256 _totalBorrowerCollateralValue,
         uint256 _totalBorrowerDebtValue,
         uint256 _ltvAfterLiquidation,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     ) internal pure returns (uint256 collateralValueToLiquidate, uint256 repayValue) {
         repayValue = estimateMaxRepayValue(
-            _totalBorrowerDebtValue, _totalBorrowerCollateralValue, _ltvAfterLiquidation, _liquidityFee
+            _totalBorrowerDebtValue, _totalBorrowerCollateralValue, _ltvAfterLiquidation, _liquidationFee
         );
 
         collateralValueToLiquidate = calculateCollateralToLiquidate(
-            repayValue, _totalBorrowerCollateralValue, _liquidityFee
+            repayValue, _totalBorrowerCollateralValue, _liquidationFee
         );
     }
 
     /// @param _maxDebtToCover assets or value, but must be in sync with `_totalCollateral`
     /// @param _sumOfCollateral assets or value, but must be in sync with `_maxDebtToCover`
     /// @return toLiquidate depends on inputs, it might be collateral value or collateral assets
-    function calculateCollateralToLiquidate(uint256 _maxDebtToCover, uint256 _sumOfCollateral, uint256 _liquidityFee)
+    function calculateCollateralToLiquidate(uint256 _maxDebtToCover, uint256 _sumOfCollateral, uint256 _liquidationFee)
         internal
         pure
         returns (uint256 toLiquidate)
     {
-        uint256 fee = _maxDebtToCover * _liquidityFee / _PRECISION_DECIMALS;
+        uint256 fee = _maxDebtToCover * _liquidationFee / _PRECISION_DECIMALS;
 
         toLiquidate = _maxDebtToCover + fee;
 
@@ -217,10 +217,10 @@ library PartialLiquidationLibChecked {
         uint256 _totalBorrowerDebtValue,
         uint256 _totalBorrowerCollateralValue,
         uint256 _ltvAfterLiquidation,
-        uint256 _liquidityFee
+        uint256 _liquidationFee
     ) internal pure returns (uint256 repayValue) {
         if (_totalBorrowerDebtValue == 0) return 0;
-        if (_liquidityFee >= _PRECISION_DECIMALS) return 0;
+        if (_liquidationFee >= _PRECISION_DECIMALS) return 0;
 
         // this will cover case, when _totalBorrowerCollateralValue == 0
         if (_totalBorrowerDebtValue >= _totalBorrowerCollateralValue) return _totalBorrowerDebtValue;
@@ -239,9 +239,9 @@ library PartialLiquidationLibChecked {
         /* unchecked */ {
             // safe because of above `LTCv >= _totalBorrowerDebtValue`
             repayValue = _totalBorrowerDebtValue - ltCv;
-            // we checked at begin `_liquidityFee >= _PRECISION_DECIMALS`
+            // we checked at begin `_liquidationFee >= _PRECISION_DECIMALS`
             // mul on DP will not overflow on uint256, div is safe
-            dividerR = _ltvAfterLiquidation + _ltvAfterLiquidation * _liquidityFee / _PRECISION_DECIMALS;
+            dividerR = _ltvAfterLiquidation + _ltvAfterLiquidation * _liquidationFee / _PRECISION_DECIMALS;
         }
 
         // now we can go back to proper precision


### PR DESCRIPTION
Fixes SILO-3179