### PR TITLE
silo-core: exclude tests from coverage

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -83,7 +83,7 @@ jobs:
           FOUNDRY_PROFILE=core forge build
 
           echo "Running forge coverage..."
-          AGGREGATOR=1INCH FOUNDRY_PROFILE=core_with_test forge coverage --report summary --report lcov --gas-price 1 --ffi --gas-limit 40000000000 --no-match-test "_skip_|_gas_|_anvil_" > coverage/silo-core.log 2>&1 || true
+          AGGREGATOR=1INCH FOUNDRY_PROFILE=core_with_test forge coverage --report summary --report lcov --gas-price 1 --ffi --gas-limit 40000000000 --no-match-test "_skip_|_gas_|_anvil_" --nmc "SiloLensCompatibilityTest|NewMarketTest" > coverage/silo-core.log 2>&1 || true
 
           echo "Coverage log contents:"
           cat coverage/silo-core.log || true


### PR DESCRIPTION
## Problem

Coverage is failing because test for new markets are triggered

## Solution

exclude new markets tests and silo lens compatibility tests, because they should not be part of coverage.
