### PR TITLE
silo-core: maxLiquidation function overestimation fix

### DIFF
--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationExecLib/LiquidationPreviewTest.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationExecLib/LiquidationPreviewTest.t.sol
@@ -106,7 +106,8 @@ contract LiquidationPreviewTest is Test, OraclesHelper {
             ltvData.borrowerDebtAssets,
             ltvData.borrowerDebtAssets,
             params.liquidationTargetLtv,
-            params.liquidationFee
+            params.liquidationFee,
+            1e18
         );
 
         emit log_named_decimal_uint("maxDebtToCover", maxDebtToCover, 18);

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxLiquidation.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/lib/PartialLiquidationLib/MaxLiquidation.t.sol
@@ -270,7 +270,8 @@ contract MaxLiquidationTest is Test, MaxRepayRawMath {
             _borrowerDebtAssets,
             borrowerDebtValue,
             _liquidationTargetLtv,
-            _liquidationFee
+            _liquidationFee,
+            1e18
         );
 
         emit log_named_decimal_uint("collateralToLiquidate", collateralToLiquidate, 18);


### PR DESCRIPTION
## Problem

The current `_UNDERESTIMATION = 2` assumes a maximum 1 wei loss per conversion. But with high ratios:
  - Loss per conversion can be up to a ratio.
  - Total loss can be up to 2 * ratio.
  - This can far exceed 2 wei.

## Solution

Change rounding error from the hardcoded 2 wei to a dynamic value calculated by 2 * ratio.
