### PR TITLE
silo-core: Env variable for coverage report generation command

### DIFF
--- a/MOREDOCS.md
+++ b/MOREDOCS.md
@@ -126,7 +126,7 @@ brew install lcov
 rm lcov.info
 mkdir coverage
 
-FOUNDRY_PROFILE=core_with_test forge coverage --report summary --report lcov --gas-price 1 --ffi --gas-limit 40000000000 --no-match-test "_skip_|_gas_|_anvil_" > coverage/silo-core.log
+AGGREGATOR=1INCH FOUNDRY_PROFILE=core_with_test forge coverage --report summary --report lcov --gas-price 1 --ffi --gas-limit 40000000000 --no-match-test "_skip_|_gas_|_anvil_" > coverage/silo-core.log
 cat coverage/silo-core.log | grep -i 'silo-core/contracts/' > coverage/silo-core.txt
 genhtml --ignore-errors inconsistent -ignore-errors range -o coverage/silo-core/ lcov.info
 


### PR DESCRIPTION
## Problem

Missed the env variable in the command for running coverage for the silo-core.

## Solution

Added `AGGREGATOR=1INCH` to the command.
