### PR TITLE
silo-core: Leverage router Natspec update

### DIFF
--- a/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
+++ b/silo-core/contracts/interfaces/ILeverageUsingSiloFlashloan.sol
@@ -82,8 +82,12 @@ interface ILeverageUsingSiloFlashloan {
 
     function SWAP_MODULE() external view returns (IGeneralSwapModule);
 
-    /// @return debtReceiveApproval amount of approval (receive approval) that is required on debt share token
-    /// in order to borrow on behalf of user when opening leverage position
+    /// @notice Calculates an amount of approval (receive approval) that is required on debt share token in order
+    /// to borrow on behalf of user when opening leverage position. This function should only be used when a flash
+    /// loan provider is the Silo contract.
+    /// @param _flashFrom Silo contract address to take flash loan from
+    /// @param _flashAmount amount of flash loan
+    /// @return debtReceiveApproval amount of receive approval
     function calculateDebtReceiveApproval(ISilo _flashFrom, uint256 _flashAmount)
         external
         view


### PR DESCRIPTION
Fixes SILO-4246

## Problem
calculateDebtReceiveApproval return value is incorrect if flashloan provider is not Silo

## Solution
The function should clarify in natspec that it should only be  used when the SILO flashloan functionality is used.
