### PR TITLE
[M-01] silo-core: fix transition collateral for deposit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PublicAllocator` contract for vaults
 - add reentrancy for `withdrawFees`
 
+### Fixed
+- ensure transition deposit not fail when user insolvent
+
 ## [0.14.0] - 2024-11-25
 ### Added
 - Vault functionality based on MetaMorpho

--- a/silo-core/contracts/interfaces/ISilo.sol
+++ b/silo-core/contracts/interfaces/ISilo.sol
@@ -178,9 +178,10 @@ interface ISilo is IERC20, IERC4626, IERC3156FlashLender {
     error InputCanBeAssetsOrShares();
     error CollateralSiloAlreadySet();
     error RepayTooHigh();
-    error InputZeroAssetsOrShares();
-    error ReturnZeroAssetsOrShares();
     error ZeroAmount();
+    error InputZeroShares();
+    error ReturnZeroAssets();
+    error ReturnZeroShares();
 
     /// @return siloFactory The associated factory of the silo
     function factory() external view returns (ISiloFactory siloFactory);

--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -225,14 +225,18 @@ library Actions {
         siloConfig.turnOnReentrancyProtection();
         siloConfig.accrueInterestForBothSilos();
 
-        (address protectedShareToken, address collateralShareToken,) = siloConfig.getShareTokens(address(this));
+        (
+            ISiloConfig.DepositConfig memory depositConfig,
+            ISiloConfig.ConfigData memory collateralConfig,
+            ISiloConfig.ConfigData memory debtConfig
+        ) = siloConfig.getConfigsForWithdraw(address(this), _args.owner);
 
         uint256 shares;
 
         // transition collateral withdraw
         address shareTokenFrom = _args.transitionFrom == ISilo.CollateralType.Collateral
-            ? collateralShareToken
-            : protectedShareToken;
+            ? depositConfig.collateralShareToken
+            : depositConfig.protectedShareToken;
 
         (assets, shares) = SiloERC4626Lib.withdraw({
             _asset: address(0), // empty token because we don't want to transfer
@@ -250,8 +254,8 @@ library Actions {
         // transition collateral deposit
         (ISilo.CollateralType depositType, address shareTokenTo) =
             _args.transitionFrom == ISilo.CollateralType.Collateral
-                ? (ISilo.CollateralType.Protected, protectedShareToken)
-                : (ISilo.CollateralType.Collateral, collateralShareToken);
+                ? (ISilo.CollateralType.Protected, depositConfig.protectedShareToken)
+                : (ISilo.CollateralType.Collateral, depositConfig.collateralShareToken);
 
         (assets, toShares) = SiloERC4626Lib.deposit({
             _token: address(0), // empty token because we don't want to transfer
@@ -264,12 +268,9 @@ library Actions {
         });
 
         // solvency check
-        ISiloConfig.ConfigData memory collateralConfig;
-        ISiloConfig.ConfigData memory debtConfig;
-
-        (collateralConfig, debtConfig) = siloConfig.getConfigsForSolvency(_args.owner);
-
-        _checkSolvencyWithoutAccruingInterest(collateralConfig, debtConfig, _args.owner);
+        if (depositConfig.silo == collateralConfig.silo) {
+            _checkSolvencyWithoutAccruingInterest(collateralConfig, debtConfig, _args.owner);
+        }
 
         siloConfig.turnOffReentrancyProtection();
 
@@ -457,17 +458,17 @@ library Actions {
 
     // this method expect interest to be already accrued
     function _checkSolvencyWithoutAccruingInterest(
-        ISiloConfig.ConfigData memory collateralConfig,
-        ISiloConfig.ConfigData memory debtConfig,
+        ISiloConfig.ConfigData memory _collateralConfig,
+        ISiloConfig.ConfigData memory _debtConfig,
         address _user
     ) private {
-        if (debtConfig.silo != collateralConfig.silo) {
-            collateralConfig.callSolvencyOracleBeforeQuote();
-            debtConfig.callSolvencyOracleBeforeQuote();
+        if (_debtConfig.silo != _collateralConfig.silo) {
+            _collateralConfig.callSolvencyOracleBeforeQuote();
+            _debtConfig.callSolvencyOracleBeforeQuote();
         }
 
         bool userIsSolvent = SiloSolvencyLib.isSolvent(
-            collateralConfig, debtConfig, _user, ISilo.AccrueInterestInMemory.No
+            _collateralConfig, _debtConfig, _user, ISilo.AccrueInterestInMemory.No
         );
 
         require(userIsSolvent, ISilo.NotSolvent());

--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -267,7 +267,7 @@ library Actions {
             _collateralType: depositType
         });
 
-        // solvency check
+        // If deposit is collateral, then check the solvency.
         if (depositConfig.silo == collateralConfig.silo) {
             _checkSolvencyWithoutAccruingInterest(collateralConfig, debtConfig, _args.owner);
         }

--- a/silo-core/contracts/lib/SiloMathLib.sol
+++ b/silo-core/contracts/lib/SiloMathLib.sol
@@ -143,19 +143,18 @@ library SiloMathLib {
         Math.Rounding _roundingToShares,
         ISilo.AssetType _assetType
     ) internal pure returns (uint256 assets, uint256 shares) {
-        require(_assets != 0 || _shares != 0, ISilo.InputZeroAssetsOrShares());
-
         if (_assets == 0) {
+            require(_shares != 0, ISilo.InputZeroShares());
             shares = _shares;
             assets = convertToAssets(_shares, _totalAssets, _totalShares, _roundingToAssets, _assetType);
+            require(assets != 0, ISilo.ReturnZeroAssets());
         } else if (_shares == 0) {
             shares = convertToShares(_assets, _totalAssets, _totalShares, _roundingToShares, _assetType);
             assets = _assets;
+            require(shares != 0, ISilo.ReturnZeroShares());
         } else {
             revert ISilo.InputCanBeAssetsOrShares();
         }
-
-        require(assets != 0 && shares != 0, ISilo.ReturnZeroAssetsOrShares());
     }
 
     /// @dev Math for collateral is exact copy of

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -33,7 +33,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
     forge test -vv --ffi --mt test_borrow_all_zeros
     */
     function test_borrow_all_zeros() public {
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.borrow(0, address(0), address(0));
     }
 
@@ -44,7 +44,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         uint256 assets = 0;
         address borrower = address(1);
 
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.borrow(assets, borrower, borrower);
     }
 

--- a/silo-core/test/foundry/Silo/borrow/BorrowSameAsset.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/BorrowSameAsset.i.sol
@@ -35,7 +35,7 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
     forge test -vv --ffi --mt test_borrowSameAsset_all_zeros
     */
     function test_borrowSameAsset_all_zeros() public {
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.borrowSameAsset(0, address(0), address(0));
     }
 
@@ -46,7 +46,7 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
         uint256 assets = 0;
         address borrower = address(1);
 
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.borrowSameAsset(assets, borrower, borrower);
     }
 

--- a/silo-core/test/foundry/Silo/deposit/Deposit.i.sol
+++ b/silo-core/test/foundry/Silo/deposit/Deposit.i.sol
@@ -41,10 +41,10 @@ contract DepositTest is SiloLittleHelper, Test {
         ISilo.CollateralType _type;
         address depositor = makeAddr("Depositor");
 
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.deposit(_assets, depositor);
 
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.deposit(_assets, depositor, _type);
     }
 

--- a/silo-core/test/foundry/Silo/max/maxLiquidation/MaxLiquidationCommon.sol
+++ b/silo-core/test/foundry/Silo/max/maxLiquidation/MaxLiquidationCommon.sol
@@ -276,7 +276,7 @@ abstract contract MaxLiquidationCommon is SiloLittleHelper, Test {
     function _calculateChunk(uint256 _maxDebtToCover, uint256 _i) internal view returns (uint256 _chunk) {
         if (_maxDebtToCover == 0) return 0;
 
-        // min amount of assets that will not generate InputZeroAssetsOrShares error
+        // min amount of assets that will not generate InputZeroShares error
         uint256 minAssets = silo1.previewRepayShares(1);
 
         if (_i < 2 || _i == 4) {
@@ -321,9 +321,9 @@ abstract contract MaxLiquidationCommon is SiloLittleHelper, Test {
         } catch (bytes memory data) {
             bytes4 errorType = bytes4(data);
 
-            bytes4 expectedError = bytes4(keccak256(abi.encodePacked("ReturnZeroAssetsOrShares()")));
+            bytes4 expectedError = bytes4(keccak256(abi.encodePacked("ReturnZeroAssets()")));
 
-            assertEq(errorType, expectedError, "only ReturnZeroAssetsOrShares error is expected");
+            assertEq(errorType, expectedError, "only ReturnZeroAssets error is expected");
         }
     }
 

--- a/silo-core/test/foundry/Silo/preview/PreviewDeposit.i.sol
+++ b/silo-core/test/foundry/Silo/preview/PreviewDeposit.i.sol
@@ -103,7 +103,7 @@ contract PreviewDepositTest is SiloLittleHelper, Test {
 
         if (previewShares1 == 0) {
             // if preview is zero for `_assets`, then deposit should also reverts
-            _depositForBorrowRevert(_assets, depositor, cType, ISilo.InputZeroAssetsOrShares.selector);
+            _depositForBorrowRevert(_assets, depositor, cType, ISilo.InputZeroShares.selector);
         } else {
             assertEq(
                 previewShares1,
@@ -132,7 +132,7 @@ contract PreviewDepositTest is SiloLittleHelper, Test {
         emit log_named_uint("previewShares1", previewShares1);
 
         if (previewShares1 == 0) {
-            _depositForBorrowRevert(_assets, depositor, cType, ISilo.InputZeroAssetsOrShares.selector);
+            _depositForBorrowRevert(_assets, depositor, cType, ISilo.InputZeroShares.selector);
         } else {
             assertEq(
                 previewShares1,

--- a/silo-core/test/foundry/Silo/repay/Repay.i.sol
+++ b/silo-core/test/foundry/Silo/repay/Repay.i.sol
@@ -26,7 +26,7 @@ contract RepayTest is SiloLittleHelper, Test {
     forge test -vv --ffi --mt test_repay_zeros
     */
     function test_repay_zeros() public {
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.repay(0, address(0));
     }
 
@@ -67,7 +67,7 @@ contract RepayTest is SiloLittleHelper, Test {
         _createDebt(assets, borrower);
         vm.warp(block.timestamp + 50 * 365 days); // interest must be big, so conversion 1 asset => share be 0
 
-        vm.expectRevert(ISilo.ReturnZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.ReturnZeroShares.selector);
         silo1.repay(assets, borrower);
     }
 

--- a/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDeposit.i.sol
+++ b/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDeposit.i.sol
@@ -79,7 +79,7 @@ contract WithdrawWhenNoDepositTest is IntegrationTest {
         _anyDeposit(ISilo.CollateralType.Collateral);
 
         // test
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
         silo0.withdraw(0, address(this), address(this), ISilo.CollateralType.Collateral);
 
         vm.expectRevert(ISilo.NothingToWithdraw.selector);

--- a/silo-core/test/foundry/data-readers/SiloLendingLibBorrowTestData.sol
+++ b/silo-core/test/foundry/data-readers/SiloLendingLibBorrowTestData.sol
@@ -58,7 +58,7 @@ contract SiloLendingLibBorrowTestData {
         uint256 i;
 
         _init(data[i], "#0 all zeros");
-        data[i].output.reverts = ISilo.InputZeroAssetsOrShares.selector;
+        data[i].output.reverts = ISilo.InputZeroShares.selector;
         data[i].mocks.debtSharesTotalSupplyMock = true;
 
         i++;

--- a/silo-core/test/foundry/gas/Borrow1st.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow1st.gas.sol
@@ -27,7 +27,7 @@ contract Borrow1stGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow1st (no interest)",
-            227225
+            227064
         );
     }
 }

--- a/silo-core/test/foundry/gas/Borrow2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Borrow2nd.gas.sol
@@ -29,7 +29,7 @@ contract Borrow2ndGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "Borrow2nd (no interest)",
-            139468
+            139307
         );
     }
 }

--- a/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/BorrowAccrueInterest.gas.sol
@@ -31,7 +31,7 @@ contract BorrowAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.borrow, (ASSETS, BORROWER, BORROWER)),
             "BorrowAccrueInterest",
-            210275
+            210114
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -40,7 +40,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 (address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            434923
+            432556
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -40,7 +40,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 (address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            432691
+            434923
         );
     }
 }

--- a/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+
+import {Gas} from "./Gas.sol";
+
+/*
+forge test -vv --ffi --mt test_gas_ | grep -i '\[GAS\]'
+*/
+contract TransitionCollateralTest is Gas, Test {
+    function setUp() public {
+        _gasTestsInit();
+
+        _depositCollateral(ASSETS * 2, BORROWER, TWO_ASSETS);
+        _depositForBorrow(ASSETS, DEPOSITOR);
+        _borrow(ASSETS, BORROWER, TWO_ASSETS);
+
+        vm.warp(block.timestamp + 1);
+    }
+
+    /*
+    FOUNDRY_PROFILE=core-test forge test -vv --ffi --mt test_gas_transitionCollateral
+    */
+    function test_gas_transitionCollateral() public {
+        _action(
+            BORROWER,
+            address(silo0),
+            abi.encodeCall(ISilo.transitionCollateral, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
+            "transitionCollateral (when debt)",
+            272000 // 74K for interest
+        );
+    }
+}

--- a/silo-core/test/foundry/lib/SiloLendingLib/Borrow.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/Borrow.t.sol
@@ -55,7 +55,7 @@ contract BorrowTest is Test {
             abi.encode(0)
         );
 
-        vm.expectRevert(ISilo.InputZeroAssetsOrShares.selector);
+        vm.expectRevert(ISilo.InputZeroShares.selector);
 
         impl.borrow({
             _debtShareToken: configData.debtShareToken,


### PR DESCRIPTION
> Description: transitionCollateral uses the wrong solvency check in cases where the user is insolvent but through a different silo.

Fixes SILO-3255