### PR TITLE
silo-oracles: ERC4626 price manipulation test

### DIFF
--- a/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
+++ b/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
@@ -92,6 +92,22 @@ contract ERC4626PriceManipulation is IntegrationTest {
         _logVaultSharesAndAssets();
     }
 
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_mint -vv
+    function test_ERC4626PriceManipulation_mint() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        uint256 expectedShares = _vault.convertToShares(attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.mint(expectedShares, address(_attacker));
+
+        _logPrice("After 100% mint");
+        _logVaultSharesAndAssets();
+    }
+
     // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_deposit_and_withdraw -vv
     function test_ERC4626PriceManipulation_deposit_and_withdraw() public priceDidNotChange {
         uint256 attackerBalance = _fundAttackerWithTotalAssets();
@@ -105,6 +121,86 @@ contract ERC4626PriceManipulation is IntegrationTest {
         _logPrice("After 100% deposit");
 
         uint256 maxWithdraw = _vault.maxWithdraw(address(_attacker));
+        assertNotEq(maxWithdraw, 0, "Max withdraw is 0");
+
+        emit log_named_decimal_uint("Max withdraw", maxWithdraw, _assetDecimals);
+
+        vm.prank(_attacker);
+        _vault.withdraw(maxWithdraw, _attacker, _attacker);
+
+        _logPrice("After 100% withdraw");
+
+        _logVaultSharesAndAssets();
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_mint_and_redeem -vv
+    function test_ERC4626PriceManipulation_mint_and_redeem() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        uint256 expectedShares = _vault.convertToShares(attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.mint(expectedShares, address(_attacker));
+
+        _logPrice("After 100% mint");
+
+        uint256 maxRedeem = _vault.maxRedeem(address(_attacker));
+        assertNotEq(maxRedeem, 0, "Max redeem is 0");
+
+        emit log_named_decimal_uint("Max redeem", maxRedeem, _assetDecimals);
+
+        vm.prank(_attacker);
+        _vault.redeem(maxRedeem, _attacker, _attacker);
+
+        _logPrice("After 100% redeem");
+
+        _logVaultSharesAndAssets();
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_crossCheck_mint_withdraw -vv
+    function test_ERC4626PriceManipulation_crossCheck_mint_withdraw() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        uint256 expectedShares = _vault.convertToShares(attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.mint(expectedShares, address(_attacker));
+
+        _logPrice("After 100% mint");
+
+        uint256 maxRedeem = _vault.maxRedeem(address(_attacker));
+        assertNotEq(maxRedeem, 0, "Max redeem is 0");
+
+        emit log_named_decimal_uint("Max redeem", maxRedeem, _assetDecimals);
+
+        vm.prank(_attacker);
+        _vault.redeem(maxRedeem, _attacker, _attacker);
+
+        _logPrice("After 100% redeem");
+
+        _logVaultSharesAndAssets();
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_crossCheck_deposit_withdraw -vv
+    function test_ERC4626PriceManipulation_crossCheck_deposit_withdraw() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.deposit(attackerBalance, address(_attacker));
+
+        _logPrice("After 100% deposit");
+
+        uint256 maxWithdraw = _vault.maxWithdraw(address(_attacker));
+        assertNotEq(maxWithdraw, 0, "Max withdraw is 0");
 
         emit log_named_decimal_uint("Max withdraw", maxWithdraw, _assetDecimals);
 

--- a/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
+++ b/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {IERC4626} from "openzeppelin5/interfaces/IERC4626.sol";
+
+import {IntegrationTest} from "silo-foundry-utils/networks/IntegrationTest.sol";
+import {AddrLib} from "silo-foundry-utils/lib/AddrLib.sol";
+
+import {IWrappedNativeToken} from "silo-core/contracts/interfaces/IWrappedNativeToken.sol";
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin5/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC4626OracleFactoryDeploy} from "silo-oracles/deploy/erc4626/ERC4626OracleFactoryDeploy.sol";
+import {ERC4626OracleFactory} from "silo-oracles/contracts/erc4626/ERC4626OracleFactory.sol";
+import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
+
+// FOUNDRY_PROFILE=oracles forge test -vv --ffi --mc ERC4626PriceManipulation
+contract ERC4626PriceManipulation is IntegrationTest {
+    string internal _vaultKey = "ERC4626_vault";
+    IERC4626 internal _vault = IERC4626(0xc8CF6D7991f15525488b2A83Df53468D682Ba4B0); // sUSDf - Ethereum
+
+    ISiloOracle internal _erc4626Oracle;
+    IERC20 internal _asset;
+    string internal _ticker;
+    string internal _vaultSymbol;
+    string internal _assetSymbol;
+    uint256 internal _vaultDecimals;
+    uint256 internal _assetDecimals;
+    address internal _attacker = makeAddr("attacker");
+
+    function setUp() public {
+        uint256 blockToFork = 22679533;
+        vm.createSelectFork(vm.envString("RPC_MAINNET"), blockToFork);
+
+        AddrLib.init();
+        AddrLib.setAddress(_vaultKey, address(_vault));
+
+        ERC4626OracleFactoryDeploy erc4626OracleFactoryDeploy = new ERC4626OracleFactoryDeploy();
+        erc4626OracleFactoryDeploy.disableDeploymentsSync();
+        ERC4626OracleFactory factory = ERC4626OracleFactory(erc4626OracleFactoryDeploy.run());
+
+        _erc4626Oracle = factory.createERC4626Oracle(_vault, bytes32(0));
+
+        _asset = IERC20(_erc4626Oracle.quoteToken());
+        _vaultDecimals = IERC20Metadata(address(_vault)).decimals();
+        _assetDecimals = IERC20Metadata(address(_asset)).decimals();
+
+        _vaultSymbol = IERC20Metadata(address(_vault)).symbol();
+        _assetSymbol = IERC20Metadata(address(_asset)).symbol();
+        _ticker = string.concat(_vaultSymbol, "/", _assetSymbol);
+
+        _logPrice("Initial price");
+        _logVaultSharesAndAssets();
+
+        emit log_string("\n");
+    }
+
+    modifier priceDidNotChange() {
+        uint256 initialPrice = _getPrice();
+        _;
+        uint256 finalPrice = _getPrice();
+        assertEq(initialPrice, finalPrice, "Price changed");
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation -vv
+    function test_ERC4626PriceManipulation_donation() public {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        uint256 priceBeforeDonation = _getPrice();
+
+        vm.prank(_attacker);
+        _asset.transfer(address(_vault), attackerBalance);
+
+        _logPrice("After 100% donation");
+        _logVaultSharesAndAssets();
+
+        uint256 priceAfterDonation = _getPrice();
+
+        assertEq(priceBeforeDonation * 2, priceAfterDonation, "Expected price to double");
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_deposit -vv
+    function test_ERC4626PriceManipulation_deposit() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.deposit(attackerBalance, address(_attacker));
+
+        _logPrice("After 100% deposit");
+        _logVaultSharesAndAssets();
+    }
+
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_deposit_and_withdraw -vv
+    function test_ERC4626PriceManipulation_deposit_and_withdraw() public priceDidNotChange {
+        uint256 attackerBalance = _fundAttackerWithTotalAssets();
+
+        vm.prank(_attacker);
+        _asset.approve(address(_vault), attackerBalance);
+
+        vm.prank(_attacker);
+        _vault.deposit(attackerBalance, address(_attacker));
+
+        _logPrice("After 100% deposit");
+
+        uint256 maxWithdraw = _vault.maxWithdraw(address(_attacker));
+
+        emit log_named_decimal_uint("Max withdraw", maxWithdraw, _assetDecimals);
+
+        vm.prank(_attacker);
+        _vault.withdraw(maxWithdraw, _attacker, _attacker);
+
+        _logPrice("After 100% withdraw");
+
+        _logVaultSharesAndAssets();
+    }
+
+    function _dealAsset(address _to, uint256 _amount) internal {
+        deal(address(_asset), _to, _amount);
+    }
+
+    function _fundAttackerWithTotalAssets() internal returns (uint256 attackerBalance) {
+        uint256 totalShares = _vault.totalSupply();
+        uint256 totalAssets = _vault.convertToAssets(totalShares);
+
+        _dealAsset(_attacker, totalAssets);
+
+        attackerBalance = _asset.balanceOf(_attacker);
+        assertEq(attackerBalance, totalAssets);
+    }
+
+    function _logPrice(string memory _prefix) internal {
+        uint256 price = _getPrice();
+
+        string memory namedAs = string.concat(_prefix, " ", _ticker);
+
+        emit log_named_decimal_uint(namedAs, price, IERC20Metadata(address(_vault)).decimals());
+    }
+
+    function _logVaultSharesAndAssets() internal {
+        uint256 totalShares = _vault.totalSupply();
+        uint256 totalAssets = _vault.convertToAssets(totalShares);
+
+        emit log_named_decimal_uint(string.concat("Vault ", _vaultSymbol, " total shares"), totalShares, _vaultDecimals);
+        emit log_named_decimal_uint(string.concat("Vault ", _vaultSymbol, " total assets"), totalAssets, _assetDecimals);
+    }
+
+    function _getPrice() internal view returns (uint256 price) {
+        price = _erc4626Oracle.quote(10 ** _vaultDecimals, address(_vault));
+    }
+}

--- a/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
+++ b/silo-oracles/test/foundry/erc4626/ERC4626PriceManipulation.t.sol
@@ -174,21 +174,21 @@ contract ERC4626PriceManipulation is IntegrationTest {
 
         _logPrice("After 100% mint");
 
-        uint256 maxRedeem = _vault.maxRedeem(address(_attacker));
-        assertNotEq(maxRedeem, 0, "Max redeem is 0");
+        uint256 maxWithdraw = _vault.maxWithdraw(address(_attacker));
+        assertNotEq(maxWithdraw, 0, "Max withdraw is 0");
 
-        emit log_named_decimal_uint("Max redeem", maxRedeem, _assetDecimals);
+        emit log_named_decimal_uint("Max withdraw", maxWithdraw, _assetDecimals);
 
         vm.prank(_attacker);
-        _vault.redeem(maxRedeem, _attacker, _attacker);
+        _vault.withdraw(maxWithdraw, _attacker, _attacker);
 
-        _logPrice("After 100% redeem");
+        _logPrice("After 100% withdraw");
 
         _logVaultSharesAndAssets();
     }
 
-    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_crossCheck_deposit_withdraw -vv
-    function test_ERC4626PriceManipulation_crossCheck_deposit_withdraw() public priceDidNotChange {
+    // FOUNDRY_PROFILE=oracles forge test --ffi --mt test_ERC4626PriceManipulation_crossCheck_deposit_redeem -vv
+    function test_ERC4626PriceManipulation_crossCheck_deposit_redeem() public priceDidNotChange {
         uint256 attackerBalance = _fundAttackerWithTotalAssets();
 
         vm.prank(_attacker);
@@ -199,15 +199,15 @@ contract ERC4626PriceManipulation is IntegrationTest {
 
         _logPrice("After 100% deposit");
 
-        uint256 maxWithdraw = _vault.maxWithdraw(address(_attacker));
-        assertNotEq(maxWithdraw, 0, "Max withdraw is 0");
+        uint256 maxRedeem = _vault.maxRedeem(address(_attacker));
+        assertNotEq(maxRedeem, 0, "Max redeem is 0");
 
-        emit log_named_decimal_uint("Max withdraw", maxWithdraw, _assetDecimals);
+        emit log_named_decimal_uint("Max redeem", maxRedeem, _assetDecimals);
 
         vm.prank(_attacker);
-        _vault.withdraw(maxWithdraw, _attacker, _attacker);
+        _vault.redeem(maxRedeem, _attacker, _attacker);
 
-        _logPrice("After 100% withdraw");
+        _logPrice("After 100% redeem");
 
         _logVaultSharesAndAssets();
     }


### PR DESCRIPTION
## Problem

When we launch new markets, we often have ERC4626 vaults as silo assets. It takes time to review the vault codebase to ensure that it is secure to use collateral. 

## Solution

Added test that:
- Shows the number of shares and assets in the vault.
- Check the initial price provided by our ERC4626 price provider for the vault that we want to launch.
- Check how the vault behaves under a donation attack.
- Check the price after the deposit
- Check the price after the mint
- Check the price after deposit/withdraw in the same transaction
- Check the price after mint/redeem in the same transaction
- Cross check the price after mint/withdraw in the same transaction
- Cross check the price after deposit/redeem in the same transaction
