### PR TITLE
silo-core: support for deployed oracle

### DIFF
--- a/silo-core/common/SiloCoreContracts.sol
+++ b/silo-core/common/SiloCoreContracts.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.7.6 <0.9.0;
 
 import {Deployments} from "silo-foundry-utils/lib/Deployments.sol";
+import {Strings} from "openzeppelin5/utils/Strings.sol";
 
 library SiloCoreContracts {
     // smart contracts list
@@ -30,5 +31,79 @@ library SiloCoreDeployments {
 
     function get(string memory _contract, string memory _network) internal returns (address) {
         return Deployments.getAddress(DEPLOYMENTS_DIR, _network, _contract);
+    }
+
+    function isFixedAddress(string memory _string) internal pure returns (address fixedAddress) {
+        if (bytes(_string).length != 42) return address(0);
+
+        bytes32 ox = keccak256(bytes("0x"));
+        bytes32 twoChars = keccak256(abi.encodePacked(bytes(_string)[0], bytes(_string)[1]));
+
+        if (ox != twoChars) return address(0);
+
+        (bool success, uint256 value) = _tryParseHexUintUncheckedBounds(_string, 0, 42);
+        if (!success) return address(0);
+
+        return address(uint160(value));
+    }
+
+    /**
+     * @dev Implementation of {tryParseHexUint} that does not check bounds. Caller should make sure that
+     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.
+     */
+    function _tryParseHexUintUncheckedBounds(
+        string memory input,
+        uint256 begin,
+        uint256 end
+    ) private pure returns (bool success, uint256 value) {
+        bytes memory buffer = bytes(input);
+
+        // skip 0x prefix if present
+        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2("0x"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty
+        uint256 offset = hasPrefix ? 2 : 0;
+
+        uint256 result = 0;
+        for (uint256 i = begin + offset; i < end; ++i) {
+            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));
+            if (chr > 15) return (false, 0);
+            result *= 16;
+            unchecked {
+            // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).
+            // This guaratees that adding a value < 16 will not cause an overflow, hence the unchecked.
+                result += chr;
+            }
+        }
+        return (true, result);
+    }
+
+    function _tryParseChr(bytes1 chr) private pure returns (uint8) {
+        uint8 value = uint8(chr);
+
+        // Try to parse `chr`:
+        // - Case 1: [0-9]
+        // - Case 2: [a-f]
+        // - Case 3: [A-F]
+        // - otherwise not supported
+        unchecked {
+            if (value > 47 && value < 58) value -= 48;
+            else if (value > 96 && value < 103) value -= 87;
+            else if (value > 64 && value < 71) value -= 55;
+            else return type(uint8).max;
+        }
+
+        return value;
+    }
+
+    /**
+     * @dev Reads a bytes32 from a bytes array without bounds checking.
+     *
+     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the
+     * assembly block as such would prevent some optimizations.
+     */
+    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {
+        // This is not memory safe in the general case, but all calls to this private function are within bounds.
+        assembly ("memory-safe") {
+            value := mload(add(buffer, add(0x20, offset)))
+        }
     }
 }

--- a/silo-core/common/SiloCoreContracts.sol
+++ b/silo-core/common/SiloCoreContracts.sol
@@ -33,7 +33,7 @@ library SiloCoreDeployments {
         return Deployments.getAddress(DEPLOYMENTS_DIR, _network, _contract);
     }
 
