### PR TITLE
silo-core: prevent empty share token on gauge like incentives controller

### DIFF
--- a/silo-core/contracts/incentives/SiloIncentivesControllerGaugeLike.sol
+++ b/silo-core/contracts/incentives/SiloIncentivesControllerGaugeLike.sol
@@ -25,6 +25,8 @@ contract SiloIncentivesControllerGaugeLike is SiloIncentivesController, IGauge {
         address _notifier,
         address _siloShareToken
     ) SiloIncentivesController(_owner, _notifier) {
+        require(_siloShareToken != address(0), EmptyShareToken());
+
         SHARE_TOKEN = _siloShareToken;
     }
 

--- a/silo-core/contracts/interfaces/IGaugeLike.sol
+++ b/silo-core/contracts/interfaces/IGaugeLike.sol
@@ -5,6 +5,8 @@ interface IGaugeLike {
     event GaugeKilled();
     event GaugeUnKilled();
 
+    error EmptyShareToken();
+
     function afterTokenTransfer(
         address _sender,
         uint256 _senderBalance,
@@ -22,6 +24,7 @@ interface IGaugeLike {
 
     // solhint-disable func-name-mixedcase
     function share_token() external view returns (address);
+
     function is_killed() external view returns (bool);
     // solhint-enable func-name-mixedcase
 }

--- a/silo-core/test/foundry/Silo/hooks/SiloBeforeHooksTest.t.sol
+++ b/silo-core/test/foundry/Silo/hooks/SiloBeforeHooksTest.t.sol
@@ -63,7 +63,7 @@ contract HookReceiver is IHookReceiver, Test {
         imIn = false;
     }
 
-    function afterAction(address, uint256, bytes calldata) external {
+    function afterAction(address, uint256, bytes calldata) external pure {
         revert("not in use");
     }
 

--- a/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
+++ b/silo-core/test/foundry/common/SiloCoreDeployments.i.sol
@@ -54,7 +54,7 @@ contract SiloCoreDeploymentsTest is SiloLittleHelper, Test {
     /*
     forge test -vv --ffi --mt test_parseAddress
     */
-    function test_parseAddress() public {
+    function test_parseAddress() public pure {
         assertEq(SiloCoreDeployments.parseAddress(""), address(0), "empty string");
         assertEq(SiloCoreDeployments.parseAddress("0x"), address(0), "0x string");
 

--- a/silo-core/test/foundry/incentives/SiloIncentivesController.i.sol
+++ b/silo-core/test/foundry/incentives/SiloIncentivesController.i.sol
@@ -42,7 +42,8 @@ contract HookContract {
         return notifierToken.balanceOf(_user);
     }
 
-    function hookReceiverConfig(address) external view returns (uint24 hooksBefore, uint24 hooksAfter) {
+    function hookReceiverConfig(address) external pure returns (uint24 hooksBefore, uint24 hooksAfter) {
+        hooksBefore = 0;
         hooksAfter = uint24(Hook.SHARE_TOKEN_TRANSFER | Hook.COLLATERAL_TOKEN);
     }
 
@@ -431,8 +432,6 @@ contract SiloIncentivesControllerIntegrationTest is SiloLittleHelper, Test {
 
         vm.prank(user1);
         _controller.claimRewards(user1);
-
-        uint256 totalRewards = emissionPerSecond * 100 + immediateDistribution;
 
         assertEq(
             _rewardToken.balanceOf(user1),

--- a/silo-core/test/foundry/incentives/SiloIncentivesControllerGaugeLike.t.sol
+++ b/silo-core/test/foundry/incentives/SiloIncentivesControllerGaugeLike.t.sol
@@ -54,6 +54,14 @@ contract SiloIncentivesControllerGaugeLikeTest is SiloLittleHelper, Test {
     }
 
     /**
+     FOUNDRY_PROFILE=core-test forge test -vvv --ffi --mt test_createGaugeLike_zeroShares
+     */
+    function test_createGaugeLike_zeroShares() public {
+        vm.expectRevert(IGauge.EmptyShareToken.selector);
+        _factory.createGaugeLike(_owner, _notifier, address(0));
+    }
+
+    /**
      FOUNDRY_PROFILE=core-test forge test -vvv --ffi --mt test_killGauge_onlyOwner
      */
     function test_killGauge_onlyOwner() public {

--- a/silo-vaults/test/foundry/incentives/VaultMultipleRewards.i.sol
+++ b/silo-vaults/test/foundry/incentives/VaultMultipleRewards.i.sol
@@ -76,13 +76,13 @@ contract VaultMultipleRewardsTest is IntegrationTest {
         _setupIncentivesContracts();
     }
 
-    function _overrideTestAddresses() internal returns (address siloWithIncentives) {
-        siloWithIncentives = address(allMarkets[2]);
-        silo1 = ISilo(siloWithIncentives);
-        silo0 = ISilo(address(collateralMarkets[IERC4626(siloWithIncentives)]));
+    function _overrideTestAddresses() internal returns (address incentiviseSilo) {
+        incentiviseSilo = address(allMarkets[2]);
+        silo1 = ISilo(incentiviseSilo);
+        silo0 = ISilo(address(collateralMarkets[IERC4626(incentiviseSilo)]));
 
-        siloConfig = ISilo(siloWithIncentives).config();
-        ISiloConfig.ConfigData memory cfg = siloConfig.getConfig(siloWithIncentives);
+        siloConfig = ISilo(incentiviseSilo).config();
+        ISiloConfig.ConfigData memory cfg = siloConfig.getConfig(incentiviseSilo);
         // TODO add test with missconfiguration
         partialLiquidation = IPartialLiquidation(cfg.hookReceiver);
     }
@@ -121,7 +121,6 @@ contract VaultMultipleRewardsTest is IntegrationTest {
         assertEq(IShareToken(siloWithIncentives).totalSupply(), 0, "deposit did not reached silo");
 
         // standard program for silo users
-        // TODO test for distributionEnd: current and past
         siloIncentivesController.createIncentivesProgram(DistributionTypes.IncentivesProgramCreationInput({
             name: "x",
             rewardToken: address(reward1),

--- a/silo-vaults/test/foundry/incentives/VaultsSiloIncentives.i.sol
+++ b/silo-vaults/test/foundry/incentives/VaultsSiloIncentives.i.sol
@@ -12,9 +12,9 @@ import {CAP} from "../helpers/BaseTest.sol";
 
 
 /*
- FOUNDRY_PROFILE=vaults-tests forge test --ffi --mc SiloVaultIncentivesTest -vvv
+ FOUNDRY_PROFILE=vaults-tests forge test --ffi --mc VaultsSiloIncentivesTest -vvv
 */
-contract SiloVaultIncentivesTest is IntegrationTest {
+contract VaultsSiloIncentivesTest is IntegrationTest {
     MintableToken reward1 = new MintableToken(18);
 
     SiloIncentivesController vaultIncentivesController;


### PR DESCRIPTION
additional tests for silo vaults with incentives