### PR TITLE
echidna-leverage: simplify approval process on initialisation

### DIFF
--- a/silo-core/test/echidna-leverage/SetupLeverage.t.sol
+++ b/silo-core/test/echidna-leverage/SetupLeverage.t.sol
@@ -84,6 +84,8 @@ contract SetupLeverage is Setup {
         for (uint256 i; i < NUMBER_OF_ACTORS; i++) {
             // Deploy actor proxies and approve system contracts
             address _actor = _setUpActor(addresses[i], tokens, contracts);
+            ActorLeverage(payable(_actor)).initLeverageApprovals(tokens[4], leverageRouter);
+            ActorLeverage(payable(_actor)).initLeverageApprovals(tokens[7], leverageRouter);
 
             // Mint initial balances to actors
             for (uint256 j = 0; j < underlyingAssetsLength; j++) {

--- a/silo-core/test/foundry/leverage/mocks/SwapRouterMock.sol
+++ b/silo-core/test/foundry/leverage/mocks/SwapRouterMock.sol
@@ -30,7 +30,7 @@ contract SwapRouterMock {
     }
 
     fallback() external {
-        IERC20(sellToken).safeTransferFrom(msg.sender, address(this), amountIn);
-        MintableToken(buyToken).mint(msg.sender, amountOut);
+        if (amountIn != 0) IERC20(sellToken).safeTransferFrom(msg.sender, address(this), amountIn);
+        if (amountOut != 0) MintableToken(buyToken).mint(msg.sender, amountOut);
     }
 }


### PR DESCRIPTION
Fixes SILO-4200

## Problem

When I added additional code, echidna started to fail

```
ReceiveApproval(115792089237316195423570985008687907853269984665640564039457584007913129639935) from: 0x1f1ad3643dd8299a52cde0899e3d122aa7d1ffb9
error Revert 0x
error Revert 0x
error Revert 0x
error Revert 0x
error Revert 0x
Approval(115792089237316195423570985008687907853269984665640564039457584007913129639935) from: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84
Approval(0) from: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84
error Revert 0x
error Revert 0x

make: *** [echidna-leverage-assert] Error 1
```

## Solution

When redesign approval process and apply additional code, echidna run as expected. No errors.
