### PR TITLE
silo-oracles: better price formatting

### DIFF
--- a/silo-oracles/deploy/CommonDeploy.sol
+++ b/silo-oracles/deploy/CommonDeploy.sol
@@ -48,9 +48,45 @@ contract CommonDeploy is Deployer {
             out /= 10;
         }
 
-        if (e < 3 || _in < 1e7) return vm.toString(_in);
+        if (e < 3 || _in < 1e6) return string.concat(vm.toString(_in), _digits(_in));
 
-        return string.concat(vm.toString(out), "e", vm.toString(e));
+        return string.concat(vm.toString(out), "e", vm.toString(e), _digits(_in));
+    }
+
+    function _formatPriceInE18(uint256 _in) internal pure returns (string memory) {
+        if (_in < 1e4) return string.concat(vm.toString(_in), _digits(_in));
+        if (_in < 1e7) return _formatNumberInE(_in);
+
+        uint256 integerPart = _in / 1e18;
+        uint256 fractionalPart = _in % 1e18;
+
+        string memory integerStr = vm.toString(integerPart);
+        uint256 leadingZeros = 18 - bytes(vm.toString(fractionalPart)).length;
+
+        while (fractionalPart != 0 && fractionalPart % 10 == 0) {
+            fractionalPart /= 10;
+        }
+
+        string memory fractionalStr = vm.toString(fractionalPart);
+
+        for (uint256 i = 0; i < leadingZeros; i++) {
+            fractionalStr = string.concat("0", fractionalStr);
+        }
+
+        if (integerPart == 0) {
+            return string.concat("0.", fractionalStr, "e18");
+        } if (fractionalPart == 0) {
+            return string.concat(integerStr, "e18");
+        } else {
+            return string.concat(integerStr, ".", fractionalStr, "e18");
+        }
+    }
+
+    function _digits(uint256 _in) internal pure returns (string memory) {
+        uint256 l = bytes(vm.toString(_in)).length;
+        if (l < 6) return "";
+
+        return string.concat(" [", vm.toString(l) ," digits]");
     }
 
     function _printMetadata(address _token) internal view {

--- a/silo-oracles/deploy/chainlink-v3-oracle/ChainlinkV3OracleDeploy.s.sol
+++ b/silo-oracles/deploy/chainlink-v3-oracle/ChainlinkV3OracleDeploy.s.sol
@@ -58,7 +58,7 @@ contract ChainlinkV3OracleDeploy is CommonDeploy {
 
         console2.log("Using token decimals:");
         uint256 price = printQuote(oracle, config, uint256(10 ** config.baseToken.decimals()));
-        console2.log("Price in quote token divided by 1e18: ", _formatNumberInE(price / 1e18));
+        console2.log("Price in quote token divided by 1e18: ", _formatPriceInE18(price / 1e18));
 
         ChainlinkV3OracleConfig oracleConfig = oracle.oracleConfig();
         IChainlinkV3Oracle.ChainlinkV3Config memory oracleConfigLive = oracleConfig.getConfig();
@@ -81,7 +81,7 @@ contract ChainlinkV3OracleDeploy is CommonDeploy {
     ) internal view returns (uint256 quote) {
          try _oracle.quote(_baseAmount, address(_config.baseToken)) returns (uint256 price) {
             require(price > 0, string.concat("Quote for ", _formatNumberInE(_baseAmount), " wei is 0"));
-            console2.log(string.concat("Quote for ", _formatNumberInE(_baseAmount), " wei is ", _formatNumberInE(price)));
+            console2.log(string.concat("Quote for ", _formatNumberInE(_baseAmount), " wei is ", _formatPriceInE18(price)));
             quote = price;
         } catch {
             console2.log(string.concat("Failed to quote", _formatNumberInE(_baseAmount), "wei"));


### PR DESCRIPTION
## Problem

Personally, I spend some time to verify prices and display format is is not perfect.

## Solution

I polish scipt and result is as follow:

```
  Quote for 1 wei is 1
  Quote for 10 wei is 10
  Quote for 1e6 [7 digits] wei is 1011086 [7 digits]
  Quote for 1e8 [9 digits] wei is 0.000000000101108651e18
  Quote for 1e18 [19 digits] wei is 1.011086516808925132e18
  Quote for 1e36 [37 digits] wei is 1011086516808925132e18
```
