### PR TITLE
allow `PermissionedLiquidationController` set for debt share token

### DIFF
--- a/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
+++ b/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
@@ -27,7 +27,7 @@ contract PermissionedLiquidationController is
 {
     address public hookReceiver;
 
-    address public collateralShareToken;
+    address public shareToken;
 
     PermisionedData internal _permisionedData;
 
@@ -42,24 +42,21 @@ contract PermissionedLiquidationController is
         _disableInitializers();
     }
 
-    /// @param _collateralShareToken collateral or protected share token address
-    function initialize(IShareToken _collateralShareToken) external initializer {
-        address hook = _collateralShareToken.hookReceiver();
-        ISiloConfig siloConfig = _collateralShareToken.siloConfig();
-        address collateralSilo = address(_collateralShareToken.silo());
+    /// @param _shareToken collateral or protected share token address
+    function initialize(IShareToken _shareToken) external initializer {
+        hookReceiver = _shareToken.hookReceiver();
+        shareToken = address(_shareToken);
 
-        ISiloConfig.ConfigData memory collateralConfig = siloConfig.getConfig(collateralSilo);
-        require(collateralConfig.lt != 0, NotCollateralSilo());
+        ISilo silo = _shareToken.silo();
 
-        require(
-            collateralConfig.collateralShareToken == address(_collateralShareToken)
-                || collateralConfig.protectedShareToken == address(_collateralShareToken),
-            NotCollateralShareToken()
-        );
+        ISiloConfig.ConfigData memory cfg = silo.config().getConfig(address(silo));
 
-        hookReceiver = hook;
-        collateralShareToken = address(_collateralShareToken);
-        _permisionedData = PermisionedData({anySilo: collateralSilo, enabled: false, pauseTokenTransfer: false});
+        _permisionedData = PermisionedData({
+            anySilo: address(silo), 
+            enabled: false, 
+            pauseTokenTransfer: false,
+            shateTokenIsDebtToken: cfg.debtShareToken == address(_shareToken)
+        });
 
         __Whitelist_init(Ownable(hookReceiver).owner());
     }
@@ -77,6 +74,7 @@ contract PermissionedLiquidationController is
         require(_permisionedData.pauseTokenTransfer != _pauseTokenTransfer, PauseTokenTransferAlreadySet());
 
         _permisionedData.pauseTokenTransfer = _pauseTokenTransfer;
+
         if (_pauseTokenTransfer) {
             _permisionedData.enabled = true;
             emit EnabledChanged(true);
@@ -97,12 +95,12 @@ contract PermissionedLiquidationController is
 
     // solhint-disable-next-line func-name-mixedcase
     function share_token() external view virtual returns (address) {
-        return collateralShareToken;
+        return shareToken;
     }
 
     // solhint-disable-next-line func-name-mixedcase
     function SHARE_TOKEN() external view returns (address) {
-        return collateralShareToken;
+        return shareToken;
     }
 
     function NOTIFIER() external view returns (address) { // solhint-disable-line func-name-mixedcase
@@ -110,7 +108,7 @@ contract PermissionedLiquidationController is
     }
 
     function VERSION() external pure virtual returns (string memory) { // solhint-disable-line func-name-mixedcase
-        return "PermissionedLiquidationController 4.12.0";
+        return "PermissionedLiquidationController 4.13.1";
     }
 
     function afterTokenTransfer(
@@ -133,6 +131,9 @@ contract PermissionedLiquidationController is
         if (data.pauseTokenTransfer) revert PauseTokenTransferActive();
 
         if (_liquidationAllowed) return;
+
+        // for debt token we can not revert, because it migth revert regular repay
+        if (data.shateTokenIsDebtToken) return;
 
         // is this liquidation?
         // After transferring collateral, the user will always be insolvent.

--- a/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
+++ b/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
@@ -14,6 +14,8 @@ interface IPermissionedLiquidationController is ISiloIncentivesController, IAcce
         bool enabled;
         /// @param pauseTokenTransfer if true, then token transfer will be paused and tx will be reverted
         bool pauseTokenTransfer;
+        /// @param shateTokenIsDebtToken if true, that means this controller is set for debt token.
+        bool shateTokenIsDebtToken;
     }
 
     event EnabledChanged(bool _enabled);
@@ -22,8 +24,6 @@ interface IPermissionedLiquidationController is ISiloIncentivesController, IAcce
     error LiquidationNotAllowed();
     error OnlyHookReceiver();
     error OnlyOwner();
-    error NotCollateralSilo();
-    error NotCollateralShareToken();
     error EnabledAlreadySet();
     error PauseTokenTransferAlreadySet();
     error PauseTokenTransferActive();

--- a/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
+++ b/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
@@ -5,7 +5,10 @@ import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
 import {SiloIncentivesControllerDeployments} from "./SiloIncentivesControllerDeployments.sol";
 
 import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin5/token/ERC20/extensions/IERC20Metadata.sol";
 import {console2} from "forge-std/console2.sol";
+import {StdCheats} from "forge-std/StdCheats.sol";
 
 import {CommonDeploy} from "../_CommonDeploy.sol";
 import {SiloCoreContracts, SiloCoreDeployments} from "silo-core/common/SiloCoreContracts.sol";
@@ -24,7 +27,7 @@ import {
         forge script silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol \
         --ffi --rpc-url $RPC_MAINNET --broadcast --verify
  */
-contract PermissionedLiquidationControllerDeploy is CommonDeploy {
+contract PermissionedLiquidationControllerDeploy is CommonDeploy, StdCheats {
     error FactoryNotFound();
 
     function run() public {
@@ -39,7 +42,7 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
             SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY, ChainsLib.chainAlias()
         );
 
-        require(factory != address(0), FactoryNotFound());
+        require(factory != address(0), string.concat(SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY, " not found"));
 
         ISiloConfig cfg = silo.config();
 
@@ -48,6 +51,10 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         ISiloConfig.ConfigData memory config = cfg.getConfig(address(silo));
         address collateralShareTokenAddress = config.collateralShareToken;
         address protectedShareTokenAddress = config.protectedShareToken;
+        address debtShareTokenAddress = config.debtShareToken;
+
+        ISiloIncentivesController debtGauge = IGaugeHookReceiver(notifier).configuredGauges(IShareToken(debtShareTokenAddress));
+        bool deployForDebt = address(debtGauge) == address(0);
 
         vm.startBroadcast(deployerPrivateKey);
 
@@ -56,6 +63,12 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         
         address incentivesControllerP =
             IPermissionedLiquidationControllerFactory(factory).create(IShareToken(protectedShareTokenAddress));
+
+        address incentivesControllerD;
+        if (deployForDebt) {
+            incentivesControllerD =
+                IPermissionedLiquidationControllerFactory(factory).create(IShareToken(debtShareTokenAddress));
+        }
 
         vm.stopBroadcast();
 
@@ -71,6 +84,12 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
             "\nHook(%s).setGauge(ic: %s, shareToken: %s)", notifier, incentivesControllerP, protectedShareTokenAddress
         );
 
+        if (deployForDebt) {
+            console2.log(
+                "\nHook(%s).setGauge(ic: %s, shareToken: %s)", notifier, incentivesControllerD, debtShareTokenAddress
+            );
+        }
+
         console2.log("QA ---");
 
         vm.startPrank(owner);
@@ -84,10 +103,23 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
                 ISiloIncentivesController(address(incentivesControllerP)), IShareToken(protectedShareTokenAddress)
             );
 
+        if (deployForDebt) {
+            IGaugeHookReceiver(notifier).setGauge(
+                ISiloIncentivesController(address(incentivesControllerD)), IShareToken(debtShareTokenAddress)
+            );
+        }
+
         IGaugeHookReceiver(notifier).removeGauge(IShareToken(collateralShareTokenAddress));
         IGaugeHookReceiver(notifier).removeGauge(IShareToken(protectedShareTokenAddress));
 
+        if (deployForDebt) {
+            IGaugeHookReceiver(notifier).removeGauge(IShareToken(debtShareTokenAddress));
+        }
+
         vm.stopPrank();
+
+        // Cheat-only smoke test (fake user + `deal`); does not use PRIVATE_KEY and is not broadcast.
+        _qaSiloSmoke(cfg);
 
         SiloIncentivesControllerDeployments.save({
             _chain: ChainsLib.chainAlias(), _shareToken: collateralShareTokenAddress, _deployed: incentivesControllerC
@@ -96,5 +128,56 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         SiloIncentivesControllerDeployments.save({
             _chain: ChainsLib.chainAlias(), _shareToken: protectedShareTokenAddress, _deployed: incentivesControllerP
         });
+    }
+
+    function _qaSiloSmoke(ISiloConfig siloConfig) private {
+        address depositor = makeAddr("depositor");
+        (address silo0Addr, address silo1Addr) = siloConfig.getSilos();
+        ISilo silo0 = ISilo(silo0Addr);
+        ISilo silo1 = ISilo(silo1Addr);
+
+        (uint256 unit0, uint256 unit1) = _qaDealForSilos(silo0, silo1, depositor);
+
+        vm.startPrank(depositor);
+
+        _qaDepositOnSilo(silo0, depositor, unit0 * 100);
+        _qaDepositOnSilo(silo1, depositor, unit1 * 100);
+
+        vm.warp(block.timestamp + 1 days);
+
+        require(_qaBorrow(silo0, depositor) || _qaBorrow(silo1, depositor), "QA: borrow failed");
+    }
+
+    function _qaDealForSilos(ISilo silo0, ISilo silo1, address depositor) private returns (uint256 unit0, uint256 unit1) {
+        address asset0 = silo0.asset();
+        address asset1 = silo1.asset();
+        unit0 = 10 ** uint256(IERC20Metadata(asset0).decimals());
+        unit1 = 10 ** uint256(IERC20Metadata(asset1).decimals());
+        deal(asset0, depositor, unit0 * 2_000);
+        deal(asset1, depositor, unit1 * 2_000);
+    }
+
+    function _qaDepositOnSilo(
+        ISilo _silo,
+        address _depositor,
+        uint256 _amount
+    ) private {
+        address asset = _silo.asset();
+        IERC20(asset).approve(address(_silo), type(uint256).max);
+        _silo.deposit(_amount, _depositor, ISilo.CollateralType.Protected);
+        _silo.deposit(_amount, _depositor, ISilo.CollateralType.Collateral);
+    }
+
+    function _qaBorrow(ISilo _silo, address _depositor) internal returns (bool success) {
+        uint256 maxBorrow0 = _silo.maxBorrow(_depositor);
+
+        if (maxBorrow0 == 0) return false;
+
+        uint256 shares = _silo.borrow(maxBorrow0, _depositor, _depositor);
+        
+        vm.warp(block.timestamp + 1 days);
+
+        _silo.repayShares(shares, _depositor);
+        success = true;
     }
 }

--- a/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
@@ -30,7 +30,8 @@ contract TransitionCollateralTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.transitionCollateral, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "transitionCollateral (when debt)",
-            343742 // 74K for interest
+            343742, // 74K for interest
+            500
         );
     }
 }


### PR DESCRIPTION
## Problem

We want full pausing functionality in this controller. 

## Solution

To be able to pause all the share tokens, we have to remove conditions for the collateral share token. 

We also have to remember to not check for liquidation for debt token, because it can prevent regular repay. 
