### PR TITLE
silo-core: count for fractions when calculate maxBorrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- silo-core: count for fractions when calculate maxBorrow
 
 ## [3.2.0] - 2025-04-30
 - Revert "silo-vaults: deployment sonic 1 min timelock"

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -365,8 +365,8 @@ library SiloLendingLib {
         assets = _maxBorrowValue.mulDiv(debtTokenSample, debtSampleValue, Rounding.MAX_BORROW_TO_ASSETS);
 
         if (assets != 0) {
-            // When we are calculating fractions it is possible that integral revenue and interest are 1.
-            // In this case total debt assets will be increased by 1 and collateral will stay the same.
+            // When we are calculating fractions it is possible that total debt assets will be increased by 1.
+            // Which can lead to the to revert on LTV check. To avoid this we underestimate assets.
             unchecked { assets--; }
         }
 

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -256,7 +256,7 @@ library SiloLendingLib {
 
         if (assets == 0 || shares == 0) return (0, 0);
 
-        uint256 liquidityWithInterest = getLiquidity(_siloConfig) - 1;
+        uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
         if (liquidityWithInterest != 0) {
             // we need to count for fractions, when fractions are applied liquidity is decreased

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -258,7 +258,7 @@ library SiloLendingLib {
 
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
-        if (liquidityWithInterest != 0) {
+        if (liquidityWithInterest != 0 && _totalDebtAssets < _ROUNDING_THRESHOLD) {
             // we need to count for fractions, when fractions are applied liquidity is decreased
             unchecked { liquidityWithInterest--; }
         }

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -258,8 +258,10 @@ library SiloLendingLib {
 
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
-        // we need to count for fractions, when fractions are applied liquidity is decreased
-        if (liquidityWithInterest != 0) unchecked { liquidityWithInterest--; }
+        if (liquidityWithInterest != 0) {
+            // we need to count for fractions, when fractions are applied liquidity is decreased
+            unchecked { liquidityWithInterest--; }
+        }
 
         if (assets > liquidityWithInterest) {
             assets = liquidityWithInterest;
@@ -362,9 +364,11 @@ library SiloLendingLib {
 
         assets = _maxBorrowValue.mulDiv(debtTokenSample, debtSampleValue, Rounding.MAX_BORROW_TO_ASSETS);
 
-        // When we are calculating fractions it is possible that integral revenue and interest are 1.
-        // In this case total debt assets will be increased by 1 and collateral will stay the same.
-        if (assets != 0) unchecked { assets--; }
+        if (assets != 0) {
+            // When we are calculating fractions it is possible that integral revenue and interest are 1.
+            // In this case total debt assets will be increased by 1 and collateral will stay the same.
+            unchecked { assets--; }
+        }
 
         // when we borrow, we convertToShares with rounding.Up, to create higher debt, however here,
         // when we want to calculate "max borrow", we can not round.Up, because it can create issue with max ltv,

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -256,7 +256,12 @@ library SiloLendingLib {
 
         if (assets == 0 || shares == 0) return (0, 0);
 
-        uint256 liquidityWithInterest = getLiquidity(_siloConfig);
+        uint256 liquidityWithInterest = getLiquidity(_siloConfig) - 1;
+
+        if (liquidityWithInterest != 0) {
+            // we need to count for fractions, when fractions are applied liquidity is decreased
+            unchecked { liquidityWithInterest--; }
+        }
 
         if (assets > liquidityWithInterest) {
             assets = liquidityWithInterest;

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -365,8 +365,8 @@ library SiloLendingLib {
         assets = _maxBorrowValue.mulDiv(debtTokenSample, debtSampleValue, Rounding.MAX_BORROW_TO_ASSETS);
 
         if (assets != 0) {
-            // When we are calculating fractions it is possible that total debt assets will be increased by 1.
-            // Which can lead to the to revert on LTV check. To avoid this we underestimate assets.
+            // When we calculate fractions, it is possible that total debt assets will increase by 1
+            // which can lead to a revert on the LTV check. To avoid this, we underestimate assets.
             unchecked { assets -= 1; }
         }
 

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -258,10 +258,8 @@ library SiloLendingLib {
 
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
-        if (liquidityWithInterest != 0) {
-            // we need to count for fractions, when fractions are applied liquidity is decreased
-            unchecked { liquidityWithInterest--; }
-        }
+        // we need to count for fractions, when fractions are applied liquidity is decreased
+        if (liquidityWithInterest != 0) unchecked { liquidityWithInterest--; }
 
         if (assets > liquidityWithInterest) {
             assets = liquidityWithInterest;
@@ -366,7 +364,7 @@ library SiloLendingLib {
 
         // When we are calculating fractions it is possible that integral revenue and interest are 1.
         // In this case total debt assets will be increased by 1 and collateral will stay the same.
-        if (assets != 0)  assets--;
+        if (assets != 0) unchecked { assets--; }
 
         // when we borrow, we convertToShares with rounding.Up, to create higher debt, however here,
         // when we want to calculate "max borrow", we can not round.Up, because it can create issue with max ltv,

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -258,7 +258,7 @@ library SiloLendingLib {
 
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
-        if (liquidityWithInterest != 0 && _totalDebtAssets < _ROUNDING_THRESHOLD) {
+        if (liquidityWithInterest != 0) {
             // we need to count for fractions, when fractions are applied liquidity is decreased
             unchecked { liquidityWithInterest--; }
         }

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -364,6 +364,10 @@ library SiloLendingLib {
 
         assets = _maxBorrowValue.mulDiv(debtTokenSample, debtSampleValue, Rounding.MAX_BORROW_TO_ASSETS);
 
+        // When we are calculating fractions it is possible that integral revenue and interest are 1.
+        // In this case total debt assets will be increased by 1 and collateral will stay the same.
+        if (assets != 0)  assets--;
+
         // when we borrow, we convertToShares with rounding.Up, to create higher debt, however here,
         // when we want to calculate "max borrow", we can not round.Up, because it can create issue with max ltv,
         // because we not creating debt here, we calculating max assets/shares, so we need to round.Down here

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -259,8 +259,8 @@ library SiloLendingLib {
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
         if (liquidityWithInterest != 0) {
-            // we need to count for fractions, when fractions are applied liquidity is decreased
-            unchecked { liquidityWithInterest--; }
+            // We need to count for fractions, when fractions are applied liquidity may be decreased
+            unchecked { liquidityWithInterest -= 1; }
         }
 
         if (assets > liquidityWithInterest) {
@@ -367,7 +367,7 @@ library SiloLendingLib {
         if (assets != 0) {
             // When we are calculating fractions it is possible that total debt assets will be increased by 1.
             // Which can lead to the to revert on LTV check. To avoid this we underestimate assets.
-            unchecked { assets--; }
+            unchecked { assets -= 1; }
         }
 
         // when we borrow, we convertToShares with rounding.Up, to create higher debt, however here,

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -30,6 +30,29 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
     }
 
     /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_replay_assertBORROWING_HSPOST_F
+    this test test fix for maxBorrow when fractions
+    */
+    function test_replay_assertBORROWING_HSPOST_F() public {
+        token0.setOnDemand(true);
+        token1.setOnDemand(true);
+
+        address borrower = address(this);
+
+        //@audit-issue BORROWING_HSPOST_F: User borrowing maxBorrow should never revert
+        // error -> NotEnoughLiquidity
+        silo0.mint(11638058238813243150339, borrower);
+        silo1.deposit(8533010, address(1));
+        silo1.borrow(8256930, borrower, borrower);
+
+        vm.warp(block.timestamp + 12);
+        silo1.accrueInterest();
+        vm.warp(block.timestamp + 7);
+
+        silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+    }
+
+    /*
     forge test -vv --ffi --mt test_borrow_all_zeros
     */
     function test_borrow_all_zeros() public {

--- a/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/Borrow.i.sol
@@ -329,8 +329,8 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         uint256 maxBorrow = silo1.maxBorrow(borrower);
         uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
 
-        assertEq(maxBorrow, 0.75e18, "invalid maxBorrow for two tokens");
-        assertEq(maxBorrowShares, 0.75e18, "invalid maxBorrowShares for two tokens");
+        assertEq(maxBorrow, 0.75e18 - 1, "invalid maxBorrow for two tokens");
+        assertEq(maxBorrowShares, 0.75e18 - 1, "invalid maxBorrowShares for two tokens");
 
         uint256 borrowToMuch = maxBorrow + 2;
         // emit log_named_uint("borrowToMuch", borrowToMuch);
@@ -350,7 +350,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_borrow_twice
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_borrow_twice
     */
     function test_borrow_twice_1token() public {
         _borrow_twice();
@@ -465,7 +465,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
 
         maxBorrow = silo1.maxBorrow(_borrower);
         emit log_named_decimal_uint("maxBorrow #1", maxBorrow, 18);
-        assertEq(maxBorrow, maxLtv, "maxBorrow borrower can do, maxLTV is 75%");
+        assertEq(maxBorrow, maxLtv - 1, "maxBorrow borrower can do, maxLTV is 75%");
 
         uint256 borrowAmount = maxBorrow / 2;
         emit log_named_decimal_uint("first borrow amount", borrowAmount, 18);
@@ -480,10 +480,10 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         uint256 expectedShares = 1e18;
         expectedShares = expectedShares.decimalsOffsetPow();
 
-        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), shareTokenCurrentDebt, "expect borrower to have 1/2 of debt");
+        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), shareTokenCurrentDebt - 1, "expect borrower to have 1/2 of debt");
         assertEq(IShareToken(_collateralToken).balanceOf(_borrower), expectedShares, "collateral silo: borrower has collateral");
-        assertEq(silo1.getDebtAssets(), shareTokenCurrentDebt, "silo debt");
-        assertEq(gotShares, shareTokenCurrentDebt, "got debt shares");
+        assertEq(silo1.getDebtAssets(), shareTokenCurrentDebt - 1, "silo debt");
+        assertEq(gotShares, shareTokenCurrentDebt - 1, "got debt shares");
         assertEq(gotShares, convertToShares, "convertToShares returns same result");
         assertEq(borrowAmount, silo1.convertToAssets(gotShares, ISilo.AssetType.Debt), "convertToAssets returns borrowAmount");
 
@@ -494,7 +494,7 @@ contract BorrowIntegrationTest is SiloLittleHelper, Test {
         convertToShares = silo1.convertToShares(borrowAmount, ISilo.AssetType.Debt);
         gotShares = _borrow(borrowAmount, _borrower);
 
-        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), maxLtv, "debt silo: borrower has debt");
+        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), maxLtv - 1, "debt silo: borrower has debt");
         assertEq(gotShares, maxLtv / 2, "got shares");
         assertEq(silo1.getDebtAssets(), maxBorrow, "debt silo: has debt");
         assertEq(gotShares, convertToShares, "convertToShares returns same result (2)");

--- a/silo-core/test/foundry/Silo/borrow/BorrowSameAsset.i.sol
+++ b/silo-core/test/foundry/Silo/borrow/BorrowSameAsset.i.sol
@@ -218,7 +218,7 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
 
         uint256 maxBorrow = silo0.maxBorrowSameAsset(borrower);
 
-        assertEq(maxBorrow, 0.75e18, "invalid maxBorrow for two tokens");
+        assertEq(maxBorrow, 0.75e18 - 1, "invalid maxBorrow for two tokens");
 
         uint256 borrowToMuch = maxBorrow + 2;
         emit log_named_uint("borrowToMuch", borrowToMuch);
@@ -324,7 +324,7 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
 
         maxBorrow = silo0.maxBorrowSameAsset(_borrower);
         emit log_named_decimal_uint("maxBorrow #1", maxBorrow, 18);
-        assertEq(maxBorrow, maxLtv, "maxBorrow borrower can do, maxLTV is 75%");
+        assertEq(maxBorrow, maxLtv - 1, "maxBorrow borrower can do, maxLTV is 75%");
 
         uint256 borrowAmount = maxBorrow / 2;
         emit log_named_decimal_uint("first borrow amount", borrowAmount, 18);
@@ -340,10 +340,10 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
         uint256 expectedShares = 1e18;
         expectedShares = expectedShares.decimalsOffsetPow();
 
-        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), shareTokenCurrentDebt, "expect borrower to have 1/2 of debt");
+        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), shareTokenCurrentDebt - 1, "expect borrower to have 1/2 of debt");
         assertEq(IShareToken(_collateralToken).balanceOf(_borrower), expectedShares, "borrower has collateral");
-        assertEq(silo0.getDebtAssets(), shareTokenCurrentDebt, "silo debt");
-        assertEq(gotShares, shareTokenCurrentDebt, "got debt shares");
+        assertEq(silo0.getDebtAssets(), shareTokenCurrentDebt - 1, "silo debt");
+        assertEq(gotShares, shareTokenCurrentDebt - 1, "got debt shares");
         assertEq(gotShares, convertToShares, "convertToShares returns same result");
         assertEq(borrowAmount, silo0.convertToAssets(gotShares, ISilo.AssetType.Debt), "convertToAssets returns borrowAmount");
 
@@ -356,7 +356,7 @@ contract BorrowSameAssetTest is SiloLittleHelper, Test {
         vm.prank(_borrower);
         gotShares = silo0.borrowSameAsset(borrowAmount, _borrower, _borrower);
 
-        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), maxLtv, "debt silo: borrower has debt");
+        assertEq(IShareToken(_debtShareToken).balanceOf(_borrower), maxLtv - 1, "debt silo: borrower has debt");
         assertEq(gotShares, maxLtv / 2, "got shares");
         assertEq(silo0.getDebtAssets(), maxBorrow, "debt silo: has debt");
         assertEq(gotShares, convertToShares, "convertToShares returns same result (2)");

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -67,10 +67,10 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
     }
 
     /*
-    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_WithFractions_scenario1_fuzz
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_WithFractions_any_scenario_fuzz
     */
     /// forge-config: core_test.fuzz.runs = 1000
-    function test_maxBorrow_WithFractions_scenario1_fuzz(
+    function test_maxBorrow_WithFractions_any_scenario_fuzz(
         uint256 _borrowAmount,
         uint256 _depositAmount,
         bool _borrowShares,

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -68,8 +68,6 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
 
     /*
     FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_WithFractions_scenario1_fuzz
-
-    scenario 1 - increase total debt assets
     */
     /// forge-config: core_test.fuzz.runs = 1000
     function test_maxBorrow_WithFractions_scenario1_fuzz(

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {SiloStorageLib} from "silo-core/contracts/lib/SiloStorageLib.sol";
+
+import {SiloLittleHelper} from "../../../_common/SiloLittleHelper.sol";
+
+import {Silo} from "silo-core/contracts/Silo.sol";
+import {ISiloFactory} from "silo-core/contracts/interfaces/ISiloFactory.sol";
+import {SiloHarness} from "silo-core/test/foundry/_mocks/SiloHarness.sol";
+
+/*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc MaxBorrowAndFractions
+
+    Testing scenarios and result with and without fix in the SiloLendingLib.sol.maxBorrowValueToAssetsAndShares fn
+    // assets--;
+
+    results for maxBorrow => borrow
+
+    borrow 50
+        scenario 1 - revert AboveMaxLtv (fix solves the issue)
+        scenario 2 - revert AboveMaxLtv (fix solves the issue)
+        scenario 3 - succeeds (no changes)
+
+    borrow max / 2
+        scenario 1 - revert AboveMaxLtv (fix solves the issue)
+        scenario 2 - revert AboveMaxLt (fix solves the issue)
+        scenario 3 - succeeds (no changes)
+
+    borrow 0
+        scenario 1 - revert AboveMaxLtv (fix solves the issue)
+        scenario 2 - revert AboveMaxLtv (fix solves the issue)
+        scenario 3 - succeeds (no changes)
+
+    scenario 1 (interest 1 revenue 1)
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+
+    scenario 2 (interest 1 revenue 0)
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        SiloHarness(payable(address(silo1))).increaseTotalCollateralAssets(1);
+
+    scenario 3 (interest 0 revenue 1)
+        SiloHarness(payable(address(silo1))).decreaseTotalCollateralAssets(1); 
+*/
+contract MaxBorrowAndFractions is SiloLittleHelper, Test {
+    function setUp() public {
+        ISiloConfig siloConfig = _setUpLocalFixture();
+
+        assertTrue(siloConfig.getConfig(address(silo0)).maxLtv != 0, "we need borrow to be allowed");
+
+        token0.setOnDemand(true);
+        token1.setOnDemand(true);
+
+        _doDeposit();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_Borrow_WithFractions_scenario1
+
+    scenario 1 - increase total debt assets
+    */
+    function test_maxBorrow_Borrow_WithFractions_scenario1() public {
+        uint256 snapshot = vm.snapshot();
+
+        uint256 borrowAmount = 50;
+        address borrower = address(this);
+        uint256 maxBorrowAfterDeposit;
+
+        _borrowAndUpdateSiloCode(borrowAmount);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        silo1.borrow(borrowAmount, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        borrowAmount = silo1.maxBorrow(borrower);
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(borrowAmount / 2);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit / 2, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(0);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit, borrower, borrower);
+
+        vm.revertTo(snapshot);
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_Borrow_WithFractions_scenario2
+
+    scenario 2 - increase total collateral and debt assets
+    */
+    function test_maxBorrow_borrow_WithFractions_scenario2() public {
+        uint256 snapshot = vm.snapshot();
+
+        uint256 borrowAmount = 50;
+        address borrower = address(this);
+        uint256 maxBorrowAfterDeposit;
+
+        _borrowAndUpdateSiloCode(borrowAmount);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        SiloHarness(payable(address(silo1))).increaseTotalCollateralAssets(1);
+        silo1.borrow(borrowAmount, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        borrowAmount = silo1.maxBorrow(borrower);
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(borrowAmount / 2);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        SiloHarness(payable(address(silo1))).increaseTotalCollateralAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit / 2, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(0);
+        SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
+        SiloHarness(payable(address(silo1))).increaseTotalCollateralAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit, borrower, borrower);
+
+        vm.revertTo(snapshot);
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowWithFractions
+
+    scenario 3 - decrease total collateral assets
+    */
+    function test_maxBorrowWithFractions_scenario3() public {
+        uint256 snapshot = vm.snapshot();
+
+        uint256 borrowAmount = 50;
+        address borrower = address(this);
+        uint256 maxBorrowAfterDeposit;
+
+        _borrowAndUpdateSiloCode(borrowAmount);
+        SiloHarness(payable(address(silo1))).decreaseTotalCollateralAssets(1);
+        silo1.borrow(borrowAmount, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        borrowAmount = silo1.maxBorrow(borrower);
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(borrowAmount / 2);
+        SiloHarness(payable(address(silo1))).decreaseTotalCollateralAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit / 2, borrower, borrower);
+
+        vm.revertTo(snapshot);
+
+        maxBorrowAfterDeposit = _borrowAndUpdateSiloCode(0);
+        SiloHarness(payable(address(silo1))).decreaseTotalCollateralAssets(1);
+        silo1.borrow(maxBorrowAfterDeposit, borrower, borrower);
+
+        vm.revertTo(snapshot);
+    }
+
+    function _doDeposit() internal {
+        silo0.mint(1e6, address(this));
+        silo1.deposit(1e6, address(1));
+    }
+
+    function _borrowAndUpdateSiloCode(uint256 _amount) internal returns (uint256 maxBorrow) {
+        address borrower = address(this);
+
+        if (_amount != 0) {
+            silo1.borrow(_amount, borrower, borrower);
+        }
+
+        address silo1Harness = address(new SiloHarness(ISiloFactory(address(this))));
+
+        vm.etch(address(silo1), address(silo1Harness).code);
+
+        ISilo.Fractions memory fractions = silo1.getFractionsStorage();
+        emit log_named_uint("fractions.interest", fractions.interest);
+        emit log_named_uint("fractions.revenue", fractions.revenue);
+
+        maxBorrow = silo1.maxBorrow(borrower);
+        emit log_named_uint("maxBorrow", maxBorrow);
+    }
+}

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -69,22 +69,46 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
     scenario 1 - increase total debt assets
     */
     function test_maxBorrow_Borrow_WithFractions_scenario1() public {
-        _executeBorrowScenario1(50);
+        bool borrowShares = false;
+
+        _executeBorrowScenario1(50, borrowShares);
         vm.revertTo(snapshot);
 
-        uint256 maxBorrowAmount = silo1.maxBorrow(address(this));
-        _executeBorrowScenario1(maxBorrowAmount / 2);
+        _executeBorrowScenario1(silo1.maxBorrow(address(this)) / 2, borrowShares);
         vm.revertTo(snapshot);
 
-        _executeBorrowScenario1(0);
+        _executeBorrowScenario1(0, borrowShares);
         vm.revertTo(snapshot);
     }
 
-    function _executeBorrowScenario1(uint256 _borrowAmount) internal {
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_BorrowShares_WithFractions_scenario1
+
+    scenario 1 - increase total debt assets
+    */
+    function test_maxBorrow_BorrowShares_WithFractions_scenario1() public {
+        bool borrowShares = true;
+
+        _executeBorrowScenario1(50, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario1(silo1.maxBorrow(address(this)) / 2, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario1(0, borrowShares);
+        vm.revertTo(snapshot);
+    }
+
+    function _executeBorrowScenario1(uint256 _borrowAmount, bool _borrowShares) internal {
         address borrower = address(this);
         _borrowAndUpdateSiloCode(_borrowAmount);
         SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
-        silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+
+        if (_borrowShares) {
+            silo1.borrowShares(silo1.maxBorrowShares(borrower), borrower, borrower);
+        } else {
+            silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+        }
     }
 
     /*
@@ -93,22 +117,47 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
     scenario 2 - increase total collateral and debt assets
     */
     function test_maxBorrow_borrow_WithFractions_scenario2() public {
-        _executeBorrowScenario2(50);
+        bool borrowShares = false;
+
+        _executeBorrowScenario2(50, borrowShares);
         vm.revertTo(snapshot);
 
-        _executeBorrowScenario2(silo1.maxBorrow(address(this)) / 2);
+        _executeBorrowScenario2(silo1.maxBorrow(address(this)) / 2, borrowShares);
         vm.revertTo(snapshot);
 
-        _executeBorrowScenario2(0);
+        _executeBorrowScenario2(0, borrowShares);
         vm.revertTo(snapshot);
     }
 
-    function _executeBorrowScenario2(uint256 _borrowAmount) internal {
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrow_borrowShares_WithFractions_scenario2
+
+    scenario 2 - increase total collateral and debt assets
+    */
+    function test_maxBorrow_borrowShares_WithFractions_scenario2() public {
+        bool borrowShares = true;
+
+        _executeBorrowScenario2(50, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario2(silo1.maxBorrow(address(this)) / 2, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario2(0, borrowShares);
+        vm.revertTo(snapshot);
+    }
+
+    function _executeBorrowScenario2(uint256 _borrowAmount, bool _borrowShares) internal {
         address borrower = address(this);
         _borrowAndUpdateSiloCode(_borrowAmount);
         SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
         SiloHarness(payable(address(silo1))).increaseTotalCollateralAssets(1);
-        silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+
+        if (_borrowShares) {
+            silo1.borrowShares(silo1.maxBorrowShares(borrower), borrower, borrower);
+        } else {
+            silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+        }
     }
 
     /*
@@ -117,21 +166,46 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
     scenario 3 - decrease total collateral assets
     */
     function test_maxBorrowWithFractions_scenario3() public {
-        _executeBorrowScenario3(50);
+        bool borrowShares = false;
+
+        _executeBorrowScenario3(50, borrowShares);
         vm.revertTo(snapshot);
 
-        _executeBorrowScenario3(silo1.maxBorrow(address(this)) / 2);
+        _executeBorrowScenario3(silo1.maxBorrow(address(this)) / 2, borrowShares);
         vm.revertTo(snapshot);
 
-        _executeBorrowScenario3(0);
+        _executeBorrowScenario3(0, borrowShares);
         vm.revertTo(snapshot);
     }
 
-    function _executeBorrowScenario3(uint256 _borrowAmount) internal {
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowWithFractions_borrowShares_scenario3
+
+    scenario 3 - decrease total collateral assets
+    */
+    function test_maxBorrowWithFractions_borrowShares_scenario3() public {
+        bool borrowShares = true;
+
+        _executeBorrowScenario3(50, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario3(silo1.maxBorrow(address(this)) / 2, borrowShares);
+        vm.revertTo(snapshot);
+
+        _executeBorrowScenario3(0, borrowShares);
+        vm.revertTo(snapshot);
+    }
+
+    function _executeBorrowScenario3(uint256 _borrowAmount, bool _borrowShares) internal {
         address borrower = address(this);
         _borrowAndUpdateSiloCode(_borrowAmount);
         SiloHarness(payable(address(silo1))).decreaseTotalCollateralAssets(1);
-        silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+
+        if (_borrowShares) {
+            silo1.borrowShares(silo1.maxBorrowShares(borrower), borrower, borrower);
+        } else {
+            silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+        }
     }
 
     function _doDeposit() internal {

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -129,9 +129,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         SiloHarness(payable(address(silo1))).increaseTotalDebtAssets(1);
 
         if (_borrowShares) {
-            silo1.borrowShares(silo1.maxBorrowShares(borrower), borrower, borrower);
+            uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
+            vm.assume(maxBorrowShares != 0);
+            silo1.borrowShares(maxBorrowShares, borrower, borrower);
         } else {
-            silo1.borrow(silo1.maxBorrow(borrower), borrower, borrower);
+            uint256 maxBorrow = silo1.maxBorrow(borrower);
+            vm.assume(maxBorrow != 0);
+            silo1.borrow(maxBorrow, borrower, borrower);
         }
     }
 

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowShares.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowShares.i.sol
@@ -42,7 +42,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_maxBorrowShares_withCollateral
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowShares_withCollateral
     */
     /// forge-config: core_test.fuzz.runs = 1000
     function test_maxBorrowShares_withCollateral_1token_fuzz(
@@ -62,7 +62,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         uint256 maxBorrowShares = silo1.maxBorrowShares(borrower);
         vm.assume(maxBorrowShares > 0);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 1);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
 
         _assertMaxBorrowSharesIsZeroAtTheEnd();
     }
@@ -92,7 +92,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
     }
 
     /*
-    forge test -vv --ffi --mt test_maxBorrowShares_withDebt
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowShares_withDebt
     */
     /// forge-config: core_test.fuzz.runs = 1000
     function test_maxBorrowShares_withDebt_1token_fuzz(uint128 _collateral, uint128 _liquidity) public {
@@ -116,7 +116,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
 
         maxBorrowShares = silo1.maxBorrowShares(borrower);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 1);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
         _assertMaxBorrowSharesIsZeroAtTheEnd();
     }
 
@@ -131,6 +131,9 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         _maxBorrowShares_withInterest_fuzz(_collateral, _liquidity, ISilo.CollateralType.Collateral);
     }
 
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowShares_withInterest_
+    */
     /// forge-config: core_test.fuzz.runs = 1000
     function test_maxBorrowShares_withInterest_1token_protected_fuzz(
         uint128 _collateral,
@@ -163,7 +166,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         maxBorrowShares = silo1.maxBorrowShares(borrower);
         emit log_named_uint("____ maxBorrowShares", maxBorrowShares);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 3);
         _assertMaxBorrowSharesIsZeroAtTheEnd(1);
     }
 
@@ -179,6 +182,9 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         _maxBorrowShares_repayWithInterest_fuzz(_collateral, _liquidity, ISilo.CollateralType.Collateral);
     }
 
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_maxBorrowShares_repayWithInterest_1token_protected_fuzz
+    */
     /// forge-config: core_test.fuzz.runs = 5000
     function test_maxBorrowShares_repayWithInterest_1token_protected_fuzz(
         uint64 _collateral,
@@ -225,7 +231,7 @@ contract MaxBorrowSharesTest is SiloLittleHelper, Test {
         maxBorrowShares = silo1.maxBorrowShares(borrower);
         emit log_named_uint("____ maxBorrowShares", maxBorrowShares);
 
-        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 2);
+        _assertWeCanNotBorrowAboveMax(maxBorrowShares, 3);
         _assertMaxBorrowSharesIsZeroAtTheEnd(1);
     }
 

--- a/silo-core/test/foundry/SiloLens/SiloLens.i.sol
+++ b/silo-core/test/foundry/SiloLens/SiloLens.i.sol
@@ -92,7 +92,7 @@ contract SiloLensIntegrationTest is SiloLittleHelper, Test {
         assertEq(siloLens.getUserLTV(silo1, borrower), 0.75e18, "borrower LTV #1");
 
         assertEq(siloLens.getUtilization(silo0), 0, "getUtilization #0");
-        assertEq(siloLens.getUtilization(silo1), 0.75e18, "getUtilization #1");
+        assertEq(siloLens.getUtilization(silo1), 0.75e18 - 1, "getUtilization #1");
 
         assertEq(
             siloLens.calculateCollateralValue(siloConfig, borrower),
@@ -129,17 +129,17 @@ contract SiloLensIntegrationTest is SiloLittleHelper, Test {
         vm.warp(block.timestamp + 65 days);
 
         assertEq(siloLens.getBorrowAPR(silo0), 0, "getBorrowAPR after 65 days #0");
-        assertEq(siloLens.getBorrowAPR(silo1), 6_605018041910688000, "getBorrowAPR after 65 days #1");
+        assertEq(siloLens.getBorrowAPR(silo1), 6_605018041879152000, "getBorrowAPR after 65 days #1");
 
         assertEq(siloLens.getDepositAPR(silo0), 0, "getDepositAPR after 65 days #0");
-        assertEq(siloLens.getDepositAPR(silo1), 4_625564840811145381, "getDepositAPR after 65 days #1");
+        assertEq(siloLens.getDepositAPR(silo1), 4_625564840789060382, "getDepositAPR after 65 days #1");
 
         ISilo[] memory silos = new ISilo[](1);
         silos[0] = silo1;
 
         ISiloLens.APR[] memory aprs = siloLens.getAPRs(silos);
-        assertEq(aprs[0].borrowAPR, 6_605018041910688000, "apr.getBorrowAPR after 65 days #1");
-        assertEq(aprs[0].depositAPR, 4_625564840811145381, "aps.getDepositAPR after 65 days #1");
+        assertEq(aprs[0].borrowAPR, 6_605018041879152000, "apr.getBorrowAPR after 65 days #1");
+        assertEq(aprs[0].depositAPR, 4_625564840789060382, "aps.getDepositAPR after 65 days #1");
 
         assertLt(siloLens.getDepositAPR(silo1), siloLens.getBorrowAPR(silo1), "deposit APR should be less than borrow");
 
@@ -220,7 +220,7 @@ contract SiloLensIntegrationTest is SiloLittleHelper, Test {
         );
 
         uint256 maxRepayBefore = silo1.maxRepay(borrower);
-        assertEq(maxRepayBefore, 14.994397297218850137e18, "maxRepayBefore");
+        assertEq(maxRepayBefore, 14.994397297218850135e18, "maxRepayBefore");
 
         vm.warp(block.timestamp + 300 days);
 
@@ -232,7 +232,7 @@ contract SiloLensIntegrationTest is SiloLittleHelper, Test {
         assertEq(siloLens.getDepositAPR(silo1), 0, "getDepositAPR after long time #1");
 
         uint256 maxRepayAfter = silo1.maxRepay(borrower);
-        assertEq(maxRepayAfter, 1247.410613506809097866e18, "maxRepayAfter");
+        assertEq(maxRepayAfter, 1247.410613506809097700e18, "maxRepayAfter");
 
         assertTrue(siloLens.hasPosition(siloConfig, borrower), "hasPosition");
     }
@@ -260,7 +260,7 @@ contract SiloLensIntegrationTest is SiloLittleHelper, Test {
         _borrow(toBorrow, borrower);
 
         assertEq(siloLens.getUtilization(silo0), 0, "getUtilization #0");
-        assertEq(siloLens.getUtilization(silo1), _utilization, "getUtilization #1");
+        assertEq(siloLens.getUtilization(silo1), _utilization - 1, "getUtilization #1");
 
         _assertInterest(toBorrow);
     }

--- a/silo-core/test/foundry/_mocks/SiloHarness.sol
+++ b/silo-core/test/foundry/_mocks/SiloHarness.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Silo} from "silo-core/contracts/Silo.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {ISiloFactory} from "silo-core/contracts/interfaces/ISiloFactory.sol";
+import {SiloStorageLib} from "silo-core/contracts/lib/SiloStorageLib.sol";
+
+contract SiloHarness is Silo {
+    constructor(ISiloFactory _siloFactory) Silo(_siloFactory) {}
+
+    function increaseTotalDebtAssets(uint256 _amount) public {
+        ISilo.SiloStorage storage $ = SiloStorageLib.getSiloStorage();
+        $.totalAssets[ISilo.AssetType.Debt] += _amount;
+    }
+
+    function decreaseTotalDebtAssets(uint256 _amount) public {
+        ISilo.SiloStorage storage $ = SiloStorageLib.getSiloStorage();
+        $.totalAssets[ISilo.AssetType.Debt] -= _amount;
+    }
+
+    function increaseTotalCollateralAssets(uint256 _amount) public {
+        ISilo.SiloStorage storage $ = SiloStorageLib.getSiloStorage();
+        $.totalAssets[ISilo.AssetType.Collateral] += _amount;
+    }
+
+    function decreaseTotalCollateralAssets(uint256 _amount) public {
+        ISilo.SiloStorage storage $ = SiloStorageLib.getSiloStorage();
+        $.totalAssets[ISilo.AssetType.Collateral] -= _amount;
+    }
+}

--- a/silo-core/test/foundry/_protocol/SiloDecimals.t.sol
+++ b/silo-core/test/foundry/_protocol/SiloDecimals.t.sol
@@ -79,10 +79,10 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _depositCollateral(100e5, borrower, TWO_ASSETS);
         _depositForBorrow(100e5, depositor);
 
-        assertEq(silo1.maxBorrow(borrower), 75e5 , "maxBorrow");
+        assertEq(silo1.maxBorrow(borrower), 75e5 - 1, "maxBorrow");
         _borrow(silo1.maxBorrow(borrower), borrower);
 
-        assertEq(silo0.maxWithdraw(borrower), 11_76470 , "maxWithdraw");
+        assertEq(silo0.maxWithdraw(borrower), 11_76471 , "maxWithdraw");
         _withdraw(silo0.maxWithdraw(borrower), borrower);
 
         vm.warp(10 days);
@@ -92,8 +92,8 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _repay(1e5, borrower);
 
         (uint256 collateral, uint256 debt, bool receiveSToken) = partialLiquidation.maxLiquidation(borrower);
-        assertEq(collateral, 41_37822 , "collateral");
-        assertEq(debt, 39_40785, "debt");
+        assertEq(collateral, 41_37821 , "collateral");
+        assertEq(debt, 39_40784, "debt");
         assertFalse(receiveSToken, "receiveSToken");
 
         token1.approve(address(partialLiquidation), debt);
@@ -116,13 +116,13 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _depositCollateral(1e18, borrower, TWO_ASSETS);
         _depositForBorrow(2000e6, depositor);
 
-        assertEq(silo1.maxBorrow(borrower), 1875e6 , "maxBorrow maxLTV is 75% (2500 * 0.75 => 1875)");
+        assertEq(silo1.maxBorrow(borrower), 1875e6 - 1, "maxBorrow maxLTV is 75% (2500 * 0.75 => 1875)");
         _borrow(silo1.maxBorrow(borrower), borrower);
 
         // LT is 85%, so 1875 / 0.85 = 2205 of value in collateral is needed.
         // we have 1ETH (2500USDC), 2500 - 2205 = 295.
         // 295 / 2500 = 0.118% can be removed, => ~118000000000000000
-        assertEq(silo0.maxWithdraw(borrower), 117647058800000000 , "maxWithdraw");
+        assertEq(silo0.maxWithdraw(borrower), 117647059200000000 , "maxWithdraw");
         _withdraw(silo0.maxWithdraw(borrower), borrower);
 
         vm.warp(1 days);
@@ -132,8 +132,8 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _repay(1e6, borrower);
 
         (uint256 collateral, uint256 debt, bool receiveSToken) = partialLiquidation.maxLiquidation(borrower);
-        assertEq(collateral, 417011081199999998, "collateral");
-        assertEq(debt, 992883527, "debt");
+        assertEq(collateral, 417011080399999998, "collateral");
+        assertEq(debt, 992883525, "debt");
         assertFalse(receiveSToken, "receiveSToken");
 
         token1.approve(address(partialLiquidation), debt);
@@ -156,7 +156,7 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _depositCollateral(2500e6, borrower, TWO_ASSETS);
         _depositForBorrow(1e18, depositor);
 
-        assertEq(silo1.maxBorrow(borrower), 0.75e18, "maxBorrow, maxLTV is 75%");
+        assertEq(silo1.maxBorrow(borrower), 0.75e18 - 1, "maxBorrow, maxLTV is 75%");
         _borrow(silo1.maxBorrow(borrower), borrower);
 
         // LT is 85%, so 0.75e18 / 0.85 = 882352941176470700 of value in collateral is needed.
@@ -173,7 +173,7 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
 
         (uint256 collateral, uint256 debt, bool receiveSToken) = partialLiquidation.maxLiquidation(borrower);
         assertEq(collateral, 100_4885426 , "collateral");
-        assertEq(debt, 382813496697463186, "debt");
+        assertEq(debt, 382813496697463181, "debt");
         assertFalse(receiveSToken, "receiveSToken");
 
         token1.approve(address(partialLiquidation), debt);
@@ -185,7 +185,7 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
     }
 
     /*
-        forge test -vv --ffi --mt test_decimals_HALF_USDC_oracle
+        FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_decimals_HALF_USDC_oracle
     */
     function test_decimals_HALF_USDC_oracle() public {
         _setUp(6, 6, true);
@@ -196,13 +196,13 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _depositCollateral(1e6, borrower, TWO_ASSETS);
         _depositForBorrow(1e6, depositor);
 
-        assertEq(silo1.maxBorrow(borrower), 0.75e6 / 2, "maxBorrow, maxLTV is 75% => 375000");
+        assertEq(silo1.maxBorrow(borrower), 0.75e6 / 2 - 1, "maxBorrow, maxLTV is 75% => 375000");
         _borrow(silo1.maxBorrow(borrower), borrower);
 
         // LT is 85%, so 375000 / 0.85 = 441176 of value in collateral is needed.
         // we have 1HALF, 1e6 - (441176 * 2) = 117648.
         // 117648 / 1e6 = 0.117648 can be removed, => 1e6 * 0.117648 = 117648
-        assertEq(silo0.maxWithdraw(borrower), 117646 , "maxWithdraw");
+        assertEq(silo0.maxWithdraw(borrower), 117648 , "maxWithdraw");
         _withdraw(silo0.maxWithdraw(borrower), borrower);
 
         vm.warp(1 days);
@@ -212,8 +212,8 @@ contract SiloDecimalsTest is SiloLittleHelper, Test {
         _repay(10, borrower);
 
         (uint256 collateral, uint256 debt, bool receiveSToken) = partialLiquidation.maxLiquidation(borrower);
-        assertEq(collateral, 400704, "collateral");
-        assertEq(debt, 190813, "debt");
+        assertEq(collateral, 400702, "collateral");
+        assertEq(debt, 190812, "debt");
         assertFalse(receiveSToken, "receiveSToken");
 
         token1.approve(address(partialLiquidation), debt);

--- a/silo-core/test/foundry/data-readers/MaxBorrowValueToAssetsAndSharesTestData.sol
+++ b/silo-core/test/foundry/data-readers/MaxBorrowValueToAssetsAndSharesTestData.sol
@@ -37,27 +37,27 @@ contract MaxBorrowValueToAssetsAndSharesTestData {
 
         i = _init("no borrow yet");
         allData[i].input.maxBorrowValue = 1;
-        allData[i].output.assets = 1;
-        allData[i].output.shares = 1;
+        allData[i].output.assets = 0;
+        allData[i].output.shares = 0;
 
         i = _init("no borrow yet case2");
         allData[i].input.maxBorrowValue = 100;
-        allData[i].output.assets = 100;
-        allData[i].output.shares = 100;
+        allData[i].output.assets = 99;
+        allData[i].output.shares = 99;
 
         i = _init("with some debt, 1value=1assets");
         allData[i].input.maxBorrowValue = 100;
         allData[i].input.totalDebtShares = 9;
         allData[i].input.totalDebtAssets = 9;
-        allData[i].output.assets = 100;
-        allData[i].output.shares = 100;
+        allData[i].output.assets = 99;
+        allData[i].output.shares = 99;
 
         i = _init("has some debt, assets:shares is 1:2");
         allData[i].input.maxBorrowValue = 100;
         allData[i].input.totalDebtShares = 18;
         allData[i].input.totalDebtAssets = 9;
-        allData[i].output.assets = 100; // for no oracle, value == assets, so maxBorrowValue = 100 => 100 assets
-        allData[i].output.shares = 200;
+        allData[i].output.assets = 99; // for no oracle, value == assets, so maxBorrowValue = 100 - 1 => 99 assets
+        allData[i].output.shares = 198;
 
         i = _init("has some debt, assets:shares is 1:2, with oracle (1e18) => 3e18");
         allData[i].input.maxBorrowValue = 100;
@@ -65,15 +65,15 @@ contract MaxBorrowValueToAssetsAndSharesTestData {
         allData[i].input.totalDebtAssets = 9;
         allData[i].input.oracleSet = true;
         allData[i].input.debtOracleQuote = 3e18;
-        allData[i].output.assets = uint256(100) / 3; // rounding down
-        allData[i].output.shares = uint256(100) / 3 * 2; // *2 because of ratio
+        allData[i].output.assets = uint256(100) / 3 - 1; // rounding down
+        allData[i].output.shares = uint256(100) / 3 * 2 - 2; // *2 because of ratio
 
         i = _init("has some debt, assets:shares is 2:1");
         allData[i].input.maxBorrowValue = 5e18;
         allData[i].input.totalDebtShares = 400e18;
         allData[i].input.totalDebtAssets = 200e18;
-        allData[i].output.assets = 5e18;
-        allData[i].output.shares = 5e18 * 2;
+        allData[i].output.assets = 5e18 - 1;
+        allData[i].output.shares = 5e18 * 2 - 2;
 
         i = _init("has some debt, assets:shares is 2:1, with oracle (1e18) => 1e18");
         allData[i].input.maxBorrowValue = 5e18;
@@ -81,8 +81,8 @@ contract MaxBorrowValueToAssetsAndSharesTestData {
         allData[i].input.totalDebtAssets = 200e18;
         allData[i].input.oracleSet = true;
         allData[i].input.debtOracleQuote = 1e18;
-        allData[i].output.assets = 5e18;
-        allData[i].output.shares = 5e18 * 2;
+        allData[i].output.assets = 5e18 - 1;
+        allData[i].output.shares = 5e18 * 2 - 2;
 
         i = _init("has some debt, assets:shares is 2:1, with oracle (1e18) => 0.5e18");
         allData[i].input.maxBorrowValue = 5e18;
@@ -90,8 +90,8 @@ contract MaxBorrowValueToAssetsAndSharesTestData {
         allData[i].input.totalDebtAssets = 200e18;
         allData[i].input.oracleSet = true;
         allData[i].input.debtOracleQuote = 0.5e18;
-        allData[i].output.assets = (5e18 * 2);
-        allData[i].output.shares = (5e18 * 2) * 2;
+        allData[i].output.assets = (5e18 * 2) - 1;
+        allData[i].output.shares = (5e18 * 2) * 2 - 2;
 
         i = _init("has some debt, assets:shares is 2:1, with oracle (1e18) => 1e6 eg different decimals");
         allData[i].input.maxBorrowValue = 5e6; // value is in quote token, so 6 decimals
@@ -99,8 +99,8 @@ contract MaxBorrowValueToAssetsAndSharesTestData {
         allData[i].input.totalDebtAssets = 200e18;
         allData[i].input.oracleSet = true;
         allData[i].input.debtOracleQuote = 1e6;
-        allData[i].output.assets = 5e18;
-        allData[i].output.shares = 5e18 * 2;
+        allData[i].output.assets = 5e18 - 1;
+        allData[i].output.shares = 5e18 * 2 - 2;
 
         return allData;
     }


### PR DESCRIPTION
we can not underestimate based on total debt, because threshold is applied before interest on fractions, but when we calculate maxBorrow we work with total after interest.