### PR TITLE
silo-3527: detect asset loss

### DIFF
--- a/silo-vaults/contracts/libraries/ErrorsLib.sol
+++ b/silo-vaults/contracts/libraries/ErrorsLib.sol
@@ -139,4 +139,7 @@ library ErrorsLib {
 
     /// @notice Thrown when attempting to supply more than the max inflow of a market.
     error MaxInflowExceeded(IERC4626 market);
+
+    /// @notice Thrown when projected withdraw is much less than what user deposit.
+    error AssetLoss(uint256 loss);
 }


### PR DESCRIPTION
Fixes: silo-3527

Total fixes for silo-3527
- [x] decimals offset for idle vault
- [x] **detect asset loss - this PR**
- [ ] adjust CAP flow