### PR TITLE
echidna-leverage: fix approvals

### DIFF
--- a/silo-core/test/echidna-leverage/handlers/user/LeverageHandler.t.sol
+++ b/silo-core/test/echidna-leverage/handlers/user/LeverageHandler.t.sol
@@ -24,6 +24,7 @@ import {console2} from "forge-std/console2.sol";
 import {BaseHandlerLeverage} from "../../base/BaseHandlerLeverage.t.sol";
 import {TestERC20} from "silo-core/test/invariants/utils/mocks/TestERC20.sol";
 import {TestWETH} from "silo-core/test/echidna-leverage/utils/mocks/TestWETH.sol";
+import {MockSiloOracle} from "silo-core/test/invariants/utils/mocks/MockSiloOracle.sol";
 
 /// @title LeverageHandler
 /// @notice Handler test contract for a set of actions

--- a/silo-core/test/echidna-leverage/handlers/user/LeverageHandler.t.sol
+++ b/silo-core/test/echidna-leverage/handlers/user/LeverageHandler.t.sol
@@ -294,12 +294,11 @@ contract LeverageHandler is BaseHandlerLeverage {
     }
 
     function assert_AllowanceDoesNotChangedForUserWhoOnlyApprove() public {
-        assertEq(
-            _asset0.allowance(_userWhoOnlyApprove(), address(leverageRouter)), type(uint256).max, "approval0 must stay"
-        );
-        assertEq(
-            _asset1.allowance(_userWhoOnlyApprove(), address(leverageRouter)), type(uint256).max, "approval1 must stay"
-        );
+        address user = _userWhoOnlyApprove();
+        address userLeverage = address(_userPredictedLeverageContract(user));
+
+        assertEq(_asset0.allowance(user, userLeverage), type(uint256).max, "approval0 must stay");
+        assertEq(_asset1.allowance(user, userLeverage), type(uint256).max, "approval1 must stay");
     }
 
     function echidna_AllowanceDoesNotChangedForUserWhoOnlyApprove() public returns (bool) {
@@ -330,6 +329,11 @@ contract LeverageHandler is BaseHandlerLeverage {
 
     function _userLeverageContract(address _user) internal returns (LeverageUsingSiloFlashloanWithGeneralSwap) {
         return LeverageUsingSiloFlashloanWithGeneralSwap(address(leverageRouter.userLeverageContract(_user)));
+    }
+
+
+    function _userPredictedLeverageContract(address _user) internal returns (LeverageUsingSiloFlashloanWithGeneralSwap) {
+        return LeverageUsingSiloFlashloanWithGeneralSwap(address(leverageRouter.predictUserLeverageContract(_user)));
     }
 
     function _swapModuleAddress() internal returns (IGeneralSwapModule swapModule) {

--- a/silo-core/test/echidna-leverage/utils/ActorLeverage.sol
+++ b/silo-core/test/echidna-leverage/utils/ActorLeverage.sol
@@ -3,18 +3,31 @@ pragma solidity ^0.8.19;
 
 // Interfaces
 import {IERC20R} from "silo-core/contracts/interfaces/IERC20R.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
 import {Actor} from "silo-core/test/invariants/utils/Actor.sol";
+import {LeverageRouter} from "silo-core/contracts/leverage/LeverageRouter.sol";
 
 /// @notice Proxy contract for invariant suite actors to avoid aTester calling contracts
 contract ActorLeverage is Actor {
     constructor(address[] memory _tokens, address[] memory _contracts) payable Actor(_tokens, _contracts) {
         for (uint256 i = 0; i < _tokens.length; i++) {
             for (uint256 j = 0; j < _contracts.length; j++) {
-                try IERC20R(_tokens[i]).setReceiveApproval(_contracts[j], type(uint256).max) {
+                try LeverageRouter(_contracts[j]).predictUserLeverageContract(address(this)) returns (address userLeverage) {
+                    IERC20(_tokens[i]).approve(userLeverage, type(uint256).max);
+                    // revoke approval for router, leverage only needs approval on cloned contract
+                    IERC20(_tokens[i]).approve(_contracts[j], 0);
+
+                    try IERC20R(_tokens[i]).setReceiveApproval(userLeverage, type(uint256).max) {
                     // nothing to do
                 } catch {
                     // it might be not debt share token, ignore fail
                 }
+                } catch {
+                    // this is not LeverageRouter, ignore fail
+                }
+
+                
             }
         }
     }


### PR DESCRIPTION
Fixes SILO-4200

## Problem

Echidna was never able to open leverage successfully.

## Solution

Problem was with approvals. 

Swap amount can also be calculated in more precise way.