-    function isFixedAddress(string memory _string) internal pure returns (address fixedAddress) {
+    function parseAddress(string memory _string) internal pure returns (address fixedAddress) {
         if (bytes(_string).length != 42) return address(0);
 
         bytes32 ox = keccak256(bytes("0x"));

--- a/silo-core/contracts/SiloDeployer.sol
+++ b/silo-core/contracts/SiloDeployer.sol
@@ -160,6 +160,8 @@ contract SiloDeployer is ISiloDeployer {
     /// @notice Create an oracle
     /// @param _txData Oracle creation details (factory and creation tx input)
     function _createOracle(OracleCreationTxData memory _txData) internal returns (address _oracle) {
+        if (_txData.deployed != address(0)) return _txData.deployed;
+
         address factory = _txData.factory;
 
         if (factory == address(0)) return address(0);

--- a/silo-core/contracts/interfaces/ISiloDeployer.sol
+++ b/silo-core/contracts/interfaces/ISiloDeployer.sol
@@ -8,6 +8,7 @@ import {ISiloConfig} from "./ISiloConfig.sol";
 interface ISiloDeployer {
     /// @dev Details of the oracle creation transaction
     struct OracleCreationTxData {
+        address deployed; // if oracle is already deployed, this will be the address to use
         address factory; // oracle factory (chainlinkV3, uniswapV3, etc)
         bytes txInput; // fn input `abi.encodeCall(fn, params...)`
     }

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -188,7 +188,15 @@ contract SiloDeploy is CommonDeploy {
             return _diaTxData(_oracleConfigName);
         }
 
-        address deployed = OraclesDeployments.get(ChainsLib.chainAlias(), _oracleConfigName);
+        address deployed = _isFixedAddress(_oracleConfigName);
+
+        if (deployed != address(0)) {
+            txData.deployed = deployed;
+            console2.log("using already deployed oracle with fixed address: %s", _oracleConfigName, deployed);
+            return txData;
+        }
+
+        deployed = OraclesDeployments.get(ChainsLib.chainAlias(), _oracleConfigName);
 
         if (deployed != address(0)) {
             txData.deployed = deployed;
@@ -289,6 +297,17 @@ contract SiloDeploy is CommonDeploy {
         );
 
         isDiaOracle = diaOracle != address(0);
+    }
+
+    function _isFixedAddress(string memory _oracleConfigName) internal pure returns (address fixedAddress) {
+        bytes32 ox = keccak256(bytes("0x"));
+        bytes32 twoChars = keccak256(abi.encodePacked(bytes(_oracleConfigName)[0], bytes(_oracleConfigName)[1]));
+
+        if (ox == twoChars && bytes(_oracleConfigName).length == 42) {
+            fixedAddress = address(bytes20(bytes(_oracleConfigName)));
+        }
+
+        return fixedAddress;
     }
 
     function beforeCreateSilo(

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -188,7 +188,7 @@ contract SiloDeploy is CommonDeploy {
             return _diaTxData(_oracleConfigName);
         }
 
-        address deployed = SiloCoreDeployments.isFixedAddress(_oracleConfigName);
+        address deployed = SiloCoreDeployments.parseAddress(_oracleConfigName);
 
         if (deployed != address(0)) {
             txData.deployed = deployed;

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -188,6 +188,14 @@ contract SiloDeploy is CommonDeploy {
             return _diaTxData(_oracleConfigName);
         }
 
+        address deployed = OraclesDeployments.get(ChainsLib.chainAlias(), _oracleConfigName);
+
+        if (deployed != address(0)) {
+            txData.deployed = deployed;
+            console2.log("using already deployed oracle %s: %s", _oracleConfigName, deployed);
+            return txData;
+        }
+
         revert("[_getOracleTxData] unknown oracle type");
     }
 

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -7,7 +7,7 @@ import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
 import {IERC20Metadata} from "openzeppelin5/token/ERC20/extensions/IERC20Metadata.sol";
 
 import {CommonDeploy} from "../_CommonDeploy.sol";
-import {SiloCoreContracts} from "silo-core/common/SiloCoreContracts.sol";
+import {SiloCoreContracts, SiloCoreDeployments} from "silo-core/common/SiloCoreContracts.sol";
 import {IInterestRateModelV2} from "silo-core/contracts/interfaces/IInterestRateModelV2.sol";
 import {InterestRateModelConfigData} from "../input-readers/InterestRateModelConfigData.sol";
 import {SiloConfigData, ISiloConfig} from "../input-readers/SiloConfigData.sol";
@@ -188,7 +188,7 @@ contract SiloDeploy is CommonDeploy {
             return _diaTxData(_oracleConfigName);
         }
 
-        address deployed = _isFixedAddress(_oracleConfigName);
+        address deployed = SiloCoreDeployments.isFixedAddress(_oracleConfigName);
 
         if (deployed != address(0)) {
             txData.deployed = deployed;
@@ -297,17 +297,6 @@ contract SiloDeploy is CommonDeploy {
         );
 
         isDiaOracle = diaOracle != address(0);
-    }
-
-    function _isFixedAddress(string memory _oracleConfigName) internal pure returns (address fixedAddress) {
-        bytes32 ox = keccak256(bytes("0x"));
-        bytes32 twoChars = keccak256(abi.encodePacked(bytes(_oracleConfigName)[0], bytes(_oracleConfigName)[1]));
-
-        if (ox == twoChars && bytes(_oracleConfigName).length == 42) {
-            fixedAddress = address(bytes20(bytes(_oracleConfigName)));
-        }
-
-        return fixedAddress;
     }
 
     function beforeCreateSilo(

--- a/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
+++ b/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
@@ -41,13 +41,33 @@ contract SiloCoreDeploymentsTest is SiloLittleHelper, Test {
         assertEq(addr, 0xb720078680Dc65B54568673410aBb81195E08122, "expect valid address on Arbitrum");
     }
 
-   function test_get_contractNotExists() public {
+    function test_get_contractNotExists() public {
        address addr = SiloCoreDeployments.get("not.exist", ChainsLib.OPTIMISM_ALIAS);
        assertEq(addr, address(0), "expect to return 0");
-   }
+    }
 
-   function test_get_invalidNetwork() public {
+    function test_get_invalidNetwork() public {
        address addr = SiloCoreDeployments.get(SiloCoreContracts.SILO_FACTORY, "abcd");
        assertEq(addr, address(0), "expect to return 0");
-   }
+    }
+
+    /*
+    forge test -vv --ffi --mt test_isFixedAddress
+    */
+    function test_isFixedAddress() public {
+        assertEq(SiloCoreDeployments.isFixedAddress(""), address(0), "empty string");
+        assertEq(SiloCoreDeployments.isFixedAddress("0x"), address(0), "0x string");
+
+        assertEq(
+            SiloCoreDeployments.isFixedAddress("0xb720078680Dc65B54568673410aBb81195E0812"),
+            address(0),
+            "not an address"
+        );
+
+        assertEq(
+            SiloCoreDeployments.isFixedAddress("0xb720078680Dc65B54568673410aBb81195E08122"),
+            address(0xb720078680Dc65B54568673410aBb81195E08122),
+            "0x string"
+        );
+    }
 }

--- a/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
+++ b/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
@@ -52,20 +52,20 @@ contract SiloCoreDeploymentsTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_isFixedAddress
+    forge test -vv --ffi --mt test_parseAddress
     */
-    function test_isFixedAddress() public {
-        assertEq(SiloCoreDeployments.isFixedAddress(""), address(0), "empty string");
-        assertEq(SiloCoreDeployments.isFixedAddress("0x"), address(0), "0x string");
+    function test_parseAddress() public {
+        assertEq(SiloCoreDeployments.parseAddress(""), address(0), "empty string");
+        assertEq(SiloCoreDeployments.parseAddress("0x"), address(0), "0x string");
 
         assertEq(
-            SiloCoreDeployments.isFixedAddress("0xb720078680Dc65B54568673410aBb81195E0812"),
+            SiloCoreDeployments.parseAddress("0xb720078680Dc65B54568673410aBb81195E0812"),
             address(0),
             "not an address"
         );
 
         assertEq(
-            SiloCoreDeployments.isFixedAddress("0xb720078680Dc65B54568673410aBb81195E08122"),
+            SiloCoreDeployments.parseAddress("0xb720078680Dc65B54568673410aBb81195E08122"),
             address(0xb720078680Dc65B54568673410aBb81195E08122),
             "0x string"
         );


### PR DESCRIPTION
This change allow us to use already deployed oracle without a need to create factory for each case.