### PR TITLE
x-silo: use rounding direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Fixed
-
+- x-silo: use rounding direction in favor of protocol for cancel redeem 
 
 ### [3.6.0] - 2025-05-19
 #Added 

--- a/x-silo/contracts/modules/XRedeemPolicy.sol
+++ b/x-silo/contracts/modules/XRedeemPolicy.sol
@@ -69,7 +69,7 @@ abstract contract XRedeemPolicy is IXRedeemPolicy, Ownable2Step, TransientReentr
         siloAmountAfterVesting = getAmountByVestingDuration(_xSiloAmountToBurn, _duration);
         require(siloAmountAfterVesting != 0, NoSiloToRedeem());
 
-        uint256 currentSiloAmount = convertToAssets(_xSiloAmountToBurn);
+        uint256 currentSiloAmount = _convertToAssets(_xSiloAmountToBurn, Math.Rounding.Floor);
 
         emit StartRedeem(msg.sender, currentSiloAmount,_xSiloAmountToBurn, siloAmountAfterVesting, _duration);
 
@@ -124,7 +124,7 @@ abstract contract XRedeemPolicy is IXRedeemPolicy, Ownable2Step, TransientReentr
     function cancelRedeem(uint256 _redeemIndex) external nonReentrant validateRedeem(msg.sender, _redeemIndex) {
         RedeemInfo storage redeemCache = _userRedeems[msg.sender][_redeemIndex];
 
-        uint256 toTransfer = convertToShares(redeemCache.currentSiloAmount);
+        uint256 toTransfer = _convertToShares(redeemCache.currentSiloAmount, Math.Rounding.Floor);
         uint256 toBurn = redeemCache.xSiloAmountToBurn - toTransfer;
 
         emit CancelRedeem(msg.sender, toTransfer, toBurn);
@@ -188,7 +188,7 @@ abstract contract XRedeemPolicy is IXRedeemPolicy, Ownable2Step, TransientReentr
         returns (uint256 siloAmountAfterVesting)
     {
         uint256 xSiloAfterVesting = getXAmountByVestingDuration(_xSiloAmount, _duration);
-        siloAmountAfterVesting = convertToAssets(xSiloAfterVesting);
+        siloAmountAfterVesting = _convertToAssets(xSiloAfterVesting, Math.Rounding.Floor);
     }
 
     /// @inheritdoc IXRedeemPolicy
@@ -226,9 +226,9 @@ abstract contract XRedeemPolicy is IXRedeemPolicy, Ownable2Step, TransientReentr
         xSiloAmountIn = Math.mulDiv(_xSiloAfterVesting, _PRECISION, ratio, Math.Rounding.Ceil);
     }
 
-    function convertToAssets(uint256 _shares) public view virtual returns (uint256);
+    function _convertToAssets(uint256 _shares, Math.Rounding _rounding) internal view virtual returns (uint256);
 
-    function convertToShares(uint256 _assets) public view virtual returns (uint256);
+    function _convertToShares(uint256 _assets, Math.Rounding _rounding) internal view virtual returns (uint256);
 
     function _deleteRedeemEntry(uint256 _index) internal {
         _userRedeems[msg.sender][_index] = _userRedeems[msg.sender][_userRedeems[msg.sender].length - 1];

--- a/x-silo/test/foundry/XSiloIntegrationTest.sol
+++ b/x-silo/test/foundry/XSiloIntegrationTest.sol
@@ -25,7 +25,7 @@ import {
 */
 contract XSiloIntegrationTest is Test {
     address public constant SILO_WHALE = 0xE641Dca2E131FA8BFe1D7931b9b040e3fE0c5BDc;
-    address public constant USDC_WHALE = 0x7214e1D350Ba8E2b19dE4f77DDd3609Af06AAdE2;
+    address public constant USDC_WHALE = 0x578Ee1ca3a8E1b54554Da1Bf7C583506C4CD11c6;
 
     ISiloIncentivesControllerFactory public siloIncentivesControllerFactory;
     ISiloIncentivesController public controller;
@@ -57,6 +57,8 @@ contract XSiloIntegrationTest is Test {
         dao = AddrLib.getAddress(AddrKey.DAO);
 
         uint256 whaleBalance = siloTokenV2.balanceOf(SILO_WHALE);
+        assertGt(whaleBalance, 1e18, "expect SILO_WHALE to have tokens");
+        emit log_named_address("usdcToken", address(usdcToken));
 
         userInitialSiloBalance = whaleBalance / 10;
 
@@ -153,6 +155,7 @@ contract XSiloIntegrationTest is Test {
         vm.prank(dao);
         controller.createIncentivesProgram(input);
 
+        assertGe(usdcToken.balanceOf(USDC_WHALE), INCENTIVE_DURATION * emissionPerSecond, "whale don't have tokens");
         vm.prank(USDC_WHALE);
         usdcToken.transfer(address(controller), INCENTIVE_DURATION * emissionPerSecond);
 


### PR DESCRIPTION
L-04 Rounding can sometime be done in favor of the user instead of the protocol upon instant redeeming

- fix cancel direction
- use explicit direction in all places