### PR TITLE
silo-core: Pendle LP tokens wrap/unwrap via SiloRouter

### DIFF
--- a/common/addresses/AddrKey.sol
+++ b/common/addresses/AddrKey.sol
@@ -28,4 +28,5 @@ library AddrKey {
     string constant public EGGS = "EGGS";
     string constant public PENDLE_ORACLE = "PENDLE_ORACLE";
     string constant public PYTH_SHADOW_USD_aggregator = "PYTH_SHADOW_USD_aggregator";
+    string constant public WRAPPER_LPT_eUSDe_14AUG25 = "Wrapper-LPT-sUSDe-25SEP25";
 }

--- a/silo-core/contracts/interfaces/IPendleWrapperLike.sol
+++ b/silo-core/contracts/interfaces/IPendleWrapperLike.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0;
+
+interface IPendleWrapperLike {
+    function wrap(address _receiver, uint256 _netLpIn) external;
+    function unwrap(address _receiver, uint256 _netWrapIn) external;
+    function LP() external view returns (address);
+}

--- a/silo-core/contracts/interfaces/ISiloRouterV2Implementation.sol
+++ b/silo-core/contracts/interfaces/ISiloRouterV2Implementation.sol
@@ -5,6 +5,7 @@ import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
 
 import {ISilo} from "./ISilo.sol";
 import {IWrappedNativeToken} from "./IWrappedNativeToken.sol";
