### PR TITLE
silo foundry utils 0.0.19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "silo-foundry-utils"]
 	path = gitmodules/silo-foundry-utils
 	url = https://github.com/silo-finance/silo-foundry-utils
-	branch = v0.0.18
+	branch = v0.0.19
 [submodule "gitmodules/uniswap/v3-periphery"]
 	path = gitmodules/uniswap/v3-periphery
 	url = https://github.com/Uniswap/v3-periphery


### PR DESCRIPTION
## Problem

- Dependency on the forge-std StdChains.sol file, which causes issues when we work with chains that are not added to the StdChains.sol.
- Deployments script that saves addresses into JSON changes the order of entities in the JSON file every time it writes into the files.

## Solution

Bump silo foundry utils version to 0.0.19, where these issues were fixed.
