### PR TITLE
[L-03] x-silo: add restriction when redeem duration is too hi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - x-silo: use rounding direction in favor of protocol for cancel redeem 
 - x-silo: ensure we set `distrubutionEnd` when reset emission
+- x-silo: add restriction when redeem duration is too hi
 
 ### [3.6.0] - 2025-05-19
 #Added 

--- a/x-silo/contracts/interfaces/IXRedeemPolicy.sol
+++ b/x-silo/contracts/interfaces/IXRedeemPolicy.sol
@@ -35,6 +35,7 @@ interface IXRedeemPolicy {
     error InvalidDurationOrder();
     error MaxRatioOverflow();
     error DurationTooLow();
+    error DurationTooHi();
     error VestingNotOver();
     error DurationTooHigh();
 

--- a/x-silo/contracts/modules/XRedeemPolicy.sol
+++ b/x-silo/contracts/modules/XRedeemPolicy.sol
@@ -64,6 +64,7 @@ abstract contract XRedeemPolicy is IXRedeemPolicy, Ownable2Step, TransientReentr
     {
         require(_xSiloAmountToBurn > 0, ZeroAmount());
         require(_duration >= minRedeemDuration, DurationTooLow());
+        require(_duration <= maxRedeemDuration, DurationTooHi());
 
         // get corresponding SILO amount based on duration
         siloAmountAfterVesting = getAmountByVestingDuration(_xSiloAmountToBurn, _duration);

--- a/x-silo/test/foundry/modules/XRedeemPolicy.t.sol
+++ b/x-silo/test/foundry/modules/XRedeemPolicy.t.sol
@@ -142,6 +142,28 @@ contract XRedeemPolicyTest is Test {
     }
 
     /*
+    FOUNDRY_PROFILE=x_silo forge test -vv --ffi --mt test_redeemSilo_revertsOnInvalidDuration
+    */
+    function test_redeemSilo_revertsOnInvalidDuration() public {
+        policy.updateRedeemSettings({
+            _minRedeemRatio: 1,
+            _minRedeemDuration: 1,
+            _maxRedeemDuration: 2
+        });
+
+        uint256 amount = 1e18;
+        address user = makeAddr("user");
+
+        _convert(user, amount);
+
+        vm.expectRevert(IXRedeemPolicy.DurationTooLow.selector);
+        policy.redeemSilo(1, 0);
+
+        vm.expectRevert(IXRedeemPolicy.DurationTooHi.selector);
+        policy.redeemSilo(1, 3);
+    }
+
+    /*
     FOUNDRY_PROFILE=x_silo forge test -vv --ffi --mt test_redeemSilo_emits_StartRedeem_noRewards_1s
     */
     function test_redeemSilo_emits_StartRedeem_noRewards_1s() public {


### PR DESCRIPTION
L-03 Missing upper‐bound check on redeem duration

Fixes: [SILO-3972](https://silofinance.atlassian.net/browse/SILO-3972)

[SILO-3972]: https://silofinance.atlassian.net/browse/SILO-3972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