### PR TITLE
silo-core: fix maxBorrow again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- silo-core: fix maxBorrow again liquidity was decreased by 1, 
+  however it was calculated based on total that was out of sync with other calculation
 
 ### [3.4.0] - 2025-05-09
 - silo-core: prioritize DAO fee to ensure it is not zero-out by precision error

--- a/silo-core/contracts/lib/SiloERC4626Lib.sol
+++ b/silo-core/contracts/lib/SiloERC4626Lib.sol
@@ -172,11 +172,6 @@ library SiloERC4626Lib {
                 depositConfig.daoFee,
                 depositConfig.deployerFee
             );
-
-            if (liquidity != 0) {
-                // We need to count for fractions. When fractions are applied, liquidity may be decreased.
-                unchecked { liquidity -= 1; }
-            }
         } else {
             shareTokenTotalSupply = IShareToken(depositConfig.protectedShareToken).totalSupply();
             liquidity = _totalAssets;

--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -273,11 +273,6 @@ library SiloLendingLib {
 
         uint256 liquidityWithInterest = getLiquidity(_siloConfig);
 
-        if (liquidityWithInterest != 0) {
-            // We need to count for fractions, when fractions are applied liquidity may be decreased
-            unchecked { liquidityWithInterest -= 1; }
-        }
-
         if (assets > liquidityWithInterest) {
             assets = liquidityWithInterest;
 
@@ -340,10 +335,15 @@ library SiloLendingLib {
             _deployerFee
         );
 
+        // We need to count for fractions. When fractions are applied totalCollateralAssets may be decreased
+        // because of revenue
+        if (totalCollateralAssets != 0) totalCollateralAssets--;
+
+        // We need to count for fractions. When fractions are applied totalDebtAssets may be increased, that's why +1
         totalDebtAssets = SiloStdLib.getTotalDebtAssetsWithInterest(
             address(this),
             _interestRateModel
-        );
+        ) + 1;
 
         liquidity = SiloMathLib.liquidity(totalCollateralAssets, totalDebtAssets);
     }


### PR DESCRIPTION
liquidity was decreased by 1,
however it was calculated based on total that was out of sync with other calculations