+import {IPendleWrapperLike} from "./IPendleWrapperLike.sol";
 
 interface ISiloRouterV2Implementation {
     /// @notice Wrap native token to wrapped native token
@@ -20,6 +21,34 @@ interface ISiloRouterV2Implementation {
     /// @param _native The address of the native token
     /// @param _amount The amount of wrapped native token to unwrap
     function unwrap(IWrappedNativeToken _native, uint256 _amount) external payable;
+
+    /// @notice Wrap pendle LP token to wrapped pendle LP token
+    /// @dev Pendle LP tokens needs to be approved to the router before wrapping
+    /// @param _wrapper The address of the pendle wrapper
+    /// @param _pendleLPToken The address of the pendle LP token
+    /// @param _amount The amount of pendle LP token to wrap
+    function wrapPendleLP(
+        IPendleWrapperLike _wrapper,
+        IERC20 _pendleLPToken,
+        address _receiver,
+        uint256 _amount
+    ) external;
+
+    /// @notice Unwrap wrapped pendle LP token to pendle LP token
+    /// @param _wrapper The address of the pendle wrapper
+    /// @param _receiver The address of the receiver
+    /// @param _amount The amount of wrapped pendle LP token to unwrap
+    function unwrapPendleLP(
+        IPendleWrapperLike _wrapper,
+        address _receiver,
+        uint256 _amount
+    ) external;
+
+    /// @notice Unwrap all wrapped pendle LP token to pendle LP token
+    /// @dev By "all" it means all tokens on the router's balance
+    /// @param _wrapper The address of the pendle wrapper
+    /// @param _receiver The address of the receiver
+    function unwrapAllPendleLP(IPendleWrapperLike _wrapper, address _receiver) external;
 
     /// @notice Unwrap all wrapped native token to native token
     /// @dev Tokens are unwrapped to the router's balance.

--- a/silo-core/test/foundry/SiloRouter/SiloRouterPendleLPTs.sol
+++ b/silo-core/test/foundry/SiloRouter/SiloRouterPendleLPTs.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {AddrLib} from "silo-foundry-utils/lib/AddrLib.sol";
+import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+
+import {SiloRouterV2Deploy} from "silo-core/deploy/SiloRouterV2Deploy.s.sol";
+import {SiloRouterV2} from "silo-core/contracts/silo-router/SiloRouterV2.sol";
+import {IPendleWrapperLike} from "silo-core/contracts/interfaces/IPendleWrapperLike.sol";
+import {SiloRouterV2Implementation} from "silo-core/contracts/silo-router/SiloRouterV2Implementation.sol";
+import {AddrKey} from "common/addresses/AddrKey.sol";
+
+/*
+FOUNDRY_PROFILE=core_test forge test --mc SiloRouterPendleLPTsTest --ffi -vv
+ */
+contract SiloRouterPendleLPTsTest is Test {
+    SiloRouterV2 public router;
+    IPendleWrapperLike public wrapper;
+    IERC20 public pendleLPToken;
+    address public depositor = makeAddr("Depositor");
+    address public pendleLPWhale = 0xF6853c77a2452576EaE5af424975a101FfC47308;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("RPC_MAINNET"), 22722152); // forking block Jun 17 2025
+
+        string memory chainAlias = ChainsLib.chainAlias();
+
+        AddrLib.init();
+        wrapper = IPendleWrapperLike(AddrLib.getAddressSafe(chainAlias, AddrKey.WRAPPER_LPT_eUSDe_14AUG25));
+        pendleLPToken = IERC20(wrapper.LP());
+
+        SiloRouterV2Deploy deployer = new SiloRouterV2Deploy();
+        deployer.disableDeploymentsSync();
+        router = deployer.run();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test --mt test_wrapPendleLP --ffi -vv
+     */
+    function test_wrapPendleLP() public {
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(depositor), 0, "Expect to have no wrapped pendle LP tokens");
+
+        uint256 amount = 100e18;
+
+        vm.prank(pendleLPWhale);
+        pendleLPToken.transfer(depositor, amount);
+
+        assertEq(pendleLPToken.balanceOf(depositor), amount, "Expect to have 100 pendle LP tokens");
+
+        vm.prank(depositor);
+        pendleLPToken.approve(address(router), amount);
+
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeCall(SiloRouterV2Implementation.wrapPendleLP, (wrapper, pendleLPToken, depositor, amount));
+
+        vm.prank(depositor);
+        router.multicall{value: 0}(data);
+
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(depositor), amount, "Expect to have 100 wrapped pendle LP tokens");
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test --mt test_unwrapPendleLP --ffi -vv
+     */
+    function test_unwrapPendleLP() public {
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(depositor), 0, "Expect to have no wrapped pendle LP tokens");
+
+        uint256 amount = 100e18;
+
+        vm.prank(pendleLPWhale);
+        pendleLPToken.transfer(depositor, amount);
+
+        vm.prank(depositor);
+        pendleLPToken.approve(address(wrapper), amount);
+
+        vm.prank(depositor);
+        wrapper.wrap(address(router), amount);
+
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(address(router)), amount, "Expect to have 100 wrapped pendle LP tokens");
+
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeCall(SiloRouterV2Implementation.unwrapPendleLP, (wrapper, depositor, amount));
+
+        vm.prank(depositor);
+        router.multicall{value: 0}(data);
+
+        assertEq(pendleLPToken.balanceOf(depositor), amount, "Expect to have 100 pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(address(router)), 0, "Expect to have no wrapped pendle LP tokens");
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test --mt test_unwrapAllPendleLP --ffi -vv
+     */
+    function test_unwrapAllPendleLP() public {
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(depositor), 0, "Expect to have no wrapped pendle LP tokens");
+
+        uint256 amount = 100e18;
+
+        vm.prank(pendleLPWhale);
+        pendleLPToken.transfer(depositor, amount);
+
+        vm.prank(depositor);
+        pendleLPToken.approve(address(wrapper), amount);
+
+        vm.prank(depositor);
+        wrapper.wrap(address(router), amount);
+
+        assertEq(pendleLPToken.balanceOf(depositor), 0, "Expect to have no pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(address(router)), amount, "Expect to have 100 wrapped pendle LP tokens");
+
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encodeCall(SiloRouterV2Implementation.unwrapAllPendleLP, (wrapper, depositor));
+
+        vm.prank(depositor);
+        router.multicall{value: 0}(data);
+
+        assertEq(pendleLPToken.balanceOf(depositor), amount, "Expect to have 100 pendle LP tokens");
+        assertEq(IERC20(address(wrapper)).balanceOf(address(router)), 0, "Expect to have no wrapped pendle LP tokens");
+    }
+}


### PR DESCRIPTION
## Problem

We have Pendle LP tokens markets that have as an asset Pendle LP token wrapper. We don't have wrap-unwrap functionality for this kind of token.

## Solution

Implemented `wrapPendleLP`, `unwrapPendleLP`, and `unwrapAllPendleLP` functions in the SiloRouter 
