### PR TITLE
silo-core: update natspec for leverage

### DIFF
--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -128,7 +128,7 @@ interface ILeverageUsingSiloFlashloan {
         CloseLeverageArgs calldata _closeLeverageArgs
     ) external;
 
-    /// @notice Does not support fee on transfer tokens. It also does not support borrow on same asset.
+    /// @notice Closes opened leveraged position. Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval is done using Permit
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token

--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -118,7 +118,8 @@ interface ILeverageUsingSiloFlashloan {
         Permit calldata _depositAllowance
     ) external;
 
-    /// @notice Closes opened leveraged position. Does not support fee on transfer tokens. It also does not support borrow on same asset.
+    /// @notice Closes opened leveraged position.
+    /// Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval can be done using Permit, for that case please use `closeLeveragePositionPermit`
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token
@@ -128,7 +129,8 @@ interface ILeverageUsingSiloFlashloan {
         CloseLeverageArgs calldata _closeLeverageArgs
     ) external;
 
-    /// @notice Closes opened leveraged position. Does not support fee on transfer tokens. It also does not support borrow on same asset.
+    /// @notice Closes opened leveraged position.
+    /// Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval is done using Permit
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token

--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -118,7 +118,7 @@ interface ILeverageUsingSiloFlashloan {
         Permit calldata _depositAllowance
     ) external;
 
-    /// @notice Does not support fee on transfer tokens. It also does not support borrow on same asset.
+    /// @notice Closes opened leveraged position. Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval can be done using Permit, for that case please use `closeLeveragePositionPermit`
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token

--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -90,6 +90,7 @@ interface ILeverageUsingSiloFlashloan {
         returns (uint256 debtReceiveApproval);
 
     /// @notice Performs leverage operation using a flash loan and token swap. Does not support fee on transfer tokens.
+    /// It also does not support borrow on same asset.
     /// @dev Reverts if the amount is so high that fee calculation fails
     /// This method requires approval for transfer collateral from borrower to leverage contract and to create
     /// debt position. Approval for collateral can be done using Permit (if asset supports it), for that case please
@@ -104,6 +105,7 @@ interface ILeverageUsingSiloFlashloan {
     ) external payable;
 
     /// @notice Performs leverage operation using a flash loan and token swap. Does not support fee on transfer tokens.
+    /// It also does not support borrow on same asset.
     /// @dev Reverts if the amount is so high that fee calculation fails
     /// @param _flashArgs Flash loan configuration
     /// @param _swapArgs Swap call data and settings, that will swap all flashloan amount into collateral
@@ -116,7 +118,7 @@ interface ILeverageUsingSiloFlashloan {
         Permit calldata _depositAllowance
     ) external;
 
-    /// @notice Does not support fee on transfer tokens.
+    /// @notice Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval can be done using Permit, for that case please use `closeLeveragePositionPermit`
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token
@@ -126,7 +128,7 @@ interface ILeverageUsingSiloFlashloan {
         CloseLeverageArgs calldata _closeLeverageArgs
     ) external;
 
-    /// @notice Does not support fee on transfer tokens.
+    /// @notice Does not support fee on transfer tokens. It also does not support borrow on same asset.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval is done using Permit
     /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token

--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -89,7 +89,7 @@ interface ILeverageUsingSiloFlashloan {
         view
         returns (uint256 debtReceiveApproval);
 
-    /// @notice Performs leverage operation using a flash loan and token swap
+    /// @notice Performs leverage operation using a flash loan and token swap. Does not support fee on transfer tokens.
     /// @dev Reverts if the amount is so high that fee calculation fails
     /// This method requires approval for transfer collateral from borrower to leverage contract and to create
     /// debt position. Approval for collateral can be done using Permit (if asset supports it), for that case please
@@ -103,7 +103,7 @@ interface ILeverageUsingSiloFlashloan {
         DepositArgs calldata _depositArgs
     ) external payable;
 
-    /// @notice Performs leverage operation using a flash loan and token swap
+    /// @notice Performs leverage operation using a flash loan and token swap. Does not support fee on transfer tokens.
     /// @dev Reverts if the amount is so high that fee calculation fails
     /// @param _flashArgs Flash loan configuration
     /// @param _swapArgs Swap call data and settings, that will swap all flashloan amount into collateral
@@ -116,17 +116,20 @@ interface ILeverageUsingSiloFlashloan {
         Permit calldata _depositAllowance
     ) external;
 
+    /// @notice Does not support fee on transfer tokens.
     /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
     /// borrower balance). Approval can be done using Permit, for that case please use `closeLeveragePositionPermit`
-    /// @param _swapArgs Swap call data and settings,
-    /// that should swap enough collateral to repay flashloan in debt token
+    /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token
     /// @param _closeLeverageArgs configuration for closing position
     function closeLeveragePosition(
         bytes calldata _swapArgs,
         CloseLeverageArgs calldata _closeLeverageArgs
     ) external;
 
-    /// that should swap enough collateral to repay flashloan in debt token
+    /// @notice Does not support fee on transfer tokens.
+    /// @dev This method requires approval for withdraw all collateral (so minimal requires amount for allowance is
+    /// borrower balance). Approval is done using Permit
+    /// @param _swapArgs Swap call data and settings, it should swap enough collateral to repay flashloan in debt token
     /// @param _closeLeverageArgs configuration for closing position
     /// @param _withdrawAllowance Permit for leverage contract to withdraw all borrower collateral tokens
     function closeLeveragePositionPermit(


### PR DESCRIPTION
Fixes SILO-4227

## Problem

Leverage (like Silo) does not support fee on transfer tokens and borrow on same asset.

## Solution

Add comment about it.
