### PR TITLE
silo-core: Leverage rescueTokens fn only leverage  user

### DIFF
--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -72,7 +72,7 @@ abstract contract RevenueModule is TransientReentrancy {
         emit TokensRescued(address(0), balance);
     }
 
-    /// @notice We do not expect anyone else to engage with a contract except the user for whom it was created.
+    /// @notice We do not expect anyone else to engage with a contract except the user for whom this contract instance was cloned.
     /// @param _tokens List of tokens to rescue
     function rescueTokens(IERC20[] calldata _tokens) external {
         for (uint256 i; i < _tokens.length; i++) {

--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -80,7 +80,7 @@ abstract contract RevenueModule is TransientReentrancy {
         }
     }
 
-    /// @notice We do not expect anyone else to engage with a contract except the user for whom it was created.
+    /// @notice We do not expect anyone else to engage with a contract except the user for whom this contract instance was cloned.
     /// @param _token ERC20 token to rescue
     function rescueTokens(IERC20 _token) public nonReentrant onlyLeverageUser {
         uint256 balance = _token.balanceOf(address(this));

--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -60,8 +60,8 @@ abstract contract RevenueModule is TransientReentrancy {
         _;
     }
 
-    /// @notice We do not expect anyone else to engage with a contract except the user for whom it was created.
-    /// @dev Use this function to rescue native tokens
+    /// @notice We do not expect anyone else to engage with a contract except the user
+    /// for whom this contract instance was cloned.
     function rescueNativeTokens() external nonReentrant onlyLeverageUser {
         uint256 balance = address(this).balance;
         require(balance != 0, EmptyBalance(address(0)));
@@ -72,7 +72,8 @@ abstract contract RevenueModule is TransientReentrancy {
         emit TokensRescued(address(0), balance);
     }
 
-    /// @notice We do not expect anyone else to engage with a contract except the user for whom this contract instance was cloned.
+    /// @notice We do not expect anyone else to engage with a contract except the user
+    /// for whom this contract instance was cloned.
     /// @param _tokens List of tokens to rescue
     function rescueTokens(IERC20[] calldata _tokens) external {
         for (uint256 i; i < _tokens.length; i++) {
@@ -80,7 +81,8 @@ abstract contract RevenueModule is TransientReentrancy {
         }
     }
 
-    /// @notice We do not expect anyone else to engage with a contract except the user for whom this contract instance was cloned.
+    /// @notice We do not expect anyone else to engage with a contract except the user
+    /// for whom this contract instance was cloned.
     /// @param _token ERC20 token to rescue
     function rescueTokens(IERC20 _token) public nonReentrant onlyLeverageUser {
         uint256 balance = _token.balanceOf(address(this));

--- a/silo-core/contracts/leverage/modules/RevenueModule.sol
+++ b/silo-core/contracts/leverage/modules/RevenueModule.sol
@@ -52,6 +52,7 @@ abstract contract RevenueModule is TransientReentrancy {
         _;
     }
 
+    /// @notice We do not expect anyone else to engage with a contract except the user for whom it was created.
     /// @param _tokens List of tokens to rescue
     function rescueTokens(IERC20[] calldata _tokens) external {
         for (uint256 i; i < _tokens.length; i++) {
@@ -59,6 +60,7 @@ abstract contract RevenueModule is TransientReentrancy {
         }
     }
 
+    /// @notice We do not expect anyone else to engage with a contract except the user for whom it was created.
     /// @param _token ERC20 token to rescue
     function rescueTokens(IERC20 _token) public nonReentrant {
         require(ROUTER.predictUserLeverageContract(msg.sender) == address(this), OnlyLeverageUser());

--- a/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueNativeTokensReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueNativeTokensReentrancyTest.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {ReentrancyGuard} from "openzeppelin5/utils/ReentrancyGuard.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {RevenueModule} from "silo-core/contracts/leverage/modules/RevenueModule.sol";
+import {MethodReentrancyTest} from "../MethodReentrancyTest.sol";
+import {TestStateLib} from "../../TestState.sol";
+import {ILeverageRouter} from "silo-core/contracts/interfaces/ILeverageRouter.sol";
+
+contract RescueNativeTokensReentrancyTest is MethodReentrancyTest {
+    // The same as user that opened leverage position
+    Vm.Wallet public wallet = vm.createWallet("User");
+
+    function callMethod() external {
+        ILeverageRouter leverageRouter = ILeverageRouter(TestStateLib.leverageRouter());
+        RevenueModule leverage = RevenueModule(leverageRouter.LEVERAGE_IMPLEMENTATION());
+
+        vm.expectRevert(RevenueModule.OnlyLeverageUser.selector);
+        leverage.rescueNativeTokens();
+    }
+
+    function verifyReentrancy() external {
+        ILeverageRouter leverageRouter = ILeverageRouter(TestStateLib.leverageRouter());
+        RevenueModule module = RevenueModule(leverageRouter.predictUserLeverageContract(wallet.addr));
+
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        module.rescueNativeTokens();
+    }
+
+    function methodDescription() external pure returns (string memory description) {
+        description = "rescueNativeTokens()";
+    }
+}

--- a/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensArrayReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensArrayReentrancyTest.sol
@@ -27,7 +27,7 @@ contract RescueTokensArrayReentrancyTest is MethodReentrancyTest {
         IERC20[] memory tokens = new IERC20[](1);
         tokens[0] = IERC20(token);
 
-        vm.expectRevert(RevenueModule.NoRevenue.selector);
+        vm.expectRevert(RevenueModule.OnlyLeverageUser.selector);
 
         leverage.rescueTokens(tokens);
     }

--- a/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensSingleReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/leverage/RescueTokensSingleReentrancyTest.sol
@@ -24,7 +24,7 @@ contract RescueTokensSingleReentrancyTest is MethodReentrancyTest {
         RevenueModule leverage = RevenueModule(leverageRouter.LEVERAGE_IMPLEMENTATION());
         address token = TestStateLib.token0();
 
-        vm.expectRevert(RevenueModule.NoRevenue.selector);
+        vm.expectRevert(RevenueModule.OnlyLeverageUser.selector);
         leverage.rescueTokens(IERC20(token));
     }
 

--- a/silo-core/test/foundry/Silo/reentrancy/registries/LeverageMethodsRegistry.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/registries/LeverageMethodsRegistry.sol
@@ -27,6 +27,7 @@ import {SetLeverageFeeReentrancyTest} from "../methods/leverage/SetLeverageFeeRe
 import {SetRevenueReceiverReentrancyTest} from "../methods/leverage/SetRevenueReceiverReentrancyTest.sol";
 import {RescueTokensArrayReentrancyTest} from "../methods/leverage/RescueTokensArrayReentrancyTest.sol";
 import {RescueTokensSingleReentrancyTest} from "../methods/leverage/RescueTokensSingleReentrancyTest.sol";
+import {RescueNativeTokensReentrancyTest} from "../methods/leverage/RescueNativeTokensReentrancyTest.sol";
 import {CalculateLeverageFeeReentrancyTest} from "../methods/leverage/CalculateLeverageFeeReentrancyTest.sol";
 import {OwnerReentrancyTest} from "../methods/leverage/OwnerReentrancyTest.sol";
 import {PendingOwnerReentrancyTest} from "../methods/leverage/PendingOwnerReentrancyTest.sol";
@@ -63,6 +64,7 @@ contract LeverageMethodsRegistry is IMethodsRegistry {
         _registerMethod(new SetRevenueReceiverReentrancyTest());
         _registerMethod(new RescueTokensArrayReentrancyTest());
         _registerMethod(new RescueTokensSingleReentrancyTest());
+        _registerMethod(new RescueNativeTokensReentrancyTest());
         _registerMethod(new CalculateLeverageFeeReentrancyTest());
         _registerMethod(new OwnerReentrancyTest());
         _registerMethod(new PendingOwnerReentrancyTest());

--- a/silo-core/test/foundry/_mocks/RevertingReceiver.sol
+++ b/silo-core/test/foundry/_mocks/RevertingReceiver.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+/// @notice Mock contract that reverts when receiving native tokens
+contract RevertingReceiver {
+    error NativeTokenNotAccepted();
+
+    receive() external payable {
+        revert NativeTokenNotAccepted();
+    }
+
+    fallback() external payable {
+        revert NativeTokenNotAccepted();
+    }
+}

--- a/silo-core/test/foundry/leverage/LeverageUsingSiloWithGeneralSwapTest.t.sol
+++ b/silo-core/test/foundry/leverage/LeverageUsingSiloWithGeneralSwapTest.t.sol
@@ -34,6 +34,7 @@ import {WETH} from "./mocks/WETH.sol";
 
 import {MintableToken} from "../_common/MintableToken.sol";
 import {SiloFixture, SiloConfigOverride} from "../_common/fixtures/SiloFixture.sol";
+import {RevertingReceiver} from "../_mocks/RevertingReceiver.sol";
 
 
 /*
@@ -1077,9 +1078,92 @@ contract LeverageUsingSiloFlashloanWithGeneralSwapTest is SiloLittleHelper, Test
         IERC20[] memory tokens = new IERC20[](2);
         tokens[0] = token0;
         tokens[1] = token1;
-        
+
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(RevenueModule.EmptyBalance.selector, address(token1)));
         siloLeverage.rescueTokens(tokens);
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_rescueNativeTokens_success
+    */
+    function test_rescueNativeTokens_success() public {
+        _openLeverageExample();
+
+        address user = wallet.addr;
+
+        // Get user's leverage contract
+        address userLeverageContract = leverageRouter.predictUserLeverageContract(user);
+
+        // Use vm.deal to directly set ETH balance on the leverage contract
+        uint256 rescueAmount = 1e18;
+        vm.deal(userLeverageContract, rescueAmount);
+
+        uint256 userBalanceBefore = user.balance;
+        uint256 contractBalanceBefore = userLeverageContract.balance;
+        
+        assertEq(contractBalanceBefore, rescueAmount, "Contract should have native tokens");
+
+        vm.expectEmit(true, true, false, true, userLeverageContract);
+        emit RevenueModule.TokensRescued(address(0), rescueAmount);
+
+        vm.prank(user);
+        siloLeverage.rescueNativeTokens();
+
+        // Verify native tokens were transferred to user
+        assertEq(user.balance, userBalanceBefore + rescueAmount, "User should receive rescued native tokens");
+        assertEq(userLeverageContract.balance, 0, "Leverage contract should have no native tokens");
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_rescueNativeTokens_noBalance
+    */
+    function test_rescueNativeTokens_noBalance() public {
+        _openLeverageExample();
+
+        address user = wallet.addr;
+
+        // Verify leverage contract has no native tokens
+        address userLeverageContract = leverageRouter.predictUserLeverageContract(user);
+        assertEq(userLeverageContract.balance, 0, "Contract should have no native tokens");
+
+        // Try to rescue native tokens when there's no balance (should revert)
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(RevenueModule.EmptyBalance.selector, address(0)));
+        siloLeverage.rescueNativeTokens();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_rescueNativeTokens_nativeTokenTransferFailed
+    */
+    function test_rescueNativeTokens_nativeTokenTransferFailed() public {
+        _openLeverageExample();
+
+        address user = wallet.addr;
+
+        // Get user's leverage contract
+        address userLeverageContract = leverageRouter.predictUserLeverageContract(user);
+
+        // Use vm.deal to set native token balance on the leverage contract
+        uint256 rescueAmount = 1e18;
+        vm.deal(userLeverageContract, rescueAmount);
+        
+        // Deploy reverting receiver and get its bytecode
+        RevertingReceiver revertingReceiver = new RevertingReceiver();
+        bytes memory revertingCode = address(revertingReceiver).code;
+
+        // Replace user's code with reverting receiver code
+        vm.etch(user, revertingCode);
+
+        // Verify contract has native tokens to rescue
+        assertEq(userLeverageContract.balance, rescueAmount, "Contract should have native tokens");
+
+        // Try to rescue native tokens - should fail because user's receive() reverts
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(RevenueModule.NativeTokenTransferFailed.selector));
+        siloLeverage.rescueNativeTokens();
+
+        // Verify native tokens are still in the contract
+        assertEq(userLeverageContract.balance, rescueAmount, "Native tokens should still be in leverage contract");
     }
 }


### PR DESCRIPTION
## Problem

After the design change, we clone a leverage contract for each user. However, rescueTokens sends tokens to the DAO.

## Solution

Changed rescueTokens fn in a way that it is protected and allows only the leverage contract user, and it sends tokens to the user instead of the DAO.
