### PR TITLE
silo-core: approve exact amount in leverage

### DIFF
--- a/silo-core/contracts/leverage/modules/GeneralSwapModule.sol
+++ b/silo-core/contracts/leverage/modules/GeneralSwapModule.sol
@@ -29,7 +29,7 @@ contract GeneralSwapModule is IGeneralSwapModule {
         if (_swapArgs.exchangeProxy == address(0)) revert ExchangeAddressZero();
 
         // Approve token for spending by the exchange
-        _setMaxAllowance(IERC20(_swapArgs.sellToken), _swapArgs.allowanceTarget, _maxApprovalAmount);
+        IERC20(_swapArgs.sellToken).forceApprove(_swapArgs.allowanceTarget, _maxApprovalAmount);
 
         // Perform low-level call to any method and any smart contract provided by the caller.
         // solhint-disable-next-line avoid-low-level-calls
@@ -48,10 +48,5 @@ contract GeneralSwapModule is IGeneralSwapModule {
         if (balance != 0) {
             IERC20(_token).safeTransfer(msg.sender, balance);
         }
-    }
-
-    function _setMaxAllowance(IERC20 _asset, address _spender, uint256 _requiredAmount) internal virtual {
-        uint256 allowance = _asset.allowance(address(this), _spender);
-        if (allowance < _requiredAmount) _asset.forceApprove(_spender, type(uint256).max);
     }
 }

--- a/silo-core/test/foundry/leverage/LeverageUsingSiloWithGeneralSwapTest.t.sol
+++ b/silo-core/test/foundry/leverage/LeverageUsingSiloWithGeneralSwapTest.t.sol
@@ -201,6 +201,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         _closeLeverage(user, closeArgs, swapArgs);
 
         _assertUserHasNoPosition(user);
+        _assertNoApprovalsFromLeverage({_checkSwap: false});
         _assertSiloLeverageHasNoTokens();
         _assertThereIsNoDebtApprovals(user);
 
@@ -263,6 +264,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         emit log_named_decimal_uint("LTV", siloLens.getUserLTV(silo0, user), 16);
 
         _assertThereIsNoDebtApprovals(user);
+        _assertNoApprovalsFromLeverage({_checkSwap: true});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -330,6 +332,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         assertEq(siloLens.getUserLTV(silo0, user), 0.677920141007389330e18, "user has leverage position");
 
         _assertThereIsNoDebtApprovals(user);
+        _assertNoApprovalsFromLeverage({_checkSwap: true});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -373,6 +376,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         assertEq(siloLens.getUserLTV(silo0, user), 0.677920141007389330e18, "user has leverage position");
 
         _assertThereIsNoDebtApprovals(user);
+        _assertNoApprovalsFromLeverage({_checkSwap: true});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -394,6 +398,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         assertEq(silo0.balanceOf(user), 0, "user nas NO collateral");
         assertEq(silo1.maxRepay(user), 0, "user has NO debt");
 
+        _assertNoApprovalsFromLeverage({_checkSwap: false});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -429,6 +434,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         assertEq(silo0.balanceOf(user), 0, "user nas NO collateral");
         assertEq(silo1.maxRepay(user), 0, "user has NO debt");
 
+        _assertNoApprovalsFromLeverage({_checkSwap: false});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -462,6 +468,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         siloLeverage.openLeveragePosition(flashArgs, abi.encode(swapArgs), depositArgs);
 
         _assertThereIsNoDebtApprovals(user);
+        _assertNoApprovalsFromLeverage({_checkSwap: true});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -597,6 +604,7 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
 
         assertEq(silo1.maxRepay(user), 0.10908e18, "users debt");
 
+        _assertNoApprovalsFromLeverage({_checkSwap: true});
         _assertSiloLeverageHasNoTokens();
     }
 
@@ -828,6 +836,29 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
                 IERC20(_customToken).balanceOf(address(siloLeverage)),
                 0,
                 "siloLeverage has no custom tokens"
+            );
+        }
+    }
+
+    // we not always checking swap, because eg on closing, we not using whole approval
+    function _assertNoApprovalsFromLeverage(bool _checkSwap) internal view {
+        assertEq(token0.allowance(address(siloLeverage), address(silo0)), 0, "[_assertNoApprovals] token0 for silo0");
+        assertEq(token0.allowance(address(siloLeverage), address(silo1)), 0, "[_assertNoApprovals] token0 for silo1");
+
+        assertEq(token1.allowance(address(siloLeverage), address(silo0)), 0, "[_assertNoApprovals] token1 for silo0");
+        assertEq(token1.allowance(address(siloLeverage), address(silo1)), 0, "[_assertNoApprovals] token1 for silo1");
+
+        if (_checkSwap) {
+            assertEq(
+                token0.allowance(address(siloLeverage.SWAP_MODULE()), address(swap)),
+                0,
+                "[_assertNoApprovals] token0 for swap router"
+            );
+
+            assertEq(
+                token1.allowance(address(siloLeverage.SWAP_MODULE()), address(swap)),
+                0,
+                "[_assertNoApprovals] token1 for swap router"
             );
         }
     }


### PR DESCRIPTION
Fixes SILO-4222

## Problem

Leverage contract uses max approvals internally because gas optimisation. We made decision to use exact approvals.

## Solution

change max approval to exact amount.
