### PR TITLE
RevertingOracle

### DIFF
--- a/silo-oracles/contracts/reverting/RevertingOracle.sol
+++ b/silo-oracles/contracts/reverting/RevertingOracle.sol
@@ -7,12 +7,27 @@ import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 import {IManageableOracle} from "silo-oracles/contracts/interfaces/IManageableOracle.sol";
 
 contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
-    string private constant MANAGEABLE_ORACLE_VERSION = "ManageableOracle";
+    string private constant _MANAGEABLE_ORACLE_VERSION = "ManageableOracle";
 
     error ThisOracleAlwaysReverts();
 
     function description() external view virtual override returns (string memory) {
         return "This oracle always reverts";
+    }
+
+    /// @notice copy quote token from msg.sender
+    function quoteToken() external view override returns (address) {
+        // Purpose of this is only to pass verification on a ManageableOracle.
+        return ISiloOracle(msg.sender).quoteToken();
+    }
+
+    /// @notice always reverts
+    function beforeQuote(address /* _baseToken */) external pure override {
+        revert ThisOracleAlwaysReverts();
+    }
+
+    function VERSION() external pure override returns (string memory) { // solhint-disable-line func-name-mixedcase
+        return "RevertingOracle 4.8.0";
     }
 
     /// @notice always reverts
@@ -27,25 +42,10 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
         return 1;
     }
 
