### PR TITLE
silo-core: prepare data for transfer tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ silo-core/deploy/input/_importFromCsv/
 .certora_internal
 certora/harness/vaults/contracts
 emv-**/*
+
+#scripts
+silo-core/scripts/airdrop/data.csv
+silo-core/scripts/airdrop/output.json

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,8 @@ fs_permissions = [
     { access = "read", path = "./silo-core/test/foundry/data/"},
     { access = "read", path = "./silo-core/deploy/input/"},
     { access = "read", path = "./silo-core/deploy/silo/_siloImplementations.json"},
-    { access = "read", path = "./silo-core/deploy/silo/_siloDeployments.json"}
+    { access = "read", path = "./silo-core/deploy/silo/_siloDeployments.json"},
+    { access = "read", path = "./silo-core/scripts/airdrop/output.json"}
 ]
 
 [profile.core_with_test]

--- a/silo-core/scripts/airdrop/SonicSeasonOneAirdrop.s.sol
+++ b/silo-core/scripts/airdrop/SonicSeasonOneAirdrop.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import {console2} from "forge-std/console2.sol";
+import {Script} from "forge-std/Script.sol";
+import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
+
+/**
+FOUNDRY_PROFILE=core \
+    forge script silo-core/scripts/airdrop/SonicSeasonOneAirdrop.s.sol \
+    --ffi --rpc-url $RPC_SONIC
+ */
+
+struct TransferData {
+    address addr;
+    uint256 amount;
+}
+
+contract SonicSeasonOneAirdrop is Script {
+    function run() public {
+        console2.log("Network:", ChainsLib.chainAlias());
+        TransferData[] memory data = readTransferData();
+
+        for (uint256 i; i < data.length; i++) {
+            console2.log(i, data[i].addr, data[i].amount);
+        }
+    }
+
+    function readTransferData() internal view returns (TransferData[] memory data) {
+        string memory root = vm.projectRoot();
+        string memory path = string.concat(root, "/silo-core/scripts/airdrop/output.json");
+        string memory json = vm.readFile(path);
+
+        data = abi.decode(vm.parseJson(json, string(abi.encodePacked("."))), (TransferData[]));
+    }
+}

--- a/silo-core/scripts/airdrop/prepareSonicSeasonOneAirdrop.py
+++ b/silo-core/scripts/airdrop/prepareSonicSeasonOneAirdrop.py
@@ -1,0 +1,40 @@
+import os
+import csv
+import json
+from decimal import Decimal, getcontext
+
+# 50 significant digits to avoid precision loss on 10**18 scaling 
+getcontext().prec = 50
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+input_path = os.path.join(script_dir, "data.csv")
+output_path = os.path.join(script_dir, "output.json")
+
+result = []
+
+with open(input_path, newline='') as csvfile:
+    reader = csv.reader(csvfile)
+    next(reader)
+
+    for row in reader:
+        if len(row) < 2 or not row[1].strip():
+            raise ValueError(f"Invalid or missing amount in row: {row}")
+
+        address = row[0].strip()
+
+        if not address.startswith("0x") or len(address) != 42:
+            raise ValueError(f"Invalid Ethereum address: '{address}'")
+
+        amount_str = row[1].replace(",", "").strip()
+        amount = Decimal(amount_str) * Decimal(10**18)
+        result.append({
+            "addr": address,
+            "amount": int(amount)
+        })
+
+result.sort(key=lambda x: x["amount"])
+print(json.dumps(result, indent=2))
+
+# Save to output.json
+with open(output_path, "w") as outfile:
+    json.dump(result, outfile, indent=2)


### PR DESCRIPTION
Fixes SILO-4356

### Solution
Generate json input for foundry script by csv table as an input

```
$ head -n 10 silo-core/scripts/airdrop/output.json
[
  {
    "addr": "0x123",
    "amount": 1000000000000000000
  },
  {
    "addr": "0x321",
    "amount": 1000000000000000000
  },
```