### PR TITLE
silo-oracles: hardcoded address option for PT AMM oracle

### DIFF
--- a/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracle.sol
+++ b/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracle.sol
@@ -14,4 +14,6 @@ interface IFixedPricePTAMMOracle is ISiloOracle {
     error ZeroQuote();
 
     function initialize(IFixedPricePTAMMOracleConfig _configAddress) external;
+
+    function oracleConfig() external view returns (IFixedPricePTAMMOracleConfig);
 }

--- a/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleConfig.sol
+++ b/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleConfig.sol
@@ -7,11 +7,15 @@ interface IFixedPricePTAMMOracleConfig {
     /// @param amm Pendle AMM contract address,
     /// see https://pendle.notion.site/Cross-chain-PT-21f567a21d3780c5b7c9fe055565d762
     /// @param ptToken PT token address
-    /// @param ptUnderlyingQuoteToken quote token address, that must be underlying token of PT
+    /// @param ptUnderlyingQuoteToken quote token address, that must be underlying token of PT,
+    /// this token will be used to query AMM for price of PT
+    /// @param hardcoddedQuoteToken quote token address, if 0, then quote token is ptUnderlyingQuoteToken,
+    /// this token will be used for quoteToken() function in oracle
     struct DeploymentConfig {
         IPendleAMM amm;
         address ptToken;
         address ptUnderlyingQuoteToken;
+        address hardcoddedQuoteToken;
     }
 
     function getConfig() external view returns (DeploymentConfig memory cfg);

--- a/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleFactory.sol
+++ b/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleFactory.sol
@@ -15,7 +15,10 @@ interface IFixedPricePTAMMOracleFactory {
 
     function resolveExistingOracle(bytes32 _configId) external view returns (address oracle);
 
-    function hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) external view returns (bytes32 configId);
+    function hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config)
+        external
+        view
+        returns (bytes32 configId);
 
     function verifyConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) external view;
 }

--- a/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleFactory.sol
+++ b/silo-oracles/contracts/interfaces/IFixedPricePTAMMOracleFactory.sol
@@ -12,4 +12,10 @@ interface IFixedPricePTAMMOracleFactory {
     function create(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config, bytes32 _externalSalt)
         external
         returns (IFixedPricePTAMMOracle oracle);
+
+    function resolveExistingOracle(bytes32 _configId) external view returns (address oracle);
+
+    function hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) external view returns (bytes32 configId);
+
+    function verifyConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) external view;
 }

--- a/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracle.sol
+++ b/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracle.sol
@@ -40,7 +40,7 @@ contract FixedPricePTAMMOracle is IFixedPricePTAMMOracle, Initializable {
 
     /// @inheritdoc ISiloOracle
     function quoteToken() external view virtual returns (address) {
-        return oracleConfig.getConfig().ptUnderlyingQuoteToken;
+        return oracleConfig.getConfig().hardcoddedQuoteToken;
     }
 
     /// @inheritdoc ISiloOracle

--- a/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleConfig.sol
+++ b/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleConfig.sol
@@ -8,17 +8,20 @@ contract FixedPricePTAMMOracleConfig is IFixedPricePTAMMOracleConfig {
     IPendleAMM internal immutable _PENDLE_AMM; // solhint-disable-line var-name-mixedcase
     address internal immutable _BASE_TOKEN; // solhint-disable-line var-name-mixedcase
     address internal immutable _QUOTE_TOKEN; // solhint-disable-line var-name-mixedcase
+    address internal immutable _HARDCODED_QUOTE_TOKEN; // solhint-disable-line var-name-mixedcase
 
     /// @dev all verification should be done by factory
     constructor(DeploymentConfig memory _cfg) {
         _PENDLE_AMM = _cfg.amm;
         _BASE_TOKEN = _cfg.ptToken;
         _QUOTE_TOKEN = _cfg.ptUnderlyingQuoteToken;
+        _HARDCODED_QUOTE_TOKEN = _cfg.hardcoddedQuoteToken;
     }
 
     function getConfig() external view virtual returns (DeploymentConfig memory cfg) {
         cfg.amm = _PENDLE_AMM;
         cfg.ptToken = _BASE_TOKEN;
         cfg.ptUnderlyingQuoteToken = _QUOTE_TOKEN;
+        cfg.hardcoddedQuoteToken = _HARDCODED_QUOTE_TOKEN;
     }
 }

--- a/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleFactory.sol
+++ b/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleFactory.sol
@@ -69,6 +69,7 @@ contract FixedPricePTAMMOracleFactory is Create2Factory, OracleFactory, IFixedPr
         require(_config.ptUnderlyingQuoteToken != address(0), AddressZero());
         require(_config.ptToken != address(0), AddressZero());
         require(_config.ptUnderlyingQuoteToken != _config.ptToken, TokensAreTheSame());
+        require(_config.hardcoddedQuoteToken != _config.ptToken, TokensAreTheSame());
     }
 
     function resolveExistingOracle(bytes32 _configId) public view virtual returns (address oracle) {

--- a/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleFactory.sol
+++ b/silo-oracles/contracts/pendle/amm/FixedPricePTAMMOracleFactory.sol
@@ -38,8 +38,8 @@ contract FixedPricePTAMMOracleFactory is Create2Factory, OracleFactory, IFixedPr
     }
 
     function predictAddress(
-        IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config, 
-        address _deployer, 
+        IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config,
+        address _deployer,
         bytes32 _externalSalt
     )
         external

