### PR TITLE
silo-core: execute initial deposit on silo deployment

### DIFF
--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -586,12 +586,10 @@ abstract contract SiloDeploy is CommonDeploy {
     }
 
     function _localOrFork() internal view returns (bool) {
-        if (block.chainid == 31337) return true;
-
         try vm.activeFork() returns (uint id) {
-            return id != 0;
+            return true;
         } catch {
-            return false;
+            return block.chainid == 31337;
         }
     }
 

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -551,7 +551,7 @@ abstract contract SiloDeploy is CommonDeploy {
     function _assertInitialBalanceAmount(address _token, address _user) internal view {
         if (_localOrFork()) return;
 
-        uint256 initialDepositAmount = 1e5;
+        uint256 initialDepositAmount = 1e3;
 
         require(
             IERC20(_token).balanceOf(_user) >= initialDepositAmount,

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -585,7 +585,7 @@ abstract contract SiloDeploy is CommonDeploy {
         vm.stopBroadcast();
     }
 
-    function _localOrFork() internal returns (bool) {
+    function _localOrFork() internal view returns (bool) {
         if (block.chainid == 31337) return true;
 
         try vm.activeFork() returns (uint id) {

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -37,6 +37,7 @@ import {IsContract} from "silo-core/contracts/lib/IsContract.sol";
 /// @dev use `SiloDeployWithDeployerOwner` or `SiloDeployWithHookReceiverOwner`
 abstract contract SiloDeploy is CommonDeploy {
     uint256 private constant _BYTES32_SIZE = 32;
+    uint256 private constant _INITIAL_DEPOSIT = 1e3;
 
     string public configName;
     uint256 public privateKey;
@@ -550,11 +551,9 @@ abstract contract SiloDeploy is CommonDeploy {
 
     function _assertInitialBalanceAmount(address _token, address _user) internal view {
         if (_localOrFork()) return;
-
-        uint256 initialDepositAmount = 1e3;
-
+        
         require(
-            IERC20(_token).balanceOf(_user) >= initialDepositAmount,
+            IERC20(_token).balanceOf(_user) >= _INITIAL_DEPOSIT,
             string.concat("missing ",IERC20Metadata(_token).symbol()," balance for initial deposit")
         );
     }
@@ -575,12 +574,11 @@ abstract contract SiloDeploy is CommonDeploy {
 
         uint256 deployerPrivateKey = privateKey == 0 ? uint256(vm.envBytes32("PRIVATE_KEY")) : privateKey;
         address deployerAddr = vm.addr(deployerPrivateKey);
-        uint256 initialDeposit = 1e5;
 
         vm.startBroadcast(deployerPrivateKey);
 
-        _asset.approve(address(_silo), initialDeposit);
-        _silo.deposit(initialDeposit, deployerAddr);
+        _asset.approve(address(_silo), _INITIAL_DEPOSIT);
+        _silo.deposit(_INITIAL_DEPOSIT, deployerAddr);
 
         vm.stopBroadcast();
     }

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -549,6 +549,8 @@ abstract contract SiloDeploy is CommonDeploy {
     }
 
     function _assertInitialBalanceAmount(address _token, address _user) internal view {
+        if (_localOrFork()) return;
+
         uint256 initialDepositAmount = 1e5;
 
         require(
@@ -558,6 +560,8 @@ abstract contract SiloDeploy is CommonDeploy {
     }
 
     function _executeInitialDeposits(ISiloConfig _siloConfig) internal {
+        if (_localOrFork()) return;
+
         console2.log("[SiloCommonDeploy] _executeInitialDeposits()");
 
         (address silo0, address silo1) = _siloConfig.getSilos();
@@ -567,6 +571,8 @@ abstract contract SiloDeploy is CommonDeploy {
     }
 
     function _doInitialDeposit(IERC20 _asset, ISilo _silo) internal {
+        if (_localOrFork()) return;
+
         uint256 deployerPrivateKey = privateKey == 0 ? uint256(vm.envBytes32("PRIVATE_KEY")) : privateKey;
         address deployerAddr = vm.addr(deployerPrivateKey);
         uint256 initialDeposit = 1e5;
@@ -577,6 +583,16 @@ abstract contract SiloDeploy is CommonDeploy {
         _silo.deposit(initialDeposit, deployerAddr);
 
         vm.stopBroadcast();
+    }
+
+    function _localOrFork() internal returns (bool) {
+        if (block.chainid == 31337) return true;
+
+        try vm.activeFork() returns (uint id) {
+            return id != 0;
+        } catch {
+            return false;
+        }
     }
 
     function _x_() internal pure virtual returns (string memory) {


### PR DESCRIPTION
## Problem

1. We want to avoid donation attack on freshly deployed Silo. 
2. We want this process to be automated.

## Solution

Deposit dust (1e3) to new deployed Silo inside our deployment script to protect agains attack.
