### PR TITLE
silo-3496 addressing comments

### DIFF
--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -139,8 +139,8 @@ library Actions {
 
     /// @notice Allows an address to borrow a specified amount of assets
     /// @param _args Contains the borrowing parameters:
-    /// - `assets`: Number of assets the borrower intends to borrow
-    /// - `shares`: Number of shares corresponding to the assets being borrowed
+    /// - `assets`: Number of assets the borrower intends to borrow (0 if `_shares` specified)
+    /// - `shares`: Number of shares corresponding to the assets being borrowed (0 if `_assets` specified)
     /// - `receiver`: Address receiving the borrowed assets
     /// - `borrower`: Address of the borrower
     /// @return assets Amount of assets borrowed

--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -255,7 +255,7 @@ library Actions {
             IHookReceiver(_shareStorage.hookSetup.hookReceiver).afterAction(address(this), Hook.REPAY, data);
         }
     }
-    /// @notice Transitions assets between borrowable (collateral) and non-borrowable (protected) states
+    /// @notice Transitions assets between collateral (borrowable) and protected (non-borrowable) states
     /// @dev This method allows assets to switch states without leaving the protocol
     /// @param _args Contains the transition parameters:
     /// - `shares`: Amount of shares to transition

--- a/silo-core/contracts/lib/Actions.sol
+++ b/silo-core/contracts/lib/Actions.sol
@@ -50,10 +50,10 @@ library Actions {
 
     /// @notice Implements IERC4626.deposit for protected (non-borrowable) and borrowable collateral
     /// @dev Reverts for debt asset type
-    /// @param _assets Amount of assets to deposit (must be > 0)
-    /// @param _shares Minimum shares expected for the deposit (optional, can be 0)
+    /// @param _assets Amount of assets to deposit (0 if `_shares` specified)
+    /// @param _shares shares expected for the deposit  (0 if `_assets` specified)
     /// @param _receiver Address to receive the deposit shares
-    /// @param _collateralType Type of collateral (Protected or Borrowable)
+    /// @param _collateralType Type of collateral (Protected or Collateral)
     /// @return assets Amount of assets deposited
     /// @return shares Amount of shares minted due to deposit
     function deposit(

--- a/silo-core/contracts/lib/Hook.sol
+++ b/silo-core/contracts/lib/Hook.sol
@@ -217,7 +217,7 @@ library Hook {
     /// `matchAction(WITHDRAW | COLLATERAL_TOKEN, COLLATERAL_TOKEN) == true`
     /// `matchAction(WITHDRAW | COLLATERAL_TOKEN, WITHDRAW | COLLATERAL_TOKEN) == true`
     function matchAction(uint256 _action, uint256 _expectedHook) internal pure returns (bool) {
-        return _action & _expectedHook == _expectedHook;
+        return (_action & _expectedHook) == _expectedHook;
     }
 
     /// @notice Adds a hook to an action

--- a/silo-core/contracts/lib/Rounding.sol
+++ b/silo-core/contracts/lib/Rounding.sol
@@ -5,30 +5,30 @@ import {Math} from "openzeppelin5/utils/math/Math.sol";
 
 // solhint-disable private-vars-leading-underscore
 library Rounding {
-    Math.Rounding internal constant UP = (Math.Rounding.Ceil);
-    Math.Rounding internal constant DOWN = (Math.Rounding.Floor);
-    Math.Rounding internal constant DEBT_TO_ASSETS = (Math.Rounding.Ceil);
+    Math.Rounding internal constant UP = Math.Rounding.Ceil;
+    Math.Rounding internal constant DOWN = Math.Rounding.Floor;
+    Math.Rounding internal constant DEBT_TO_ASSETS = Math.Rounding.Ceil;
     // COLLATERAL_TO_ASSETS is used to calculate borrower collateral (so we want to round down)
-    Math.Rounding internal constant COLLATERAL_TO_ASSETS = (Math.Rounding.Floor);
+    Math.Rounding internal constant COLLATERAL_TO_ASSETS = Math.Rounding.Floor;
     // why DEPOSIT_TO_ASSETS is Up if COLLATERAL_TO_ASSETS is Down?
     // DEPOSIT_TO_ASSETS is used for preview deposit and deposit, based on provided shares we want to pull "more" tokens
     // so we rounding up, "token flow" is in different direction than for COLLATERAL_TO_ASSETS, that's why
     // different rounding policy
-    Math.Rounding internal constant DEPOSIT_TO_ASSETS = (Math.Rounding.Ceil);
-    Math.Rounding internal constant DEPOSIT_TO_SHARES = (Math.Rounding.Floor);
-    Math.Rounding internal constant BORROW_TO_ASSETS = (Math.Rounding.Floor);
-    Math.Rounding internal constant BORROW_TO_SHARES = (Math.Rounding.Ceil);
-    Math.Rounding internal constant MAX_BORROW_TO_ASSETS = (Math.Rounding.Floor);
-    Math.Rounding internal constant MAX_BORROW_TO_SHARES = (Math.Rounding.Floor);
-    Math.Rounding internal constant MAX_BORROW_VALUE = (Math.Rounding.Floor);
-    Math.Rounding internal constant REPAY_TO_ASSETS = (Math.Rounding.Ceil);
-    Math.Rounding internal constant REPAY_TO_SHARES = (Math.Rounding.Floor);
-    Math.Rounding internal constant MAX_REPAY_TO_ASSETS = (Math.Rounding.Ceil);
-    Math.Rounding internal constant WITHDRAW_TO_ASSETS = (Math.Rounding.Floor);
-    Math.Rounding internal constant WITHDRAW_TO_SHARES = (Math.Rounding.Ceil);
-    Math.Rounding internal constant MAX_WITHDRAW_TO_ASSETS = (Math.Rounding.Floor);
-    Math.Rounding internal constant MAX_WITHDRAW_TO_SHARES = (Math.Rounding.Floor);
-    Math.Rounding internal constant LIQUIDATE_TO_SHARES = (Math.Rounding.Floor);
-    Math.Rounding internal constant LTV = (Math.Rounding.Ceil);
-    Math.Rounding internal constant ACCRUED_INTEREST = (Math.Rounding.Floor);
+    Math.Rounding internal constant DEPOSIT_TO_ASSETS = Math.Rounding.Ceil;
+    Math.Rounding internal constant DEPOSIT_TO_SHARES = Math.Rounding.Floor;
+    Math.Rounding internal constant BORROW_TO_ASSETS = Math.Rounding.Floor;
+    Math.Rounding internal constant BORROW_TO_SHARES = Math.Rounding.Ceil;
+    Math.Rounding internal constant MAX_BORROW_TO_ASSETS = Math.Rounding.Floor;
+    Math.Rounding internal constant MAX_BORROW_TO_SHARES = Math.Rounding.Floor;
+    Math.Rounding internal constant MAX_BORROW_VALUE = Math.Rounding.Floor;
+    Math.Rounding internal constant REPAY_TO_ASSETS = Math.Rounding.Ceil;
+    Math.Rounding internal constant REPAY_TO_SHARES = Math.Rounding.Floor;
+    Math.Rounding internal constant MAX_REPAY_TO_ASSETS = Math.Rounding.Ceil;
+    Math.Rounding internal constant WITHDRAW_TO_ASSETS = Math.Rounding.Floor;
+    Math.Rounding internal constant WITHDRAW_TO_SHARES = Math.Rounding.Ceil;
+    Math.Rounding internal constant MAX_WITHDRAW_TO_ASSETS = Math.Rounding.Floor;
+    Math.Rounding internal constant MAX_WITHDRAW_TO_SHARES = Math.Rounding.Floor;
+    Math.Rounding internal constant LIQUIDATE_TO_SHARES = Math.Rounding.Floor;
+    Math.Rounding internal constant LTV = Math.Rounding.Ceil;
+    Math.Rounding internal constant ACCRUED_INTEREST = Math.Rounding.Floor;
 }

--- a/silo-core/contracts/lib/ShareCollateralTokenLib.sol
+++ b/silo-core/contracts/lib/ShareCollateralTokenLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
 import {ISilo} from "../interfaces/ISilo.sol";

--- a/silo-core/contracts/utils/liquidationHelper/DexSwap.sol
+++ b/silo-core/contracts/utils/liquidationHelper/DexSwap.sol
@@ -27,7 +27,6 @@ contract DexSwap {
     }
 
     /// @dev Swaps ERC20->ERC20 tokens held by this contract using a 0x-API quote.
-    /// Must attach ETH equal to the `value` field from the API response.
     /// @param _sellToken The `sellTokenAddress` field from the API response.
     /// @param _spender The `allowanceTarget` field from the API response.
     /// @param _swapCallData The `data` field from the API response.

--- a/silo-core/contracts/utils/liquidationHelper/LiquidationHelper.sol
+++ b/silo-core/contracts/utils/liquidationHelper/LiquidationHelper.sol
@@ -35,6 +35,7 @@ contract LiquidationHelper is ILiquidationHelper, IERC3156FlashBorrower, DexSwap
 
     error NoDebtToCover();
     error STokenNotSupported();
+    error ZeroAddress();
 
     /// @param _nativeToken address of wrapped native blockchain token eg. WETH on Ethereum
     /// @param _exchangeProxy exchange address, where to send swap data on liquidation
@@ -44,6 +45,10 @@ contract LiquidationHelper is ILiquidationHelper, IERC3156FlashBorrower, DexSwap
         address _exchangeProxy,
         address payable _tokensReceiver
     ) DexSwap(_exchangeProxy) {
+        require(_nativeToken != address(0), ZeroAddress());
+        require(_exchangeProxy != address(0), ZeroAddress());
+        require(address(_tokensReceiver) != address(0), ZeroAddress());
+
         NATIVE_TOKEN = _nativeToken;
         EXCHANGE_PROXY = _exchangeProxy;
         TOKENS_RECEIVER = _tokensReceiver;

--- a/silo-core/deploy/LiquidationHelperDeploy.s.sol
+++ b/silo-core/deploy/LiquidationHelperDeploy.s.sol
@@ -26,7 +26,7 @@ contract LiquidationHelperDeploy is CommonDeploy {
     address constant EXCHANGE_PROXY_1INCH = 0x1111111254EEB25477B68fb85Ed929f73A960582;
     address constant ODOS_ROUTER_SONIC = 0xaC041Df48dF9791B0654f1Dbbf2CC8450C5f2e9D;
 
-    address payable constant GNOSIS_SAFE_MAINNET = payable(0); // placeholder for integration tests
+    address payable constant GNOSIS_SAFE_MAINNET = payable(address(1)); // placeholder for integration tests
     address payable constant GNOSIS_SAFE_ARB = payable(0x865A1DA42d512d8854c7b0599c962F67F5A5A9d9);
     address payable constant GNOSIS_SAFE_OP = payable(0x468CD12aa9e9fe4301DB146B0f7037831B52382d);
     address payable constant GNOSIS_SAFE_SONIC = payable(0x7461d8c0fDF376c847b651D882DEa4C73fad2e4B);
@@ -40,7 +40,7 @@ contract LiquidationHelperDeploy is CommonDeploy {
 
         console2.log("[LiquidationHelperDeploy] nativeToken(): ", nativeToken);
         console2.log("[LiquidationHelperDeploy] exchangeProxy: ", exchangeProxy);
-        console2.log("[LiquidationHelperDeploy] tokensReceiver: ", tokenReceiver);
+        console2.log("[LiquidationHelperDeploy] tokenReceiver: ", tokenReceiver);
 
         vm.startBroadcast(deployerPrivateKey);
 

--- a/silo-core/test/foundry/gas/Deposit1st.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit1st.gas.sol
@@ -24,7 +24,7 @@ contract Deposit1stGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "Deposit1st ever",
-            168127
+            167938
         );
     }
 }

--- a/silo-core/test/foundry/gas/Deposit2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit2nd.gas.sol
@@ -24,7 +24,7 @@ contract Deposit2ndGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "Deposit2nd (no interest)",
-            79498
+            79359
         );
     }
 }

