### PR TITLE
accept native token in manual liquidation

### DIFF
--- a/silo-core/contracts/utils/liquidationHelper/ManualLiquidationHelper.sol
+++ b/silo-core/contracts/utils/liquidationHelper/ManualLiquidationHelper.sol
@@ -39,6 +39,8 @@ contract ManualLiquidationHelper is TokenRescuer {
         TOKENS_RECEIVER = _tokensReceiver;
     }
 
+    receive() external payable {}
+
     /// @dev open method to rescue tokens, tokens will be transferred to `TOKENS_RECEIVER`
     function rescueTokens(IERC20 _token) external virtual {
         _rescueTokens(TOKENS_RECEIVER, _token);


### PR DESCRIPTION
Fixes SILO-4142
## Problem

tx fail because we not accept native on manual liquidation helper
https://sonicscan.org/tx/0xb7e93a2b83612e5d178d6e1cb16d3e3ed22c808b860034ac96f3264b72d871c4

## Solution

accept native token