### PR TITLE
throw error when too much warnings

### DIFF
--- a/scripts/lint-sol.sh
+++ b/scripts/lint-sol.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Default values
+MAX_WARNINGS="${1:-0}"
+
+# Show usage if help is requested
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo "Usage: $0 [max_warnings]"
+    echo "  max_warnings: Maximum number of warnings allowed (default: 0)"
+    echo ""
+    echo "Examples:"
+    echo "  $0        # Use default (0 warnings allowed)"
+    echo "  $0 10     # Allow up to 10 warnings"
+    exit 0
+fi
+
+# Run solhint and capture the output
+output=$(npx solhint "contracts/**/*.sol" --ignore-path .solhintignore --max-warnings="$MAX_WARNINGS" 2>&1)
+exit_code=$?
+
+# Extract the number of warnings from the output
+warnings_line=$(echo "$output" | grep "✖.*problems.*warnings")
+if [ -n "$warnings_line" ]; then
+    # Extract the number of warnings using regex - format: "✖ 40 problems (0 errors, 40 warnings)"
+    warnings_count=$(echo "$warnings_line" | sed -n 's/.*✖ [0-9]* problems ([0-9]* errors, \([0-9]*\) warnings).*/\1/p')
+    if [ "$warnings_count" -gt "$MAX_WARNINGS" ]; then
+        echo "$output"
+        exit 1
+    fi
+fi
+
+# If no problems found or warnings are within limit, exit with the original exit code
+echo "$output"
+exit $exit_code

--- a/silo-core/package.json
+++ b/silo-core/package.json
@@ -13,7 +13,7 @@
     "solhint": "~3.4.1"
   },
   "scripts": {
-    "lint:sol": "solhint \"contracts/**/*.sol\" --ignore-path .solhintignore --max-warnings=0",
+    "lint:sol": "../scripts/lint-sol.sh 40",
     "foundry:qa": "FOUNDRY_PROFILE=core forge test -vvv"
   }
 }

--- a/silo-oracles/package.json
+++ b/silo-oracles/package.json
@@ -13,6 +13,6 @@
     "solhint": "~3.4.1"
   },
   "scripts": {
-    "lint:sol": "solhint \"contracts/**/*.sol\" --max-warnings=0"
+    "lint:sol": "../scripts/lint-sol.sh 12"
   }
 }

--- a/silo-vaults/package.json
+++ b/silo-vaults/package.json
@@ -13,6 +13,6 @@
     "solhint": "~3.4.1"
   },
   "scripts": {
-    "lint:sol": "solhint \"contracts/**/*.sol\" --ignore-path .solhintignore --max-warnings=0"
+    "lint:sol": "../scripts/lint-sol.sh 39" 
   }
 }

--- a/x-silo/package.json
+++ b/x-silo/package.json
@@ -13,6 +13,6 @@
     "solhint": "~3.4.1"
   },
   "scripts": {
-    "lint:sol": "solhint \"contracts/**/*.sol\" --ignore-path .solhintignore --max-warnings=0"
+    "lint:sol": "../scripts/lint-sol.sh 10"
   }
 }


### PR DESCRIPTION
## Problem

Solhint does not change return code to non zero when we have more warnings than provided as `--max-warnings` and CI pass. Because of that we could miss warnings.

## Solution

Wrapper script that analyse linter output and throw error when too much warnings. Max warnings values are set based on current state of the code.