--- a/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract DepositAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.deposit, (ASSETS, DEPOSITOR, ISilo.CollateralType.Collateral)),
             "DepositAccrueInterest",
-            133945
+            133837
         );
     }
 }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -40,7 +40,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 (address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            465760
+            465602
         );
     }
 }

--- a/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
@@ -32,7 +32,7 @@ contract TransitionCollateralTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.transitionCollateral, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "transitionCollateral (when debt)",
-            292922 // 74K for interest
+            292682 // 74K for interest
         );
     }
 }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -32,7 +32,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.CollateralType.Collateral)),
             "Withdraw partial with accrue interest",
-            204226
+            204086
         );
     }
 }


### PR DESCRIPTION
1. Possible Zero Address For Immutable Variables DONE
2. TODO Comment In Production Code - deprecated, already removed
3. Mismatch between comment and code - DONE
4. code consistency in SiloConfig - **NOT done**, imp using silo address is more clear
5. Missing Parentheses in Hook - DONE
6. Lack Of NatSpec Comments in Actions DONE
7. Unnecessary Use of Parentheses in Rounding DONE
8. Invalid SPDX License DONE
9. Repetitive Conversion Of Asset Type DONE
10. isBelowMaxLTV - **NOT done**, we will have to adjust a lot of test by `-1`. it is just easier to have `<=`
11. Caching decimals - deprecated, decimals was removed
12. Potentially Inaccurate hooksBefore - separate [PR](https://github.com/silo-finance/silo-contracts-v2/pull/1022)
13. Data Type Mismatch Related Asset(s): SiloHookReceiver.sol - separate [PR](https://github.com/silo-finance/silo-contracts-v2/pull/1022)