--- a/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracle.t.sol
+++ b/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracle.t.sol
@@ -140,9 +140,9 @@ contract FixedPricePTAMMOracleTest is Test {
     /*
     FOUNDRY_PROFILE=oracles forge test --mt test_ptamm_quoteToken --ffi -vv
     */
-    function test_ptamm_quoteToken_fuzz(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) 
-        public 
-        assumeValidConfig(_config) 
+    function test_ptamm_quoteToken_fuzz(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config)
+        public
+        assumeValidConfig(_config)
     {
         IFixedPricePTAMMOracle oracle = factory.create(_config, bytes32(0));
 

--- a/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracleFactory.t.sol
+++ b/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracleFactory.t.sol
@@ -18,6 +18,15 @@ import {IPendleAMM} from "silo-oracles/contracts/interfaces/IPendleAMM.sol";
 contract FixedPricePTAMMOracleFactoryTest is Test {
     FixedPricePTAMMOracleFactory immutable factory;
 
+    modifier assumeValidConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) {
+        vm.assume(_config.ptToken != address(0));
+        vm.assume(_config.ptUnderlyingQuoteToken != address(0));
+        vm.assume(_config.ptUnderlyingQuoteToken != _config.ptToken);
+        vm.assume(_config.hardcoddedQuoteToken != _config.ptToken);
+
+        _;
+    }
+
     constructor() {
         factory = new FixedPricePTAMMOracleFactory();
     }
@@ -29,11 +38,11 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         address _deployer,
         bytes32 _externalSalt,
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config
-    ) public {
+    ) 
+        public 
+        assumeValidConfig(_config) 
+    {
         vm.assume(_deployer != address(0));
-        vm.assume(_config.ptToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != _config.ptToken);
 
         address predictedAddress = factory.predictAddress(_config, _deployer, _externalSalt);
 
@@ -62,7 +71,8 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory config = IFixedPricePTAMMOracleConfig.DeploymentConfig({
             amm: IPendleAMM(makeAddr("amm")),
             ptToken: makeAddr("ptToken"),
-            ptUnderlyingQuoteToken: makeAddr("ptUnderlyingQuoteToken")
+            ptUnderlyingQuoteToken: makeAddr("ptUnderlyingQuoteToken"),
+            hardcoddedQuoteToken: address(0)
         });
 
         bytes32 configId = factory.hashConfig(config);
@@ -84,11 +94,10 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         address _deployer,
         bytes32 _externalSalt,
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config
-    ) public {
-        vm.assume(_deployer != address(0));
-        vm.assume(_config.ptToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != _config.ptToken);
+    ) 
+        public 
+        assumeValidConfig(_config) 
+    {
 
         vm.prank(_deployer);
         address oracle1 = address(factory.create(_config, _externalSalt));
@@ -100,22 +109,30 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
     /*
     FOUNDRY_PROFILE=oracles forge test --mt test_ptamm_reorg --ffi -vv
     */
-    function test_ptamm_reorg(address _eoa1, address _eoa2) public {
-        IFixedPricePTAMMOracleConfig.DeploymentConfig memory config = IFixedPricePTAMMOracleConfig.DeploymentConfig({
-            amm: IPendleAMM(makeAddr("amm")),
-            ptToken: makeAddr("ptToken"),
-            ptUnderlyingQuoteToken: makeAddr("ptUnderlyingQuoteToken")
-        });
+    function test_ptamm_reorg(
+        address _eoa1, 
+        address _eoa2,
+        IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config1,
+        IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config2
+    ) 
+        public 
+        assumeValidConfig(_config1) 
+        assumeValidConfig(_config2) 
+    {
+        vm.assume(_eoa1 != address(0));
+        vm.assume(_eoa2 != address(0));
+        vm.assume(_eoa1 != _eoa2);
+        vm.assume(_hashConfig(_config1) != _hashConfig(_config2));
 
         uint256 snapshot = vm.snapshotState();
 
         vm.prank(_eoa1);
-        address oracle1 = address(factory.create(config, bytes32(0)));
+        address oracle1 = address(factory.create(_config1, bytes32(0)));
 
         vm.revertToState(snapshot);
 
         vm.prank(_eoa2);
-        address oracle2 = address(factory.create(config, bytes32(0)));
+        address oracle2 = address(factory.create(_config2, bytes32(0)));
 
         assertNotEq(oracle1, oracle2, "Oracle addresses should be different if we reorg");
     }
@@ -126,10 +143,8 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
     function test_ptamm_verifyConfig_pass_fuzz(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config)
         public
         view
+        assumeValidConfig(_config)
     {
-        vm.assume(_config.ptToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != address(0));
-        vm.assume(_config.ptUnderlyingQuoteToken != _config.ptToken);
 
         factory.verifyConfig(_config);
     }
@@ -155,7 +170,12 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(IFixedPricePTAMMOracleFactory.TokensAreTheSame.selector));
         factory.verifyConfig(config);
 
+        config.hardcoddedQuoteToken = address(1);
+        vm.expectRevert(abi.encodeWithSelector(IFixedPricePTAMMOracleFactory.TokensAreTheSame.selector));
+        factory.verifyConfig(config);
+
         config.ptUnderlyingQuoteToken = address(2);
+        config.hardcoddedQuoteToken = address(0);
         factory.verifyConfig(config); // pass
     }
 
@@ -195,12 +215,33 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory config = IFixedPricePTAMMOracleConfig.DeploymentConfig({
             amm: IPendleAMM(0x4d717868F4Bd14ac8B29Bb6361901e30Ae05e340),
             ptToken: address(1),
-            ptUnderlyingQuoteToken: address(2)
+            ptUnderlyingQuoteToken: address(2),
+            hardcoddedQuoteToken: address(0)
         });
 
         address oracle = address(factory.create(config, bytes32(0)));
 
         vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
         IFixedPricePTAMMOracle(oracle).initialize(IFixedPricePTAMMOracleConfig(address(1)));
+    }
+
+    /*
+    FOUNDRY_PROFILE=oracles forge test --mt test_ptamm_getConfig --ffi -vv
+    */
+    function test_ptamm_getConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) 
+        public
+        assumeValidConfig(_config) 
+    {
+        IFixedPricePTAMMOracle oracle = factory.create(_config, bytes32(0));
+        IFixedPricePTAMMOracleConfig.DeploymentConfig memory cfg = oracle.oracleConfig().getConfig();
+
+        assertEq(address(cfg.amm), address(_config.amm), "AMM should match");
+        assertEq(cfg.ptToken, _config.ptToken, "PT token should match");
+        assertEq(cfg.ptUnderlyingQuoteToken, _config.ptUnderlyingQuoteToken, "PT underlying quote token should match");
+        assertEq(cfg.hardcoddedQuoteToken, _config.hardcoddedQuoteToken, "Hardcoded quote token should match");
+    }
+
+    function _hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) internal view returns (bytes32) {
+        return keccak256(abi.encode(_config));
     }
 }

