### PR TITLE
silo-core: reset k to min on overflow in Kink

### DIFF
--- a/silo-core/contracts/interestRateModel/kink/DynamicKinkModel.sol
+++ b/silo-core/contracts/interestRateModel/kink/DynamicKinkModel.sol
@@ -440,10 +440,11 @@ contract DynamicKinkModel is IDynamicKinkModel, Ownable1and2Steps, Initializable
 
         require(_args.silo == state.silo, InvalidSilo());
 
-        if (_args.interestRateTimestamp.wouldOverflowOnCastToInt256()) return (0, 0);
-        if (_args.blockTimestamp.wouldOverflowOnCastToInt256()) return (0, 0);
-        if (_args.collateralAssets.wouldOverflowOnCastToInt256()) return (0, 0);
-        if (_args.debtAssets.wouldOverflowOnCastToInt256()) return (0, 0);
+        // k should be set to min on overflow
+        if (_args.interestRateTimestamp.wouldOverflowOnCastToInt256()) return (0, cfg.kmin);
+        if (_args.blockTimestamp.wouldOverflowOnCastToInt256()) return (0, cfg.kmin);
+        if (_args.collateralAssets.wouldOverflowOnCastToInt256()) return (0, cfg.kmin);
+        if (_args.debtAssets.wouldOverflowOnCastToInt256()) return (0, cfg.kmin);
 
         try this.compoundInterestRate({
             _cfg: cfg,

--- a/silo-core/deploy/silo/verifier/checks/silo/CheckIrmConfig.sol
+++ b/silo-core/deploy/silo/verifier/checks/silo/CheckIrmConfig.sol
@@ -45,7 +45,7 @@ contract CheckIrmConfig is ICheck {
         }
     }
 
-    function _isKinkIrm(address _irm) internal returns (bool isKinkIrm) {
+    function _isKinkIrm(address _irm) internal returns (bool) {
         address factory = AddrLib.getAddress(SiloCoreContracts.DYNAMIC_KINK_MODEL_FACTORY);
         if (factory == address(0)) return false;
 


### PR DESCRIPTION
## Problem

On total asset amount and timestamp overflow, we returned k = 0, but we have rule that it should be reset to kmin.

## Solution

fix
