### PR TITLE
foundry.toml read file permissions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -39,7 +39,8 @@ fs_permissions = [
     { access = "read", path = "./silo-core/test/foundry/data/"},
     { access = "read", path = "./silo-core/deploy/input/"},
     { access = "read", path = "./silo-core/deploy/silo/_siloDeployments.json"},
-    { access = "read", path = "./silo-core/deploy/silo/_siloImplementations.json"}
+    { access = "read", path = "./silo-core/deploy/silo/_siloImplementations.json"},
+    { access = "read", path = "./silo-core/scripts/airdrop/output.json"}
 ]
 
 [profile.core-with-invariants]


### PR DESCRIPTION
## Problem
When generating coverage report
Failing tests:
Encountered 1 failing test in silo-core/test/foundry/scripts/SonicSeasonOneAirdrop.t.sol:SonicSeasonOneAirdropTest
[FAIL: vm.readFile: the path silo-core/scripts/airdrop/output.json is not allowed to be accessed for read operations] test_BalancesIncreaseExpected() (gas: 2437715)

## Solution

Add read permission for the silo-core/scripts/airdrop/output.json file
