### PR TITLE
fix irm ri type

### DIFF
--- a/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
@@ -373,6 +373,29 @@ contract InterestRateModelV2 is IInterestRateModel, IInterestRateModelV2 {
         }
     }
 
+    /// @dev this method is to detect possible overflow in math for provided config in next 50years
+    function configOverflowDetection(IInterestRateModelV2.Config calldata _config) external pure {
+        int256 YEAR = 365 days;
+        int256 MAX_TIME = 50 * 365 days;
+
+        int256 Tcrit_max = _config.Tcrit + _config.beta * MAX_TIME;
+        int256 rp_max = _config.kcrit * (_DP + Tcrit_max) / _DP * (_DP - _config.ucrit) / _DP;
+        int256 rp_min = -_config.klow * _config.ulow / _DP;
+        int256 rlin_max = _config.klin * _DP / _DP;
+        int256 ri_max = _max(_config.ri, rlin_max) +_config.ki * (_DP - _config.uopt) * MAX_TIME / _DP;
+        int256 ri_min = -_config.ki * _config.uopt * MAX_TIME / _DP;
+        int256 rcur_max = ri_max + rp_max;
+        int256 rcur_min = ri_min + rp_min;
+        int256 rcur_ann_max = rcur_max * YEAR;
+
+        int256 slopei_max = _config.ki * (_DP - _config.uopt) / _DP;
+        int256 slopei_min = - _config.ki * _config.uopt / _DP;
+        int256 slope_max = slopei_max + _config.kcrit * _config.beta / _DP * (_DP - _config.ucrit) / _DP;
+        int256 slope_min = slopei_min;
+
+        int256 x_max = rcur_max * 2 * MAX_TIME / 2 + (_max(slope_max, -slope_min) * MAX_TIME)**2 / 2;
+    }
+
     /// @dev checks for the overflow in rcomp calculations, accruedInterest, totalDeposits and totalBorrowedAmount.
     /// In case of the overflow, rcomp is reduced to make totalDeposits and totalBorrowedAmount <= 2**196.
     function _calculateRComp(

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Config.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Config.sol
@@ -25,9 +25,9 @@ contract InterestRateModelV2Config is IInterestRateModelV2Config {
     int256 internal immutable _BETA;
 
     // initial value for ri, ri ≥ 0 – initial value of the integrator
-    int128 internal immutable _RI;
+    int112 internal immutable _RI;
     // initial value for Tcrit, Tcrit ≥ 0 - the time during which the utilization exceeds the critical value
-    int128 internal immutable _TCRIT;
+    int112 internal immutable _TCRIT;
 
     constructor(IInterestRateModelV2.Config memory _config) {
         _UOPT = _config.uopt;

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -14,6 +14,8 @@ import {InterestRateModelV2Config} from "./InterestRateModelV2Config.sol";
 contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
     /// @dev DP is 18 decimal points used for integer calculations
     uint256 public constant DP = 1e18;
+    uint256 public constant MAX_RI = 2 ** 46;
+    uint256 public constant MAX_TCRIT = 2 ** 112;
 
     /// @dev IRM contract implementation address to clone
     address public immutable IRM;
@@ -67,8 +69,8 @@ contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
         require(_config.klin >= 0, IInterestRateModelV2.InvalidKlin());
         require(_config.beta >= 0, IInterestRateModelV2.InvalidBeta());
 
-        require(_config.ri >= 0, IInterestRateModelV2.InvalidRi());
-        require(_config.Tcrit >= 0, IInterestRateModelV2.InvalidTcrit());
+        require(_config.ri >= 0 && _config.ri < MAX_RI, IInterestRateModelV2.InvalidRi());
+        require(_config.Tcrit >= 0 && _config.Tcrit < MAX_TCRIT, IInterestRateModelV2.InvalidTcrit());
     }
 
     /// @inheritdoc IInterestRateModelV2Factory

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -14,8 +14,8 @@ import {InterestRateModelV2Config} from "./InterestRateModelV2Config.sol";
 contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
     /// @dev DP is 18 decimal points used for integer calculations
     uint256 public constant DP = 1e18;
-    uint256 public constant MAX_RI = 2 ** 46;
-    uint256 public constant MAX_TCRIT = 2 ** 112;
+    int256 public constant MAX_RI = 2 ** 46;
+    int256 public constant MAX_TCRIT = 2 ** 112;
 
     /// @dev IRM contract implementation address to clone
     address public immutable IRM;

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -67,13 +67,6 @@ contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
         require(_config.klin >= 0, IInterestRateModelV2.InvalidKlin());
         require(_config.beta >= 0, IInterestRateModelV2.InvalidBeta());
 
-//        int256 tmpMax = _config.ri > _config.klin ? _config.ri : _config.klin;
-//
-//        require(
-//            (_config.ri >= 0) && (tmpMax + _config.kcrit * (dp - _config.ucrit) < 10**20),
-//            IInterestRateModelV2.InvalidRi()
-//        );
-
         require(_config.ri >= 0, IInterestRateModelV2.InvalidRi());
         require(_config.Tcrit >= 0, IInterestRateModelV2.InvalidTcrit());
 

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -15,8 +15,6 @@ contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
     /// @dev DP is 18 decimal points used for integer calculations
     uint256 public constant DP = 1e18;
 
-    int256 public constant MAX_TCRIT = 2 ** 112;
-
     /// @dev IRM contract implementation address to clone
     address public immutable IRM;
 

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -69,15 +69,18 @@ contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
         require(_config.klin >= 0, IInterestRateModelV2.InvalidKlin());
         require(_config.beta >= 0, IInterestRateModelV2.InvalidBeta());
 
-        uint256 tmpMax = _config.ri > _config.klin ? _config.ri : _config.klin;
+//        int256 tmpMax = _config.ri > _config.klin ? _config.ri : _config.klin;
+//
+//        require(
+//            (_config.ri >= 0) && (tmpMax + _config.kcrit * (dp - _config.ucrit) < 10**20),
+//            IInterestRateModelV2.InvalidRi()
+//        );
 
-        require(
-            _config.ri >= 0 && tmpMax + _config.kcrit * (1 - _config.ucrit) < 10**20,
-            IInterestRateModelV2.InvalidRi()
-        );
+        require(_config.ri >= 0, IInterestRateModelV2.InvalidRi());
+        require(_config.Tcrit >= 0, IInterestRateModelV2.InvalidTcrit());
 
-        require(_config.Tcrit >= 0 && _config.Tcrit < MAX_TCRIT, IInterestRateModelV2.InvalidTcrit());
-
+        // overflow check
+        InterestRateModelV2(IRM).configOverflowCheck(_config);
     }
 
     /// @inheritdoc IInterestRateModelV2Factory

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2Factory.sol
@@ -14,7 +14,7 @@ import {InterestRateModelV2Config} from "./InterestRateModelV2Config.sol";
 contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
     /// @dev DP is 18 decimal points used for integer calculations
     uint256 public constant DP = 1e18;
-    int256 public constant MAX_RI = 2 ** 46;
+
     int256 public constant MAX_TCRIT = 2 ** 112;
 
     /// @dev IRM contract implementation address to clone
@@ -69,8 +69,15 @@ contract InterestRateModelV2Factory is IInterestRateModelV2Factory {
         require(_config.klin >= 0, IInterestRateModelV2.InvalidKlin());
         require(_config.beta >= 0, IInterestRateModelV2.InvalidBeta());
 
-        require(_config.ri >= 0 && _config.ri < MAX_RI, IInterestRateModelV2.InvalidRi());
+        uint256 tmpMax = _config.ri > _config.klin ? _config.ri : _config.klin;
+
+        require(
+            _config.ri >= 0 && tmpMax + _config.kcrit * (1 - _config.ucrit) < 10**20,
+            IInterestRateModelV2.InvalidRi()
+        );
+
         require(_config.Tcrit >= 0 && _config.Tcrit < MAX_TCRIT, IInterestRateModelV2.InvalidTcrit());
+
     }
 
     /// @inheritdoc IInterestRateModelV2Factory

--- a/silo-core/contracts/interfaces/IInterestRateModelV2.sol
+++ b/silo-core/contracts/interfaces/IInterestRateModelV2.sol
@@ -22,13 +22,13 @@ interface IInterestRateModelV2 {
         // beta ≥ 0 - a scaling factor
         int256 beta;
         // ri ≥ 0 – initial value of the integrator
-        int128 ri;
-        // Tcrit ≥ 0 - the time during which the utilization exceeds the critical value
-        int128 Tcrit;
+        int112 ri;
+        // Tcrit ≥ 0 - initial value of the time during which the utilization exceeds the critical value
+        int112 Tcrit;
     }
 
     struct Setup {
-        // ri ≥ 0 – initial value of the integrator
+        // ri ≥ 0 – the integrator
         int112 ri;
         // Tcrit ≥ 0 - the time during which the utilization exceeds the critical value
         int112 Tcrit;

--- a/silo-core/deploy/input-readers/InterestRateModelConfigData.sol
+++ b/silo-core/deploy/input-readers/InterestRateModelConfigData.sol
@@ -55,8 +55,11 @@ contract InterestRateModelConfigData {
                 modelConfig.ucrit = configs[index].config.ucrit;
                 modelConfig.ulow = configs[index].config.ulow;
                 modelConfig.uopt = configs[index].config.uopt;
-                modelConfig.ri = int128(configs[index].config.ri);
-                modelConfig.Tcrit = int128(configs[index].config.Tcrit);
+                modelConfig.ri = int112(configs[index].config.ri);
+                modelConfig.Tcrit = int112(configs[index].config.Tcrit);
+
+                require(modelConfig.ri == configs[index].config.ri, "ri overflow");
+                require(modelConfig.Tcrit == configs[index].config.Tcrit, "Tcrit overflow");
 
                 return modelConfig;
             }

--- a/silo-core/test/foundry/data-readers/RcompTestData.sol
+++ b/silo-core/test/foundry/data-readers/RcompTestData.sol
@@ -8,9 +8,9 @@ import {IInterestRateModelV2} from "../../../contracts/interfaces/IInterestRateM
 contract RcompTestData is Test {
     // must be in alphabetic order
     struct Input {
-        int128 Tcrit;
+        int112 Tcrit;
         uint256 currentTime;
-        int128 integratorState;
+        int112 integratorState;
         uint256 lastTransactionTime;
         uint256 lastUtilization;
         uint256 totalBorrowAmount;

--- a/silo-core/test/foundry/data-readers/RcurTestData.sol
+++ b/silo-core/test/foundry/data-readers/RcurTestData.sol
@@ -8,9 +8,9 @@ import {IInterestRateModelV2} from "../../../contracts/interfaces/IInterestRateM
 contract RcurTestData is Test {
     // must be in alphabetic order
     struct Input {
-        int128 Tcrit;
+        int112 Tcrit;
         uint256 currentTime;
-        int128 integratorState;
+        int112 integratorState;
         uint256 lastTransactionTime;
         uint256 lastUtilization;
         uint256 totalBorrowAmount;

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2.t.sol
@@ -12,7 +12,9 @@ import {InterestRateModelConfigs} from "../_common/InterestRateModelConfigs.sol"
 import {InterestRateModelV2Impl} from "./InterestRateModelV2Impl.sol";
 import {InterestRateModelV2Checked} from "./InterestRateModelV2Checked.sol";
 
-// forge test -vv --mc InterestRateModelV2Test
+/*
+ forge test -vv --mc InterestRateModelV2Test
+*/
 contract InterestRateModelV2Test is Test, InterestRateModelConfigs {
     uint256 constant TODAY = 1682885514;
     InterestRateModelV2 immutable INTEREST_RATE_MODEL;

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2.t.sol
@@ -209,4 +209,29 @@ contract InterestRateModelV2Test is Test, InterestRateModelConfigs {
         assertEq(rcomp1, rcomp2, "expect exact rcomp value");
         assertEq(overflow1, overflow2, "expect exact overflow value");
     }
+
+    /*
+    forge test -vv --mt test_IRM_configOverflowCheck
+    */
+    /// forge-config: core-test.fuzz.runs = 10000
+    function test_IRM_configOverflowCheck(int112 _Tcrit, int112 _ri) public {
+        vm.assume(_Tcrit > 0);
+        vm.assume(_ri > 0);
+
+        IInterestRateModelV2.Config memory config = IInterestRateModelV2.Config({
+            uopt: 300000000000000000,
+            ucrit: 500000000000000000,
+            ulow: 700000000000000000,
+            ki: 1761655,
+            kcrit: 63419583967,
+            klow: 3170979198,
+            klin: 634195839,
+            beta: 69444444444444,
+            ri: _ri,
+            Tcrit: _Tcrit
+        });
+
+        InterestRateModelV2 impl = new InterestRateModelV2();
+        impl.configOverflowCheck(config);
+    }
 }

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
@@ -95,9 +95,17 @@ contract InterestRateModelV2FactoryTest is Test, InterestRateModelConfigs {
         config.ri = -1;
         vm.expectRevert(IInterestRateModelV2.InvalidRi.selector);
         factory.verifyConfig(config);
-        config.ri = type(int112).max; // valid
+
+        config.ri = 2 ** 46;
+        vm.expectRevert(IInterestRateModelV2.InvalidRi.selector);
+        factory.verifyConfig(config);
+        config.ri = 2 ** 46 - 1; // valid
 
         config.Tcrit = -1;
+        vm.expectRevert(IInterestRateModelV2.InvalidTcrit.selector);
+        factory.verifyConfig(config);
+
+        config.Tcrit = type(int112).max + 1;
         vm.expectRevert(IInterestRateModelV2.InvalidTcrit.selector);
         factory.verifyConfig(config);
         config.Tcrit = type(int112).max; // valid

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
@@ -90,8 +90,18 @@ contract InterestRateModelV2FactoryTest is Test, InterestRateModelConfigs {
         config.beta = -1;
         vm.expectRevert(IInterestRateModelV2.InvalidBeta.selector);
         factory.verifyConfig(config);
-
         config.beta = 1;
+
+        config.ri = -1;
+        vm.expectRevert(IInterestRateModelV2.InvalidRi.selector);
+        factory.verifyConfig(config);
+        config.ri = type(int112).max; // valid
+
+        config.Tcrit = -1;
+        vm.expectRevert(IInterestRateModelV2.InvalidTcrit.selector);
+        factory.verifyConfig(config);
+        config.Tcrit = type(int112).max; // valid
+
         factory.verifyConfig(config);
 
         factory.verifyConfig(_defaultConfig());

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
@@ -95,17 +95,9 @@ contract InterestRateModelV2FactoryTest is Test, InterestRateModelConfigs {
         config.ri = -1;
         vm.expectRevert(IInterestRateModelV2.InvalidRi.selector);
         factory.verifyConfig(config);
-
-        config.ri = 2 ** 46;
-        vm.expectRevert(IInterestRateModelV2.InvalidRi.selector);
-        factory.verifyConfig(config);
         config.ri = 2 ** 46 - 1; // valid
 
         config.Tcrit = -1;
-        vm.expectRevert(IInterestRateModelV2.InvalidTcrit.selector);
-        factory.verifyConfig(config);
-
-        config.Tcrit = type(int112).max + 1;
         vm.expectRevert(IInterestRateModelV2.InvalidTcrit.selector);
         factory.verifyConfig(config);
         config.Tcrit = type(int112).max; // valid


### PR DESCRIPTION
- we added method that can detect overflow in next 50y, 50y is arbitrary
- factory will check config for overflow using that new method
- tests for overflow added
- this PR was team work together with researchers, [see on slack](https://joinsilo.slack.com/archives/C055E7QDA1K/p1733239902901159)