### PR TITLE
silo-core: add reentrancy check for rescue tokens

### DIFF
--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -82,6 +82,8 @@ interface ILeverageUsingSiloFlashloan {
 
     function SWAP_MODULE() external view returns (IGeneralSwapModule);
 
+    function reentrancyGuardEntered() internal view returns (bool);
+
     /// @return debtReceiveApproval amount of approval (receive approval) that is required on debt share token
     /// in order to borow on behalf of user when opening leverage position
     function calculateDebtReceiveApproval(ISilo _flashFrom, uint256 _flashAmount)

--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -82,8 +82,6 @@ interface ILeverageUsingSiloFlashloan {
 
     function SWAP_MODULE() external view returns (IGeneralSwapModule);
 
-    function reentrancyGuardEntered() internal view returns (bool);
-
     /// @return debtReceiveApproval amount of approval (receive approval) that is required on debt share token
     /// in order to borow on behalf of user when opening leverage position
     function calculateDebtReceiveApproval(ISilo _flashFrom, uint256 _flashAmount)

--- a/silo-core/contracts/leverage/LeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/leverage/LeverageUsingSiloFlashloan.sol
@@ -5,8 +5,6 @@ import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "openzeppelin5/token/ERC20/extensions/IERC20Permit.sol";
 import {SafeERC20} from "openzeppelin5/token/ERC20/utils/SafeERC20.sol";
 
-import {TransientReentrancy} from "../hooks/_common/TransientReentrancy.sol";
-
 import {RevertLib} from "../lib/RevertLib.sol";
 
 import {ISilo} from "../interfaces/ISilo.sol";
@@ -48,7 +46,6 @@ abstract contract LeverageUsingSiloFlashloan is
     ILeverageUsingSiloFlashloan,
     IERC3156FlashBorrower,
     RevenueModule,
-    TransientReentrancy,
     LeverageTxState
 {
     using SafeERC20 for IERC20;

--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -7,7 +7,7 @@ import {Ownable2Step, Ownable} from "openzeppelin5/access/Ownable2Step.sol";
 import {SafeERC20} from "openzeppelin5/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "openzeppelin5/utils/math/Math.sol";
 
-import {TransientReentrancy} from "../hooks/_common/TransientReentrancy.sol";
+import {TransientReentrancy} from "../../hooks/_common/TransientReentrancy.sol";
 
 /// @title Revenue Module for Leverage Operations
 /// @notice This contract collects and distributes revenue from leveraged operations.
@@ -102,8 +102,6 @@ abstract contract RevenueModule is TransientReentrancy, Ownable2Step, Pausable {
         _token.safeTransfer(receiver, balance);
         emit LeverageRevenue(address(_token), balance, receiver);
     }
-
-    function reentrancyGuardEntered() internal view returns (bool);
 
     /// @notice Calculates the leverage fee for a given amount
     /// @dev Will always return at least 1 if fee > 0 and calculation rounds down

--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -50,6 +50,9 @@ abstract contract RevenueModule is Ownable2Step, Pausable {
     /// @dev Thrown when there is no revenue to withdraw
     error NoRevenue();
 
+    /// @dev Thrown when reentrancy is detected
+    error ReentrancyGuardReentrantCall();
+
     /// @dev Thrown when revenue receiver is not set
     error ReceiverNotSet();
 
@@ -91,6 +94,8 @@ abstract contract RevenueModule is Ownable2Step, Pausable {
 
     /// @param _token ERC20 token to rescue
     function rescueTokens(IERC20 _token) public {
+        require(!reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
+
         uint256 balance = _token.balanceOf(address(this));
         require(balance != 0, NoRevenue());
 
@@ -100,6 +105,8 @@ abstract contract RevenueModule is Ownable2Step, Pausable {
         _token.safeTransfer(receiver, balance);
         emit LeverageRevenue(address(_token), balance, receiver);
     }
+
+    function reentrancyGuardEntered() internal view returns (bool);
 
     /// @notice Calculates the leverage fee for a given amount
     /// @dev Will always return at least 1 if fee > 0 and calculation rounds down

--- a/silo-core/test/foundry/Silo/reentrancy/SiloReentrancy.t.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/SiloReentrancy.t.sol
@@ -21,7 +21,9 @@ import {
     LeverageUsingSiloFlashloanWithGeneralSwapDeploy
 } from "silo-core/deploy/LeverageUsingSiloFlashloanWithGeneralSwapDeploy.s.sol";
 
-// FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc SiloReentrancyTest
+/*
+FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc SiloReentrancyTest
+*/
 contract SiloReentrancyTest is Test {
     ISiloConfig public siloConfig;
     

--- a/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensArrayReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensArrayReentrancyTest.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
 import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {ReentrancyGuard} from "openzeppelin5/utils/ReentrancyGuard.sol";
 
 import {RevenueModule} from "silo-core/contracts/leverage/modules/RevenueModule.sol";
 import {MethodReentrancyTest} from "../MethodReentrancyTest.sol";
@@ -29,12 +30,7 @@ contract RescueTokensArrayReentrancyTest is MethodReentrancyTest {
         IERC20[] memory tokens = new IERC20[](1);
         tokens[0] = IERC20(token);
 
-        if (tokens[0].balanceOf(address(leverage)) != 0) {
-            vm.expectRevert(RevenueModule.ReceiverNotSet.selector);
-        } else {
-            vm.expectRevert(RevenueModule.NoRevenue.selector);
-        }
-
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
         leverage.rescueTokens(tokens);
     }
 

--- a/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensSingleReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensSingleReentrancyTest.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
 import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {ReentrancyGuard} from "openzeppelin5/utils/ReentrancyGuard.sol";
 
 import {RevenueModule} from "silo-core/contracts/leverage/modules/RevenueModule.sol";
 import {MethodReentrancyTest} from "../MethodReentrancyTest.sol";
@@ -22,12 +23,7 @@ contract RescueTokensSingleReentrancyTest is MethodReentrancyTest {
         RevenueModule leverage = _getLeverage();
         address token = TestStateLib.token0();
 
-        if (IERC20(token).balanceOf(address(leverage)) != 0) {
-            vm.expectRevert(RevenueModule.ReceiverNotSet.selector);
-        } else {
-            vm.expectRevert(RevenueModule.NoRevenue.selector);
-        }
-
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
         leverage.rescueTokens(IERC20(token));
     }
 


### PR DESCRIPTION
Fixes SILO-4199

## Problem

rescue token method has no reentrant protection

## Solution

add reentrancy protection.

