### PR TITLE
silo-core: added mainnet silo implementation to known implementations

### DIFF
--- a/silo-core/deploy/silo/_siloImplementations.json
+++ b/silo-core/deploy/silo/_siloImplementations.json
@@ -30,5 +30,11 @@
             "implementation": "0xd3De080436b9d38DC315944c16d89C050C414Fed",
             "description": "original implementation"
         }
+    ],
+    "mainnet": [
+        {
+            "implementation": "0xEF1BC66E0eA9717a3f2C969633A989D6BF41024B",
+            "description": "original implementation"
+        }
     ]
 }


### PR DESCRIPTION
Fixes SILO-<!-- ticket ID -->

## Problem

Mainnet silo implementation was no added to the silo-core/deploy/silo/_siloImplementations.json which caused a silo verifier checks to fail.

## Solution

Added mainnet silo implementation address into silo-core/deploy/silo/_siloImplementations.json
