### PR TITLE
forge-std 1.9.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "foundry"]
 	path = gitmodules/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.8.1
+	branch = v1.9.7
 [submodule "silo-foundry-utils"]
 	path = gitmodules/silo-foundry-utils
 	url = https://github.com/silo-finance/silo-foundry-utils

--- a/silo-core/test/foundry/Silo/deploy/SiloDeploy.i.sol
+++ b/silo-core/test/foundry/Silo/deploy/SiloDeploy.i.sol
@@ -110,7 +110,7 @@ contract SiloDeployTest is IntegrationTest {
         Vm.Wallet memory wallet1 = vm.createWallet("eoa1");
         Vm.Wallet memory wallet2 = vm.createWallet("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         ISiloConfig siloConfig1 = _siloDeploy
             .useConfig(SiloConfigsNames.SILO_FULL_CONFIG_TEST)
@@ -121,7 +121,7 @@ contract SiloDeployTest is IntegrationTest {
 
         ISiloConfig.ConfigData memory siloConfigData1 = siloConfig1.getConfig(silo0);
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         ISiloConfig siloConfig2 = _siloDeploy
             .useConfig(SiloConfigsNames.SILO_FULL_CONFIG_TEST)

--- a/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxBorrow/MaxBorrowAndFractions.i.sol
@@ -63,7 +63,7 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         uint256 depositAmount = 1e6;
         _doDeposit(depositAmount);
 
-        snapshot = vm.snapshot();
+        snapshot = vm.snapshotState();
     }
 
     /*
@@ -109,13 +109,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = false;
 
         _executeBorrowScenario1(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario1(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario1(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -127,13 +127,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = true;
 
         _executeBorrowScenario1(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario1(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario1(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeBorrowScenario1(uint256 _firstBorrowAmount, bool _borrowShares) internal {
@@ -170,13 +170,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = false;
 
         _executeBorrowScenario2(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario2(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario2(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -188,13 +188,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = true;
 
         _executeBorrowScenario2(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario2(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario2(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeBorrowScenario2(uint256 _firstBorrowAmount, bool _borrowShares) internal {
@@ -230,13 +230,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = false;
 
         _executeBorrowScenario3(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario3(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario3(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -248,13 +248,13 @@ contract MaxBorrowAndFractions is SiloLittleHelper, Test {
         bool borrowShares = true;
 
         _executeBorrowScenario3(50, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario3(silo1.maxBorrow(address(this)) / 2, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeBorrowScenario3(0, borrowShares);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeBorrowScenario3(uint256 _firstBorrowAmount, bool _borrowShares) internal {

--- a/silo-core/test/foundry/Silo/max/maxWithdraw/MaxWithdrawAndFractions.i.sol
+++ b/silo-core/test/foundry/Silo/max/maxWithdraw/MaxWithdrawAndFractions.i.sol
@@ -32,7 +32,7 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         uint256 depositAmount = 1e6;
         _doDeposit(depositAmount);
 
-        snapshot = vm.snapshot();
+        snapshot = vm.snapshotState();
     }
 
     /*
@@ -72,13 +72,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = false;
 
         _executeWithdrawScenario1(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario1(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario1(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -90,13 +90,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = true;
 
         _executeWithdrawScenario1(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario1(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario1(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeWithdrawScenario1(uint256 _borrowAmount, bool _redeem) internal {
@@ -133,13 +133,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = false;
 
         _executeWithdrawScenario2(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario2(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario2(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -151,13 +151,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = true;
 
         _executeWithdrawScenario2(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario2(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario2(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeWithdrawScenario2(uint256 _borrowAmount, bool _redeem) internal {
@@ -192,13 +192,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = false;
 
         _executeWithdrawScenario3(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario3(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario3(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     /*
@@ -210,13 +210,13 @@ contract MaxWithdrawAndFractions is SiloLittleHelper, Test {
         bool redeem = true;
 
         _executeWithdrawScenario3(50, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario3(silo0.maxBorrow(borrower) / 2, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         _executeWithdrawScenario3(0, redeem);
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
     }
 
     function _executeWithdrawScenario3(uint256 _borrowAmount, bool _redeem) internal {

--- a/silo-core/test/foundry/Silo/reentrancy/MaliciousToken.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/MaliciousToken.sol
@@ -48,7 +48,7 @@ contract MaliciousToken is MintableToken, Test {
 
         TestStateLib.disableReentrancy();
 
-        uint256 stateBeforeReentrancyTest = vm.snapshot();
+        uint256 stateBeforeReentrancyTest = vm.snapshotState();
 
         for (uint j = 0; j < _methodRegistries.length; j++) {
             uint256 totalMethods = _methodRegistries[j].supportedMethodsLength();
@@ -61,7 +61,7 @@ contract MaliciousToken is MintableToken, Test {
 
                 method.verifyReentrancy();
 
-                vm.revertTo(stateBeforeReentrancyTest);
+                vm.revertToState(stateBeforeReentrancyTest);
             }
         }
 

--- a/silo-core/test/foundry/Silo/reentrancy/SiloReentrancy.t.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/SiloReentrancy.t.sol
@@ -56,7 +56,7 @@ contract SiloReentrancyTest is Test {
 
         emit log_string("\n\nRunning reentrancy test");
 
-        uint256 stateBeforeTest = vm.snapshot();
+        uint256 stateBeforeTest = vm.snapshotState();
 
         for (uint j = 0; j < methodRegistries.length; j++) {
             uint256 totalMethods = methodRegistries[j].supportedMethodsLength();
@@ -77,7 +77,7 @@ contract SiloReentrancyTest is Test {
                 entered = siloConfig.reentrancyGuardEntered();
                 assertTrue(!entered, "Reentrancy should be disabled after calling the method");
 
-                vm.revertTo(stateBeforeTest);
+                vm.revertToState(stateBeforeTest);
             }
         }
     }

--- a/silo-core/test/foundry/Silo/reentrancy/methods/silo/FlashLoanReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/silo/FlashLoanReentrancyTest.sol
@@ -42,7 +42,7 @@ contract FlashLoanReentrancyTest is MethodReentrancyTest {
         uint256 flashLoanAmount = 1e18;
         bytes memory data;
 
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         TestStateLib.disableReentrancy();
 
@@ -52,6 +52,6 @@ contract FlashLoanReentrancyTest is MethodReentrancyTest {
         // no reentrancy test as flashLoan allows to reenter
         silo.flashLoan(IERC3156FlashBorrower(address(this)), address(token), flashLoanAmount, data);
 
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
     }
 }

--- a/silo-core/test/foundry/incentives/SiloIncentivesController.t.sol
+++ b/silo-core/test/foundry/incentives/SiloIncentivesController.t.sol
@@ -1115,12 +1115,12 @@ contract SiloIncentivesControllerTest is Test {
     }
 
     function _claimRewards(address _user, address _to, string memory _programName) internal {
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         vm.prank(_user);
         IDistributionManager.AccruedRewards[] memory accruedRewards1 = _controller.claimRewards(_to);
 
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         string[] memory programsNames = new string[](1);
         programsNames[0] = _programName;

--- a/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
+++ b/silo-core/test/foundry/interestRateModel/InterestRateModelV2ConfigFactory.t.sol
@@ -141,12 +141,12 @@ contract InterestRateModelV2FactoryTest is Test, InterestRateModelConfigs {
 
         IInterestRateModelV2.Config memory config = _defaultConfig();
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         (, IInterestRateModelV2 irm) = factory.create(config, bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         (, IInterestRateModelV2 irm2) = factory.create(config, bytes32(0));

--- a/silo-core/test/invariants/utils/mocks/TestERC20.sol
+++ b/silo-core/test/invariants/utils/mocks/TestERC20.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
-import {MockERC20} from "forge-std/mocks/MockERC20.sol";
+import {ERC20} from "openzeppelin5/token/ERC20/ERC20.sol";
 
-contract TestERC20 is MockERC20 {
-    constructor(string memory name, string memory symbol, uint8 decimals) {
-        initialize(name, symbol, decimals);
+contract TestERC20 is ERC20 {
+    uint8 _decimals;
+
+    constructor(string memory name, string memory symbol, uint8 decimals_) ERC20(name, symbol) {
+        _decimals = decimals_;
     }
 
     function mint(address to, uint256 value) public virtual {
@@ -14,5 +16,9 @@ contract TestERC20 is MockERC20 {
 
     function burn(address from, uint256 value) public virtual {
         _burn(from, value);
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
     }
 }

--- a/silo-oracles/test/foundry/chainlinkV3/ChainlinkV3OracleFactory.t.sol
+++ b/silo-oracles/test/foundry/chainlinkV3/ChainlinkV3OracleFactory.t.sol
@@ -84,12 +84,12 @@ contract ChainlinkV3OracleFactoryTest is ChainlinkV3Configs {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         ChainlinkV3Oracle oracle1 = ORACLE_FACTORY.create(_dydxChainlinkV3Config(1e20, 0), bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         ChainlinkV3Oracle oracle2 = ORACLE_FACTORY.create(_dydxChainlinkV3Config(1e20, 0), bytes32(0));

--- a/silo-oracles/test/foundry/dia/DIAOracleFactory.t.sol
+++ b/silo-oracles/test/foundry/dia/DIAOracleFactory.t.sol
@@ -110,12 +110,12 @@ contract DIAOracleFactoryTest is DIAConfigDefault {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         DIAOracle oracle1 = ORACLE_FACTORY.create(_defaultDIAConfig(1e20, 0), bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         DIAOracle oracle2 = ORACLE_FACTORY.create(_defaultDIAConfig(1e20, 0), bytes32(0));

--- a/silo-oracles/test/foundry/erc4626/ERC4626Oracle.t.sol
+++ b/silo-oracles/test/foundry/erc4626/ERC4626Oracle.t.sol
@@ -99,7 +99,7 @@ contract ERC4626OracleTest is Test {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         ISiloOracle oracle1 = _factory.createERC4626Oracle(
@@ -107,7 +107,7 @@ contract ERC4626OracleTest is Test {
             bytes32(0)
         );
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         ISiloOracle oracle2 = _factory.createERC4626Oracle(

--- a/silo-oracles/test/foundry/forwarder/OracleForwarder.t.sol
+++ b/silo-oracles/test/foundry/forwarder/OracleForwarder.t.sol
@@ -131,7 +131,7 @@ contract OracleForwarderTest is Test {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         IOracleForwarder oracle1 = _factory.createOracleForwarder(
@@ -140,7 +140,7 @@ contract OracleForwarderTest is Test {
             bytes32(0)
         );
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         IOracleForwarder oracle2 = _factory.createOracleForwarder(

--- a/silo-oracles/test/foundry/pendle/PendlePTOracle.t.sol
+++ b/silo-oracles/test/foundry/pendle/PendlePTOracle.t.sol
@@ -349,12 +349,12 @@ contract PendlePTOracleTest is Forking {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         address oracle1 = address(factory.create(underlyingOracle, market, bytes32(0)));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         address oracle2 = address(factory.create(underlyingOracle, market, bytes32(0)));

--- a/silo-oracles/test/foundry/pendle/PendlePTToAssetOracle.t.sol
+++ b/silo-oracles/test/foundry/pendle/PendlePTToAssetOracle.t.sol
@@ -293,12 +293,12 @@ contract PendlePTToAssetOracleTest is Forking {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         address oracle1 = address(factory.create(underlyingOracle, market, bytes32(0)));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         address oracle2 = address(factory.create(underlyingOracle, market, bytes32(0)));

--- a/silo-oracles/test/foundry/pyth/PythAggregatorFactory.t.sol
+++ b/silo-oracles/test/foundry/pyth/PythAggregatorFactory.t.sol
@@ -83,12 +83,12 @@ contract PythAggregatorFactoryTest is TokensGenerator {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         AggregatorV3Interface ethAggregator1 = factory.deploy(PYTH_ETH_USD_PRICE_ID, bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         AggregatorV3Interface ethAggregator2 = factory.deploy(PYTH_ETH_USD_PRICE_ID, bytes32(0));

--- a/silo-oracles/test/foundry/scaler/OracleScaler.t.sol
+++ b/silo-oracles/test/foundry/scaler/OracleScaler.t.sol
@@ -103,12 +103,12 @@ contract OracleScalerTest is Test {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         ISiloOracle scaler1 = factory.createOracleScaler(USDC, bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         ISiloOracle scaler2 = factory.createOracleScaler(USDC, bytes32(0));

--- a/silo-oracles/test/foundry/uniswapV3/UniswapV3OracleFactoryReorgTest.t.sol
+++ b/silo-oracles/test/foundry/uniswapV3/UniswapV3OracleFactoryReorgTest.t.sol
@@ -41,12 +41,12 @@ contract UniswapV3OracleFactoryReorgTest is UniswapPools {
         address eoa1 = makeAddr("eoa1");
         address eoa2 = makeAddr("eoa2");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(eoa1);
         UniswapV3Oracle oracle1 = UNISWAPV3_ORACLE_FACTORY.create(creationConfig, bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(eoa2);
         UniswapV3Oracle oracle2 = UNISWAPV3_ORACLE_FACTORY.create(creationConfig, bytes32(0));

--- a/silo-vaults/test/foundry/IdleVault.t.sol
+++ b/silo-vaults/test/foundry/IdleVault.t.sol
@@ -67,12 +67,12 @@ contract IdleVaultTest is IntegrationTest {
         address devWallet = makeAddr("dev wallet");
         address otherWallet = makeAddr("other wallet");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(devWallet);
         IdleVault idleVault1 = factory.createIdleVault(IERC4626(idleMarket), bytes32(0));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(otherWallet);
         IdleVault idleVault2 = factory.createIdleVault(IERC4626(idleMarket), bytes32(0));

--- a/silo-vaults/test/foundry/SiloVaultsFactoryTest.sol
+++ b/silo-vaults/test/foundry/SiloVaultsFactoryTest.sol
@@ -186,7 +186,7 @@ contract SiloVaultsFactoryTest is IntegrationTest {
         address devWallet = makeAddr("dev wallet");
         address otherWallet = makeAddr("other wallet");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(devWallet);
         ISiloVault siloVault = factory.createSiloVault(
@@ -202,7 +202,7 @@ contract SiloVaultsFactoryTest is IntegrationTest {
             new IIncentivesClaimingLogicFactory[](0)
         );
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(otherWallet);
         ISiloVault siloVault2 = factory.createSiloVault(

--- a/silo-vaults/test/foundry/call-and-reenter/MaliciousToken.sol
+++ b/silo-vaults/test/foundry/call-and-reenter/MaliciousToken.sol
@@ -51,7 +51,7 @@ contract MaliciousToken is MintableToken, Test {
 
         TestStateLib.disableReentrancy();
 
-        uint256 stateBeforeReentrancyTest = vm.snapshot();
+        uint256 stateBeforeReentrancyTest = vm.snapshotState();
 
         for (uint j = 0; j < _methodRegistries.length; j++) {
             uint256 totalMethods = _methodRegistries[j].supportedMethodsLength();
@@ -64,7 +64,7 @@ contract MaliciousToken is MintableToken, Test {
 
                 method.verifyReentrancy();
 
-                vm.revertTo(stateBeforeReentrancyTest);
+                vm.revertToState(stateBeforeReentrancyTest);
             }
         }
 

--- a/silo-vaults/test/foundry/call-and-reenter/VaultReentrancy.t.sol
+++ b/silo-vaults/test/foundry/call-and-reenter/VaultReentrancy.t.sol
@@ -62,7 +62,7 @@ contract VaultReentrancyTest is Test {
 
         emit log_string("\n\nRunning reentrancy test");
 
-        uint256 stateBeforeTest = vm.snapshot();
+        uint256 stateBeforeTest = vm.snapshotState();
 
         for (uint j = 0; j < methodRegistries.length; j++) {
             uint256 totalMethods = methodRegistries[j].supportedMethodsLength();
@@ -83,7 +83,7 @@ contract VaultReentrancyTest is Test {
                 entered = vault.reentrancyGuardEntered();
                 assertTrue(!entered, "Reentrancy should be disabled after calling the method");
 
-                vm.revertTo(stateBeforeTest);
+                vm.revertToState(stateBeforeTest);
             }
         }
     }

--- a/silo-vaults/test/foundry/incentives/claiming-logics/SiloIncentivesControllerCL.t.sol
+++ b/silo-vaults/test/foundry/incentives/claiming-logics/SiloIncentivesControllerCL.t.sol
@@ -51,7 +51,7 @@ contract SiloIncentivesControllerCLTest is Test {
         address devWallet = makeAddr("dev wallet");
         address otherWallet = makeAddr("other wallet");
 
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         vm.prank(devWallet);
         SiloIncentivesControllerCL logic1 = factory.createIncentivesControllerCL(
@@ -60,7 +60,7 @@ contract SiloIncentivesControllerCLTest is Test {
             bytes32(0)
         );
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
 
         vm.prank(otherWallet);
         SiloIncentivesControllerCL logic2 = factory.createIncentivesControllerCL(

--- a/x-silo/test/foundry/XSilo.t.sol
+++ b/x-silo/test/foundry/XSilo.t.sol
@@ -215,7 +215,7 @@ contract XSiloTest is Test {
 
         vm.startPrank(user);
 
-        uint256 checkpoint = vm.snapshot();
+        uint256 checkpoint = vm.snapshotState();
 
         vm.assume(xSilo.previewWithdraw(assetsToWithdraw) > 0);
 
@@ -223,7 +223,7 @@ contract XSiloTest is Test {
 
         assertEq(asset.balanceOf(user), assetsToWithdraw, "user got exact amount of tokens");
 
-        vm.revertTo(checkpoint);
+        vm.revertToState(checkpoint);
 
         emit log_named_uint("withdrawnShares after rollback", withdrawnShares);
         emit log_named_uint("_siloToWithdraw", assetsToWithdraw);


### PR DESCRIPTION
## Problem

In tests we used `vm.snapshot` and `vm.revertTo` functions which are deprecated and during the build forge showed warnings that these methods will be removed.

## Solution

Updated forge-std to the latest (1.9.7) version.
Updated tests to use:
- `vm.snapshotState` instead of the `vm.snapshot`
- `vm.revertToState` instead of the  `vm.revertTo`