--- a/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracleFactory.t.sol
+++ b/silo-oracles/test/foundry/pendle/amm/FixedPricePTAMMOracleFactory.t.sol
@@ -50,15 +50,13 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         address oracle = address(factory.create(_config, _externalSalt));
 
         assertEq(oracle, predictedAddress, "Predicted address does not match");
-        
+
         address oracle2 = address(factory.create(_config, _externalSalt));
 
         address predictedAddress2 = factory.predictAddress(_config, _deployer, _externalSalt);
 
         assertEq(
-            predictedAddress, 
-            predictedAddress2, 
-            "predicted addresses should be the same if we reuse the same config"
+            predictedAddress, predictedAddress2, "predicted addresses should be the same if we reuse the same config"
         );
 
         assertEq(oracle2, oracle, "Oracle addresses should be the same if we reuse the same config");
@@ -110,7 +108,7 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
     FOUNDRY_PROFILE=oracles forge test --mt test_ptamm_reorg --ffi -vv
     */
     function test_ptamm_reorg(
-        address _eoa1, 
+        address _eoa1,
         address _eoa2,
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config1,
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config2
@@ -145,7 +143,6 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         view
         assumeValidConfig(_config)
     {
-
         factory.verifyConfig(_config);
     }
 
@@ -228,9 +225,9 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
     /*
     FOUNDRY_PROFILE=oracles forge test --mt test_ptamm_getConfig --ffi -vv
     */
-    function test_ptamm_getConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) 
+    function test_ptamm_getConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config)
         public
-        assumeValidConfig(_config) 
+        assumeValidConfig(_config)
     {
         IFixedPricePTAMMOracle oracle = factory.create(_config, bytes32(0));
         IFixedPricePTAMMOracleConfig.DeploymentConfig memory cfg = oracle.oracleConfig().getConfig();
@@ -241,7 +238,11 @@ contract FixedPricePTAMMOracleFactoryTest is Test {
         assertEq(cfg.hardcoddedQuoteToken, _config.hardcoddedQuoteToken, "Hardcoded quote token should match");
     }
 
-    function _hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config) internal view returns (bytes32) {
+    function _hashConfig(IFixedPricePTAMMOracleConfig.DeploymentConfig memory _config)
+        internal
+        view
+        returns (bytes32)
+    {
         return keccak256(abi.encode(_config));
     }
 }


### PR DESCRIPTION
Fixes SILO-4425

## Problem

Sometimes quote token for query price is different from the one we expected, eg when we hardcode USDC to USDCe price.

## Solution

Allow to set hardcoded quote token.

coverage report: https://silo-finance.github.io/silo-contracts-v2/coverage/feature/SILO-4425-pt-amm-oracle-quote/silo-oracles/
