### PR TITLE
[1 of X] fix warnings 

### DIFF
--- a/silo-core/contracts/SiloLens.sol
+++ b/silo-core/contracts/SiloLens.sol
@@ -32,8 +32,8 @@ contract SiloLens is ISiloLens {
     }
 
     /// @inheritdoc ISiloLens
-    function getRawLiquidity(ISilo _silo) external view virtual returns (uint256 liquidity) {
-        return SiloLensLib.getRawLiquidity(_silo);
+    function getRawLiquidity(ISilo _silo) external view virtual returns (uint256 rawLiquidity) {
+        rawLiquidity = SiloLensLib.getRawLiquidity(_silo);
     }
 
     /// @inheritdoc ISiloLens
@@ -130,8 +130,8 @@ contract SiloLens is ISiloLens {
     }
 
     /// @inheritdoc ISiloLens
-    function totalDeposits(ISilo _silo) external view returns (uint256 totalDeposits) {
-        totalDeposits = _silo.getTotalAssetsStorage(ISilo.AssetType.Collateral);
+    function totalDeposits(ISilo _silo) external view returns (uint256 totalDepositsAmount) {
+        totalDepositsAmount = _silo.getTotalAssetsStorage(ISilo.AssetType.Collateral);
     }
 
     /// @inheritdoc ISiloLens
@@ -205,11 +205,11 @@ contract SiloLens is ISiloLens {
     }
 
     /// @inheritdoc ISiloLens
-    function getUtilization(ISilo _silo) external view returns (uint256) {
+    function getUtilization(ISilo _silo) external view returns (uint256 utilization) {
         ISilo.UtilizationData memory data = _silo.utilizationData();
 
         if (data.collateralAssets != 0) {
-            return data.debtAssets * _PRECISION_DECIMALS / data.collateralAssets;
+            utilization = data.debtAssets * _PRECISION_DECIMALS / data.collateralAssets;
         }
     }
 

--- a/silo-core/contracts/hooks/PendleRewardsClaimer.sol
+++ b/silo-core/contracts/hooks/PendleRewardsClaimer.sol
@@ -83,7 +83,7 @@ contract PendleRewardsClaimer is GaugeHookReceiver, PartialLiquidation, IPendleR
     }
 
     /// @inheritdoc IHookReceiver
-    function beforeAction(address _silo, uint256 _action, bytes calldata _inputAndOutput)
+    function beforeAction(address /* _silo */, uint256 _action, bytes calldata /* _inputAndOutput */)
         public
         virtual
         onlySilo()
@@ -201,7 +201,7 @@ contract PendleRewardsClaimer is GaugeHookReceiver, PartialLiquidation, IPendleR
     /// @notice Get the incentives controller from the `GaugeHookReceiver` configuration.
     /// @dev Reverts if the incentives controller is not configured.
     /// @return controller
-    function _getIncentivesControllerSafe() private returns (ISiloIncentivesController controller) {
+    function _getIncentivesControllerSafe() private view returns (ISiloIncentivesController controller) {
         controller = ISiloIncentivesController(address(configuredGauges[protectedShareToken]));
         require(address(controller) != address(0), IncentivesControllerRequired());
     }

--- a/silo-core/contracts/incentives/SiloIncentivesController.sol
+++ b/silo-core/contracts/incentives/SiloIncentivesController.sol
@@ -26,11 +26,13 @@ contract SiloIncentivesController is BaseIncentivesController {
 
     /// @param _owner address of wallet that can manage the storage
     /// @param _notifier address of the notifier
-    /// @param _shareToken is contract with IERC20 interface with users balances, based based on which
+    /// @param _shareTokenAddress is contract with IERC20 interface with users balances, based based on which
     /// rewards distribution is calculated
-    constructor(address _owner, address _notifier, address _shareToken) BaseIncentivesController(_owner, _notifier) {
-        require(_shareToken != address(0), EmptyShareToken());
-        SHARE_TOKEN = _shareToken;
+    constructor(address _owner, address _notifier, address _shareTokenAddress)
+        BaseIncentivesController(_owner, _notifier)
+    {
+        require(_shareTokenAddress != address(0), EmptyShareToken());
+        SHARE_TOKEN = _shareTokenAddress;
     }
 
     /// @inheritdoc ISiloIncentivesController

--- a/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
+++ b/silo-core/contracts/interestRateModel/InterestRateModelV2.sol
@@ -389,8 +389,8 @@ contract InterestRateModelV2 is IInterestRateModel, IInterestRateModelV2 {
             int256 ri_max = _max(_config.ri, rlin_max) +_config.ki * (DP - _config.uopt) * MAX_TIME / DP;
             int256 ri_min = -_config.ki * _config.uopt * MAX_TIME / DP;
             rcur_max = ri_max + rp_max;
-            int256 rcur_min = ri_min + rp_min;
-            int256 rcur_ann_max = rcur_max * YEAR;
+            ri_min + rp_min;
+            rcur_max * YEAR;
         }
 
         {
@@ -399,7 +399,7 @@ contract InterestRateModelV2 is IInterestRateModel, IInterestRateModelV2 {
             int256 slope_max = slopei_max + _config.kcrit * _config.beta / DP * (DP - _config.ucrit) / DP;
             int256 slope_min = slopei_min;
 
-            int256 x_max = rcur_max * 2 * MAX_TIME / 2 + (_max(slope_max, -slope_min) * MAX_TIME)**2 / 2;
+            rcur_max * 2 * MAX_TIME / 2 + (_max(slope_max, -slope_min) * MAX_TIME)**2 / 2;
         }
     }
 

--- a/silo-core/test/foundry/utils/UnassignedCodeTest.sol
+++ b/silo-core/test/foundry/utils/UnassignedCodeTest.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+contract A {
+    function div(uint256 d) external pure {
+        1 / d;
+    }
+}
+
+contract UnassignedCodeTest is Test {
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --mt test_ifUnassignedCodeWillBeExecuted
+    */
+    function test_ifUnassignedCodeWillBeExecuted() public {
+        A a = new A();
+        a.div(1);
+
+        vm.expectRevert(); // because of / 0
+        a.div(0);
+    }
+}


### PR DESCRIPTION
Fixes SILO-4155

## Problem

we have hundreds of compilation warnings in code.

## Solution

Fix warnings, so code is clean. This will be done in multiple steps (PRs). After merge, we don't have redeploy anything. This change will have 0 affect on functionality.