-    /// @notice always reverts
-    function beforeQuote(address /* _baseToken */) external pure override {
-        revert ThisOracleAlwaysReverts();
-    }
-
-    /// @notice copy quote token from msg.sender
-    function quoteToken() external view override returns (address) {
-        // Purpose of this is only to pass verification on a ManageableOracle.
-        return ISiloOracle(msg.sender).quoteToken();
-    }
-
     /// @notice copy base token from msg.sender
     function baseToken() public view override returns (address) {
         // Purpose of this is only to pass verification on a ManageableOracle.
         return Aggregator(msg.sender).baseToken();
-    }
-
-    function VERSION() external pure override returns (string memory) {
-        return "RevertingOracle 4.7.0";
     }
 
     function _isRevertingActive() internal view returns (bool) {
@@ -55,16 +55,16 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
     }
 
     function _detectManageableOracle() internal view returns (bool) {
-        uint256 l = bytes(MANAGEABLE_ORACLE_VERSION).length;
+        uint256 versionLength = bytes(_MANAGEABLE_ORACLE_VERSION).length;
 
         try IVersioned(msg.sender).VERSION() returns (string memory version) {
-            if (bytes(version).length < l) {
+            if (bytes(version).length < versionLength) {
                 return false;
             }
 
 
-            for (uint256 i = 0; i < l; i++) {
-                if (bytes1(bytes(version)[i]) != bytes1(bytes(MANAGEABLE_ORACLE_VERSION)[i])) {
+            for (uint256 i = 0; i < versionLength; i++) {
+                if (bytes1(bytes(version)[i]) != bytes1(bytes(_MANAGEABLE_ORACLE_VERSION)[i])) {
                     return false;
                 }
             }

--- a/silo-oracles/contracts/reverting/RevertingOracle.sol
+++ b/silo-oracles/contracts/reverting/RevertingOracle.sol
@@ -6,9 +6,10 @@ import {IVersioned} from "silo-core/contracts/interfaces/IVersioned.sol";
 import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 import {IManageableOracle} from "silo-oracles/contracts/interfaces/IManageableOracle.sol";
 
+/// @dev this oracle is created to use as underlying for ManageableOracle.
+/// It will pass the verification process so it can be set as underlying oracle, 
+/// but once it is set, it will always revert.
 contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
-    string private constant _MANAGEABLE_ORACLE_VERSION = "ManageableOracle";
-
     error ThisOracleAlwaysReverts();
 
     function description() external view virtual override returns (string memory) {
@@ -50,28 +51,8 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
     }
 
     function _isRevertingActive() internal view returns (bool) {
-        if (!_detectManageableOracle()) return false;
-
-        return address(IManageableOracle(msg.sender).oracle()) == address(this);
-    }
-
-    function _detectManageableOracle() internal view returns (bool) {
-        uint256 versionLength = bytes(_MANAGEABLE_ORACLE_VERSION).length;
-
-        try IVersioned(msg.sender).VERSION() returns (string memory version) {
-            if (bytes(version).length < versionLength) {
-                return false;
-            }
-
-
-            for (uint256 i = 0; i < versionLength; i++) {
-                if (bytes1(bytes(version)[i]) != bytes1(bytes(_MANAGEABLE_ORACLE_VERSION)[i])) {
-                    return false;
-                }
-            }
-            
-            return true;
-
+        try IManageableOracle(msg.sender).oracle() returns (ISiloOracle oracle) {
+            return address(oracle) == address(this);
         } catch {
             return false;
         }

--- a/silo-oracles/contracts/reverting/RevertingOracle.sol
+++ b/silo-oracles/contracts/reverting/RevertingOracle.sol
@@ -39,6 +39,7 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
     {
         if (_isRevertingActive()) revert ThisOracleAlwaysReverts();
 
+        // Purpose of this is only to pass verification on a ManageableOracle.
         return 1;
     }
 

--- a/silo-oracles/contracts/reverting/RevertingOracle.sol
+++ b/silo-oracles/contracts/reverting/RevertingOracle.sol
@@ -9,6 +9,8 @@ import {IManageableOracle} from "silo-oracles/contracts/interfaces/IManageableOr
 /// @dev this oracle is created to use as underlying for ManageableOracle.
 /// It will pass the verification process so it can be set as underlying oracle, 
 /// but once it is set, it will always revert.
+/// If the message sender has the oracle() method and the value of oracle() is not set 
+/// to the RevertingOracle contract, then we will not revert.
 contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
     error ThisOracleAlwaysReverts();
 
@@ -28,7 +30,7 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
     }
 
     function VERSION() external pure override returns (string memory) { // solhint-disable-line func-name-mixedcase
-        return "RevertingOracle 4.8.0";
+        return "RevertingOracle 4.9.0";
     }
 
     /// @notice always reverts
@@ -54,7 +56,7 @@ contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
         try IManageableOracle(msg.sender).oracle() returns (ISiloOracle oracle) {
             return address(oracle) == address(this);
         } catch {
-            return false;
+            return true;
         }
     }
 }

--- a/silo-oracles/contracts/reverting/RevertingOracle.sol
+++ b/silo-oracles/contracts/reverting/RevertingOracle.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.28;
+
+import {Aggregator} from "../_common/Aggregator.sol";
+import {IVersioned} from "silo-core/contracts/interfaces/IVersioned.sol";
+import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
+import {IManageableOracle} from "silo-oracles/contracts/interfaces/IManageableOracle.sol";
+
+contract RevertingOracle is Aggregator, IVersioned, ISiloOracle {
+    string private constant MANAGEABLE_ORACLE_VERSION = "ManageableOracle";
+
+    error ThisOracleAlwaysReverts();
+
+    function description() external view virtual override returns (string memory) {
+        return "This oracle always reverts";
+    }
+
+    /// @notice always reverts
+    function quote(uint256 /* _baseAmount */, address /* _baseToken */)
+        public
+        view
+        override(Aggregator, ISiloOracle)
+        returns (uint256 quoteAmount)
+    {
+        if (_isRevertingActive()) revert ThisOracleAlwaysReverts();
+
+        return 1;
+    }
+
+    /// @notice always reverts
+    function beforeQuote(address /* _baseToken */) external pure override {
+        revert ThisOracleAlwaysReverts();
+    }
+
+    /// @notice copy quote token from msg.sender
+    function quoteToken() external view override returns (address) {
+        // Purpose of this is only to pass verification on a ManageableOracle.
+        return ISiloOracle(msg.sender).quoteToken();
+    }
+
+    /// @notice copy base token from msg.sender
+    function baseToken() public view override returns (address) {
+        // Purpose of this is only to pass verification on a ManageableOracle.
+        return Aggregator(msg.sender).baseToken();
+    }
+
+    function VERSION() external pure override returns (string memory) {
+        return "RevertingOracle 4.7.0";
+    }
+
+    function _isRevertingActive() internal view returns (bool) {
+        if (!_detectManageableOracle()) return false;
+
+        return address(IManageableOracle(msg.sender).oracle()) == address(this);
+    }
+
+    function _detectManageableOracle() internal view returns (bool) {
+        uint256 l = bytes(MANAGEABLE_ORACLE_VERSION).length;
+
+        try IVersioned(msg.sender).VERSION() returns (string memory version) {
+            if (bytes(version).length < l) {
+                return false;
+            }
+
+
+            for (uint256 i = 0; i < l; i++) {
+                if (bytes1(bytes(version)[i]) != bytes1(bytes(MANAGEABLE_ORACLE_VERSION)[i])) {
+                    return false;
+                }
+            }
+            
+            return true;
+
+        } catch {
+            return false;
+        }
+    }
+}

--- a/silo-oracles/deploy/RevertingOracleDeploy.s.sol
+++ b/silo-oracles/deploy/RevertingOracleDeploy.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.7.6;
+
+import {CommonDeploy} from "./CommonDeploy.sol";
+import {RevertingOracle} from "silo-oracles/contracts/reverting/RevertingOracle.sol";
+import {SiloOraclesContracts} from "./SiloOraclesContracts.sol";
+
+/*
+    FOUNDRY_PROFILE=oracles \
+        forge script silo-oracles/deploy/RevertingOracleDeploy.s.sol \
+        --ffi --rpc-url $RPC_ARBITRUM --broadcast --verify
+
+    Resume verification:
+    FOUNDRY_PROFILE=oracles \
+        forge script silo-oracles/deploy/RevertingOracleDeploy.s.sol \
+        --ffi --rpc-url $RPC_INJECTIVE \
+        --verify \
+        --private-key $PRIVATE_KEY \
+        --resume
+ */
+contract RevertingOracleDeploy is CommonDeploy {
+    function run() public {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        address revertingOracle = address(new RevertingOracle());
+
+        vm.stopBroadcast();
+
+        _registerDeployment(revertingOracle, SiloOraclesContracts.REVERTING_ORACLE);
+    }
+}

--- a/silo-oracles/deploy/SiloOraclesContracts.sol
+++ b/silo-oracles/deploy/SiloOraclesContracts.sol
@@ -13,6 +13,7 @@ library SiloOraclesContracts {
     string public constant X33_TO_USD_ADAPTER = "X33ToUsdAdapter.sol";
     string public constant WSTETH_TO_STETH_ADAPTER_MAINNET = "WstEthToStEthAdapterMainnet.sol";
     string public constant VIRTUAL_TOKEN_PRICE = "VirtualTokenPrice.sol";
+    string public constant REVERTING_ORACLE = "RevertingOracle.sol";
 }
 
 library SiloOraclesDeployments {

--- a/silo-oracles/test/foundry/manageable/ManageableOracleBase.sol
+++ b/silo-oracles/test/foundry/manageable/ManageableOracleBase.sol
@@ -127,12 +127,15 @@ abstract contract ManageableOracleBase is Test {
             abi.encodeWithSelector(ISiloOracle.quoteToken.selector),
             abi.encode(oracleMock.quoteToken())
         );
+        
         vm.mockCall(
             revertingOracle, abi.encodeWithSelector(IManageableOracle.baseToken.selector), abi.encode(baseToken)
         );
+        
         vm.mockCallRevert(
             revertingOracle, abi.encodeWithSelector(ISiloOracle.quote.selector, 10 ** 18, baseToken), ""
         );
+
         vm.expectRevert(IManageableOracle.OracleQuoteFailed.selector);
         oracle.oracleVerification(ISiloOracle(revertingOracle));
     }
@@ -405,14 +408,26 @@ abstract contract ManageableOracleBase is Test {
     function test_proposeOracle_ThisOracleAlwaysReverts() public {
         RevertingOracle oracleReverts = new RevertingOracle();
 
+        vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
+        oracleReverts.quote(1e6, baseToken); // It does revert if ask direcly
+
         vm.prank(owner);
         oracle.proposeOracle(oracleReverts);
+
+        vm.startPrank(address(oracle));
+        assertEq(
+            oracleReverts.quote(1e6, baseToken), 
+            1, 
+            "It does not revert if it is not active yet and call is from managable oracle"
+        );
+        vm.stopPrank();
+
+        vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
+        ISiloOracle(address(oracleReverts)).quote(1e6, baseToken);
 
         vm.warp(block.timestamp + TIMELOCK);
         vm.prank(owner);
         oracle.acceptOracle();
-
-        assertEq(oracleReverts.quote(1e6, baseToken), 1, "It does not revert if it is not active yet");
 
         vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
         ISiloOracle(address(oracle)).quote(1e6, baseToken);
@@ -420,7 +435,8 @@ abstract contract ManageableOracleBase is Test {
         vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
         ISiloOracle(address(oracle)).beforeQuote(baseToken);
 
-        assertEq(oracleReverts.quote(1e6, baseToken), 1, "It does not revert if it is not asked by manageable oracle");
+        vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
+        oracleReverts.quote(1e6, baseToken); // It does revert if ask direcly
     }
 
     /*

--- a/silo-oracles/test/foundry/manageable/ManageableOracleBase.sol
+++ b/silo-oracles/test/foundry/manageable/ManageableOracleBase.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {RevertingOracle} from "silo-oracles/contracts/reverting/RevertingOracle.sol";
+
 import {IERC20Metadata} from "silo-oracles/test/foundry/interfaces/IERC20Metadata.sol";
 import {ManageableOracleFactory} from "silo-oracles/contracts/manageable/ManageableOracleFactory.sol";
 import {IManageableOracleFactory} from "silo-oracles/contracts/interfaces/IManageableOracleFactory.sol";
@@ -395,6 +397,30 @@ abstract contract ManageableOracleBase is Test {
         assertEq(pendingOracleValue, address(0), "pendingOracle not cleared after accept");
         assertEq(pendingOracleValidAt, 0, "pendingOracle validAt not cleared after accept");
         assertEq(address(oracle.oracle()), address(otherOracleMock), "oracle not updated after accept");
+    }
+    
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_proposeOracle_ThisOracleAlwaysReverts
+    */
+    function test_proposeOracle_ThisOracleAlwaysReverts() public {
+        RevertingOracle oracleReverts = new RevertingOracle();
+
+        vm.prank(owner);
+        oracle.proposeOracle(oracleReverts);
+
+        vm.warp(block.timestamp + TIMELOCK);
+        vm.prank(owner);
+        oracle.acceptOracle();
+
+        assertEq(oracleReverts.quote(1e6, baseToken), 1, "It does not revert if it is not active yet");
+
+        vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
+        ISiloOracle(address(oracle)).quote(1e6, baseToken);
+
+        vm.expectRevert(RevertingOracle.ThisOracleAlwaysReverts.selector);
+        ISiloOracle(address(oracle)).beforeQuote(baseToken);
+
+        assertEq(oracleReverts.quote(1e6, baseToken), 1, "It does not revert if it is not asked by manageable oracle");
     }
 
     /*


### PR DESCRIPTION
## Problem

Silo is immutable; however, there's a way to kind of pause it if we set an oracle that reverts. 

## Solution

Create an oracle that always reverts. 

This oracle (same deployed instance) will be working for any market. It will require base and quote tokens, and it will behave to pass verification until it will be set as an active oracle. 

It basically checks if the message sender has oracle() methods and if it returns its address. If that's the case, that means the Oracle is active under the ManageableOracle contract and will revert always. 
