### PR TITLE
remove gitmodules from cache

### DIFF
--- a/.github/workflows/silo-core.yml
+++ b/.github/workflows/silo-core.yml
@@ -50,21 +50,12 @@ on:
             - .github/workflows/silo-core.yml
 
 jobs:
-    silo-core-cache:
+    silo-size:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
                 with:
                     submodules: recursive
-
-            -   name: Cache silo-core contracts
-                uses: actions/cache@v3
-                with:
-                    path: ./cache/
-                    key: silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
-                    restore-keys: |
-                        silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
-                        silo-core-contracts-cache-
 
             -   name: Install Foundry
                 uses: foundry-rs/foundry-toolchain@v1
@@ -81,9 +72,6 @@ jobs:
                     cp target/release/silo-foundry-utils ../../silo-foundry-utils
                     ../../silo-foundry-utils --version
 
-            -   name: Run single test to build cache for contracts
-                run: FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_siloStoragePointer
-
             -   name: Run Forge build
                 run: |
                     git submodule
@@ -91,7 +79,6 @@ jobs:
                     FOUNDRY_PROFILE=core forge build --sizes
 
     linters:
-        needs: silo-core-cache
         runs-on: ubuntu-latest
 
         steps:
@@ -112,19 +99,12 @@ jobs:
                 run: yarn workspace silo-core lint:sol
 
     fast-tests:
-        needs: silo-core-cache
         runs-on: ubuntu-latest
 
         steps:
             -   uses: actions/checkout@v3
                 with:
                     submodules: recursive
-
-            -   name: Cache silo-core contracts
-                uses: actions/cache@v3
-                with:
-                    path: ./cache/
-                    key: silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
 
             -   name: Install Foundry
                 uses: foundry-rs/foundry-toolchain@v1
@@ -153,18 +133,11 @@ jobs:
                     PreviewMintTest
                ]
 
-        needs: silo-core-cache
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
                 with:
                     submodules: recursive
-
-            -   name: Cache silo-core contracts
-                uses: actions/cache@v3
-                with:
-                    path: ./cache/
-                    key: silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
 
             -   name: Install Foundry
                 uses: foundry-rs/foundry-toolchain@v1
@@ -192,18 +165,11 @@ jobs:
                     test_maxLiquidation_partial_2tokens_tokens
                ]
 
-        needs: silo-core-cache
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
                 with:
                     submodules: recursive
-
-            -   name: Cache silo-core contracts
-                uses: actions/cache@v3
-                with:
-                    path: ./cache/
-                    key: silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
 
             -   name: Install Foundry
                 uses: foundry-rs/foundry-toolchain@v1
@@ -225,18 +191,11 @@ jobs:
             matrix:
                 match-contract: [ SiloLensCompatibilityTest ]
 
-        needs: silo-core-cache
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
                 with:
                     submodules: recursive
-
-            -   name: Cache silo-core contracts
-                uses: actions/cache@v3
-                with:
-                    path: ./cache/
-                    key: silo-core-contracts-cache-${{ hashFiles('./silo-core/**/*.sol') }}
 
             -   name: Install Foundry
                 uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
## Problem

Looks like cache might slow CI down

## Solution

Check if we will be faster without it: they are faster, because even with cache, we still needs to compile contracts (and this takes time anyway).