### PR TITLE
silo-vaults: addressed todos

### DIFF
--- a/silo-vaults/contracts/libraries/ConstantsLib.sol
+++ b/silo-vaults/contracts/libraries/ConstantsLib.sol
@@ -11,10 +11,10 @@ library ConstantsLib {
     uint256 internal constant MAX_TIMELOCK = 2 weeks;
 
     /// @dev The minimum delay of a timelock.
-    uint256 internal constant MIN_TIMELOCK = 1 minutes;
+    uint256 internal constant MIN_TIMELOCK = 1 days;
 
     /// @dev The maximum number of markets in the supply/withdraw queue.
-    uint256 internal constant MAX_QUEUE_LENGTH = 5; // TODO revert after debuggind
+    uint256 internal constant MAX_QUEUE_LENGTH = 30;
 
     /// @dev The maximum fee the vault can have (50%).
     uint256 internal constant MAX_FEE = 0.5e18;

--- a/silo-vaults/test/foundry/ERC4626ComplianceTest.sol
+++ b/silo-vaults/test/foundry/ERC4626ComplianceTest.sol
@@ -7,7 +7,6 @@ import {IntegrationTest} from "./helpers/IntegrationTest.sol";
 
 /*
  FOUNDRY_PROFILE=vaults-tests forge test --ffi --mc ERC4626ComplianceTest -vvv
- TODO apply for silo-core?
 */
 contract ERC4626ComplianceTest is IntegrationTest, ERC4626Test {
     function setUp() public override(IntegrationTest, ERC4626Test) {


### PR DESCRIPTION
`SiloVault`
119: // TODO use 2stepOwnable
793: // TODO change it to safeApproval, maybe this can be removed
799: // TODO change it to forceApproval (or safeApproval)
946: // TODO make this external call
`ConstansLib`
14: // TODO revert to original value