### PR TITLE
echidna-leverage: ensure user leverage is paused when router is paused

### DIFF
--- a/silo-core/test/echidna-leverage/SetupLeverage.t.sol
+++ b/silo-core/test/echidna-leverage/SetupLeverage.t.sol
@@ -98,6 +98,8 @@ contract SetupLeverage is Setup {
 
         // set first actor an admin for leverare router
         leverageRouter.grantRole(bytes32(0), actorAddresses[0]);
+        // set first actor an pauser for leverare router
+        leverageRouter.grantRole(leverageRouter.PAUSER_ROLE(), actorAddresses[0]);
     }
 
     /// @notice Deploy an actor proxy contract for a user address


### PR DESCRIPTION
Fixes SILO-4286

## Problem

implement rule: if you pause router, you pause all leverage contracts

## Solution

echidna implementaion
