### PR TITLE
silo-oracles: optional underlying asset in ERC4626OracleHardcodeQuote

### DIFF
--- a/silo-oracles/contracts/erc4626/ERC4626Oracle.sol
+++ b/silo-oracles/contracts/erc4626/ERC4626Oracle.sol
@@ -7,14 +7,12 @@ import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 
 contract ERC4626Oracle is ISiloOracle {
     IERC4626 public immutable VAULT;
-    address public immutable UNDERLYING;
 
     error AssetNotSupported();
     error ZeroPrice();
 
     constructor(IERC4626 _vault) {
         VAULT = _vault;
-        UNDERLYING = _vault.asset();
     }
 
     /// @inheritdoc ISiloOracle
@@ -33,6 +31,6 @@ contract ERC4626Oracle is ISiloOracle {
 
     /// @inheritdoc ISiloOracle
     function quoteToken() external view virtual returns (address) {
-        return UNDERLYING;
+        return VAULT.asset();
     }
 }

--- a/silo-oracles/contracts/erc4626/ERC4626OracleHardcodeQuote.sol
+++ b/silo-oracles/contracts/erc4626/ERC4626OracleHardcodeQuote.sol
@@ -2,36 +2,19 @@
 pragma solidity 0.8.28;
 
 import {IERC4626} from "openzeppelin5/interfaces/IERC4626.sol";
+
+import {ERC4626Oracle} from "silo-oracles/contracts/erc4626/ERC4626Oracle.sol";
 import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 
-contract ERC4626OracleHardcodeQuote is ISiloOracle {
-    IERC4626 public immutable VAULT;
+contract ERC4626OracleHardcodeQuote is ERC4626Oracle {
     address internal immutable _QUOTE_TOKEN;
 
-    error AssetNotSupported();
-    error ZeroPrice();
-
-    constructor(IERC4626 _vault, address _quoteToken) {
-        VAULT = _vault;
+    constructor(IERC4626 _vault, address _quoteToken) ERC4626Oracle(_vault) {
         _QUOTE_TOKEN = _quoteToken;
     }
 
     /// @inheritdoc ISiloOracle
-    function beforeQuote(address _baseToken) external view virtual {
-        // only for an ISiloOracle interface implementation
-    }
-
-    /// @inheritdoc ISiloOracle
-    function quote(uint256 _baseAmount, address _baseToken) external view virtual returns (uint256 quoteAmount) {
-        if (_baseToken != address(VAULT)) revert AssetNotSupported();
-
-        quoteAmount = VAULT.convertToAssets(_baseAmount);
-
-        if (quoteAmount == 0) revert ZeroPrice();
-    }
-
-    /// @inheritdoc ISiloOracle
-    function quoteToken() external view virtual returns (address) {
+    function quoteToken() external view override returns (address) {
         return _QUOTE_TOKEN;
     }
 }

--- a/silo-oracles/test/foundry/erc4626/ERC4626OracleHardcodeQuote.t.sol
+++ b/silo-oracles/test/foundry/erc4626/ERC4626OracleHardcodeQuote.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC4626} from "openzeppelin5/interfaces/IERC4626.sol";
+import {ERC4626Oracle} from "silo-oracles/contracts/erc4626/ERC4626Oracle.sol";
 
 import {
     ERC4626OracleHardcodeQuoteFactoryDeploy
@@ -52,13 +53,13 @@ contract ERC4626OracleHardcodeQuoteTest is Test {
 
     // FOUNDRY_PROFILE=oracles forge test --mt test_ERC4626OracleHardcodeQuote_quote_wrongBaseToken -vvv
     function test_ERC4626OracleHardcodeQuote_quote_wrongBaseToken() public {
-        vm.expectRevert(ERC4626OracleHardcodeQuote.AssetNotSupported.selector);
+        vm.expectRevert(ERC4626Oracle.AssetNotSupported.selector);
         oracle.quote(1 ether, address(1));
     }
 
     // FOUNDRY_PROFILE=oracles forge test --mt test_ERC4626OracleHardcodeQuote_quote_revertsZeroPrice -vvv
     function test_ERC4626OracleHardcodeQuote_quote_revertsZeroPrice() public {
-        vm.expectRevert(ERC4626OracleHardcodeQuote.ZeroPrice.selector);
+        vm.expectRevert(ERC4626Oracle.ZeroPrice.selector);
         oracle.quote(0, address(vault));
 
         vm.mockCall(
@@ -67,12 +68,12 @@ contract ERC4626OracleHardcodeQuoteTest is Test {
             abi.encode(0)
         );
 
-        vm.expectRevert(ERC4626OracleHardcodeQuote.ZeroPrice.selector);
+        vm.expectRevert(ERC4626Oracle.ZeroPrice.selector);
         oracle.quote(1 ether, address(vault));
     }
 
     // FOUNDRY_PROFILE=oracles forge test --mt test_ERC4626OracleHardcodeQuote_quoteToken -vvv
-    function test_ERC4626OracleHardcodeQuote_quoteToken() public {
+    function test_ERC4626OracleHardcodeQuote_quoteToken() public view {
         assertEq(oracle.quoteToken(), quoteToken);
     }
 


### PR DESCRIPTION
Fixes SILO-4363

## Problem

ERC4626OracleHardcodeQuote in parent constructor calls underlying vault's .asset() function. This variable is not used in ERC4626OracleHardcodeQuote, because quote token is a different asset. Some vaults do not have .asset() function, so it blocks deployment.

## Solution

Do not call  .asset() in parent constructor