### PR TITLE
silo-core: IRM zero for non borrowable assets

### DIFF
--- a/silo-core/common/SiloCoreContracts.sol
+++ b/silo-core/common/SiloCoreContracts.sol
@@ -24,6 +24,7 @@ library SiloCoreContracts {
     string public constant SILO_ROUTER_V2 = "SiloRouterV2.sol";
     string public constant INCENTIVES_CONTROLLER_FACTORY = "SiloIncentivesControllerFactory.sol";
     string public constant GLOBAL_PAUSE = "GlobalPause.sol";
+    string public constant IRM_ZERO = "IRMZero.sol";
 }
 
 /// @notice SiloCoreDeployments library

--- a/silo-core/contracts/interestRateModel/IRMZero.sol
+++ b/silo-core/contracts/interestRateModel/IRMZero.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IInterestRateModel} from "silo-core/contracts/interfaces/IInterestRateModel.sol";
+
+contract IRMZero is IInterestRateModel {
+    /// @inheritdoc IInterestRateModel
+    function initialize(address _irmConfig) external {}
+
+    /// @inheritdoc IInterestRateModel
+    function getCompoundInterestRateAndUpdate(uint256, uint256, uint256) external returns (uint256) {}
+
+    /// @inheritdoc IInterestRateModel
+    function getCompoundInterestRate(address, uint256) external view returns (uint256) {}
+
+    /// @inheritdoc IInterestRateModel
+    function getCurrentInterestRate(address _silo, uint256 _blockTimestamp)
+        external
+        view
+        returns (uint256 rcur) {}
+
+    /// @inheritdoc IInterestRateModel
+    function decimals() external view returns (uint256) {}
+}

--- a/silo-core/deploy/IRMZeroDeploy.s.sol
+++ b/silo-core/deploy/IRMZeroDeploy.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {CommonDeploy} from "./_CommonDeploy.sol";
+import {SiloCoreContracts} from "silo-core/common/SiloCoreContracts.sol";
+
+import {IRMZero} from "silo-core/contracts/interestRateModel/IRMZero.sol";
+
+/**
+    FOUNDRY_PROFILE=core \
+        forge script silo-core/deploy/IRMZeroDeploy.s.sol \
+        --ffi --rpc-url $RPC_SONIC --broadcast --verify
+
+    Resume verification:
+    FOUNDRY_PROFILE=core \
+        forge script silo-core/deploy/IRMZeroDeploy.s.sol \
+        --ffi --rpc-url $RPC_INK \
+        --verify \
+        --verifier blockscout --verifier-url $VERIFIER_URL_INK \
+        --private-key $PRIVATE_KEY \
+        --resume
+*/
+contract IRMZeroDeploy is CommonDeploy {
+    function run() public returns (IRMZero irm) {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        irm = new IRMZero();
+
+        vm.stopBroadcast();
+
+        _registerDeployment(address(irm), SiloCoreContracts.IRM_ZERO);
+    }
+}

--- a/silo-core/deploy/MainnetDeploy.s.sol
+++ b/silo-core/deploy/MainnetDeploy.s.sol
@@ -14,6 +14,7 @@ import {SiloRouterV2Deploy} from "./SiloRouterV2Deploy.s.sol";
 import {SiloFactoryDeploy} from "./SiloFactoryDeploy.s.sol";
 import {SiloIncentivesControllerFactoryDeploy} from "silo-core/deploy/SiloIncentivesControllerFactoryDeploy.s.sol";
 import {ManualLiquidationHelperDeploy} from "silo-core/deploy/ManualLiquidationHelperDeploy.s.sol";
+import {IRMZeroDeploy} from "silo-core/deploy/IRMZeroDeploy.s.sol";
 
 /**
     FOUNDRY_PROFILE=core \
@@ -32,6 +33,9 @@ contract MainnetDeploy is CommonDeploy {
         TowerDeploy towerDeploy = new TowerDeploy();
         SiloRouterV2Deploy siloRouterV2Deploy = new SiloRouterV2Deploy();
         ManualLiquidationHelperDeploy manualLiquidationHelperDeploy = new ManualLiquidationHelperDeploy();
+        IRMZeroDeploy irmZeroDeploy = new IRMZeroDeploy();
+
+        irmZeroDeploy.run();
 
         SiloIncentivesControllerFactoryDeploy siloIncentivesControllerFactoryDeploy =
             new SiloIncentivesControllerFactoryDeploy();

--- a/silo-core/test/foundry/interestRateModel/IRMZeroTest.sol
+++ b/silo-core/test/foundry/interestRateModel/IRMZeroTest.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {AddrLib} from "silo-foundry-utils/lib/AddrLib.sol";
+
+import {SiloCoreContracts} from "silo-core/common/SiloCoreContracts.sol";
+import {IRMZeroDeploy} from "silo-core/deploy/IRMZeroDeploy.s.sol";
+import {IInterestRateModel} from "silo-core/contracts/interfaces/IInterestRateModel.sol";
+
+/**
+AGGREGATOR=1INCH FOUNDRY_PROFILE=core_test forge test --ffi --mc IRMZeroTest -vv
+*/
+contract IRMZeroTest is Test {
+    address silo0;
+
+    function setUp() public {
+        IRMZeroDeploy deploy = new IRMZeroDeploy();
+        deploy.disableDeploymentsSync();
+        deploy.run();
+    }
+
+    /**
+    AGGREGATOR=1INCH FOUNDRY_PROFILE=core_test forge test --ffi --mt test_IRMzero_returns_zero -vv
+    */
+    function test_IRMzero_returns_zero() public {
+        IInterestRateModel irmZero = IInterestRateModel(AddrLib.getAddress(SiloCoreContracts.IRM_ZERO));
+
+        uint256 rcomp = irmZero.getCompoundInterestRate(address(silo0), block.timestamp);
+        assertEq(rcomp, 0);
+
+        uint256 rcur = irmZero.getCurrentInterestRate(address(silo0), block.timestamp);
+        assertEq(rcur, 0);
+
+        rcomp = irmZero.getCompoundInterestRateAndUpdate(1e18, 0, block.timestamp);
+        assertEq(rcomp, 0);
+
+        uint256 decimals = irmZero.decimals();
+        assertEq(decimals, 0);
+
+        irmZero.initialize(makeAddr("anyAddress")); // do nothing
+    }
+}


### PR DESCRIPTION
## Problem

Markets with non-borrowable assets that generate no interest need an IRM that will always return zero interest.

## Solution

Create an IRM mock with methods that we are using in the silo getCompoundInterestRateAndUpdate and getCompoundInterestRate.

Coverage report:
https://silo-finance.github.io/silo-contracts-v2/coverage/feature/irm-mock-for-non-borrowable-assets/silo-core/
