### PR TITLE
push PermissionedLiquidationController to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [4.13.0] - 2026-05-07
+### Updated
+- allow `PermissionedLiquidationController` set for debt share token (#1896)
+
 ## [4.12.0] - 2026-05-06
 ### Added
 - flat price oracle deployment

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "silo-contracts-v2",
   "packageManager": "yarn@3.5.0",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:silo-finance/silo-v2.git"

--- a/silo-core/.solhintignore
+++ b/silo-core/.solhintignore
@@ -4,3 +4,4 @@ contracts/hooks/_common/TransientReentrancy.sol
 contracts/hooks/PendleRewardsClaimer.sol
 contracts/leverage/modules/LeverageTxState.sol
 contracts/SiloDeployer.sol
+contracts/incentives/functional/PermissionedLiquidationController.sol

--- a/silo-core/common/SiloCoreContracts.sol
+++ b/silo-core/common/SiloCoreContracts.sol
@@ -28,6 +28,8 @@ library SiloCoreContracts {
     string public constant LEVERAGE_ROUTER = "LeverageRouter.sol";
     string public constant SILO_ROUTER_V2 = "SiloRouterV2.sol";
     string public constant INCENTIVES_CONTROLLER_FACTORY = "SiloIncentivesControllerFactory.sol";
+    string public constant PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY =
+        "PermissionedLiquidationControllerFactory.sol";
     string public constant GLOBAL_PAUSE = "GlobalPause.sol";
 }
 

--- a/silo-core/contracts/incentives/base/BaseIncentivesControllerCompatible.sol
+++ b/silo-core/contracts/incentives/base/BaseIncentivesControllerCompatible.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.28;
+
+import {ISiloIncentivesController} from "../interfaces/ISiloIncentivesController.sol";
+import {IBackwardsCompatibleGaugeLike} from "../interfaces/IBackwardsCompatibleGaugeLike.sol";
+import {DistributionTypes} from "../lib/DistributionTypes.sol";
+
+abstract contract BaseIncentivesControllerCompatible is IBackwardsCompatibleGaugeLike, ISiloIncentivesController {
+    /// @notice Whether the gauge is killed
+    /// @dev This flag is not used in the SiloIncentivesController,
+    /// but it is used in the Gauge hook receiver (versions <= 3.7.0).
+    bool internal _isKilled;
+
+    event GaugeKilled();
+    event GaugeUnKilled();
+
+    modifier onlyOwner() {
+        _onlyOwner();
+        _;
+    }
+
+    function killGauge() external virtual onlyOwner {
+        _isKilled = true;
+        emit GaugeKilled();
+    }
+
+    function unkillGauge() external virtual onlyOwner {
+        _isKilled = false;
+        emit GaugeUnKilled();
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function is_killed() external view virtual returns (bool) {
+        return _isKilled;
+    }
+
+    function setDistributionEnd(string calldata, uint40) external pure {
+        // do nothing
+    }
+
+    function getDistributionEnd(string calldata) external pure returns (uint256) {
+        // do nothing
+    }
+
+    function getUserData(address, string calldata) external pure returns (uint256) {
+        // do nothing
+    }
+
+    function incentivesProgram(string calldata) external pure returns (IncentiveProgramDetails memory) {
+        // do nothing
+    }
+
+    function getAllProgramsNames() external pure returns (string[] memory) {
+        // do nothing
+    }
+
+    function getProgramName(bytes32) external pure returns (string memory) {
+        // do nothing
+    }
+
+    function getProgramId(string calldata) external pure returns (bytes32) {
+        // do nothing
+    }
+
+    function immediateDistribution(address, uint256) external pure returns (bytes32) {
+        // do nothing
+    }
+
+    function rescueRewards(address) external pure {
+        // do nothing
+    }
+
+    function setClaimer(address, address) external pure {
+        // do nothing
+    }
+
+    function createIncentivesProgram(DistributionTypes.IncentivesProgramCreationInput memory) external pure {
+        // do nothing
+    }
+
+    function updateIncentivesProgram(string calldata, uint40, uint256) external pure {
+        // do nothing
+    }
+
+    function claimRewards(address) external pure returns (AccruedRewards[] memory accruedRewards) {
+        // do nothing
+    }
+
+    function claimRewards(address, string[] calldata) external pure returns (AccruedRewards[] memory) {
+        // do nothing
+    }
+
+    function claimRewardsOnBehalf(address, address, string[] calldata)
+        external
+        pure
+        returns (AccruedRewards[] memory)
+    {
+        // do nothing
+    }
+
+    function getClaimer(address) external pure returns (address) {
+        // do nothing
+    }
+
+    function getRewardsBalance(address, string calldata) external pure returns (uint256) {
+        // do nothing
+    }
+
+    function getRewardsBalance(address, string[] calldata) external pure returns (uint256) {
+        // do nothing
+    }
+
+    function getUserUnclaimedRewards(address, string calldata) external pure returns (uint256) {
+        // do nothing
+    }
+
+    function afterTokenTransfer(
+        address _sender,
+        uint256 _senderBalance,
+        address _recipient,
+        uint256 _recipientBalance,
+        uint256 _totalSupply,
+        uint256 _amount
+    ) public virtual override(IBackwardsCompatibleGaugeLike, ISiloIncentivesController);
+
+    function _onlyOwner() internal view virtual;
+}

--- a/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
+++ b/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
@@ -27,7 +27,7 @@ contract PermissionedLiquidationController is
 {
     address public hookReceiver;
 
-    address public collateralShareToken;
+    address public shareToken;
 
     PermisionedData internal _permisionedData;
 
@@ -42,24 +42,21 @@ contract PermissionedLiquidationController is
         _disableInitializers();
     }
 
-    /// @param _collateralShareToken collateral or protected share token address
-    function initialize(IShareToken _collateralShareToken) external initializer {
-        address hook = _collateralShareToken.hookReceiver();
-        ISiloConfig siloConfig = _collateralShareToken.siloConfig();
-        address collateralSilo = address(_collateralShareToken.silo());
+    /// @param _shareToken collateral or protected share token address
+    function initialize(IShareToken _shareToken) external initializer {
+        hookReceiver = _shareToken.hookReceiver();
+        shareToken = address(_shareToken);
 
-        ISiloConfig.ConfigData memory collateralConfig = siloConfig.getConfig(collateralSilo);
-        require(collateralConfig.lt != 0, NotCollateralSilo());
+        ISilo silo = _shareToken.silo();
 
-        require(
-            collateralConfig.collateralShareToken == address(_collateralShareToken)
-                || collateralConfig.protectedShareToken == address(_collateralShareToken),
-            NotCollateralShareToken()
-        );
+        ISiloConfig.ConfigData memory cfg = silo.config().getConfig(address(silo));
 
-        hookReceiver = hook;
-        collateralShareToken = address(_collateralShareToken);
-        _permisionedData = PermisionedData({anySilo: collateralSilo, enabled: false, pauseTokenTransfer: false});
+        _permisionedData = PermisionedData({
+            anySilo: address(silo), 
+            enabled: false, 
+            pauseTokenTransfer: false,
+            shateTokenIsDebtToken: cfg.debtShareToken == address(_shareToken)
+        });
 
         __Whitelist_init(Ownable(hookReceiver).owner());
     }
@@ -77,6 +74,7 @@ contract PermissionedLiquidationController is
         require(_permisionedData.pauseTokenTransfer != _pauseTokenTransfer, PauseTokenTransferAlreadySet());
 
         _permisionedData.pauseTokenTransfer = _pauseTokenTransfer;
+
         if (_pauseTokenTransfer) {
             _permisionedData.enabled = true;
             emit EnabledChanged(true);
@@ -97,12 +95,12 @@ contract PermissionedLiquidationController is
 
     // solhint-disable-next-line func-name-mixedcase
     function share_token() external view virtual returns (address) {
-        return collateralShareToken;
+        return shareToken;
     }
 
     // solhint-disable-next-line func-name-mixedcase
     function SHARE_TOKEN() external view returns (address) {
-        return collateralShareToken;
+        return shareToken;
     }
 
     function NOTIFIER() external view returns (address) { // solhint-disable-line func-name-mixedcase
@@ -110,7 +108,7 @@ contract PermissionedLiquidationController is
     }
 
     function VERSION() external pure virtual returns (string memory) { // solhint-disable-line func-name-mixedcase
-        return "PermissionedLiquidationController 4.12.0";
+        return "PermissionedLiquidationController 4.13.1";
     }
 
     function afterTokenTransfer(
@@ -133,6 +131,9 @@ contract PermissionedLiquidationController is
         if (data.pauseTokenTransfer) revert PauseTokenTransferActive();
 
         if (_liquidationAllowed) return;
+
+        // for debt token we can not revert, because it migth revert regular repay
+        if (data.shateTokenIsDebtToken) return;
 
         // is this liquidation?
         // After transferring collateral, the user will always be insolvent.

--- a/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
+++ b/silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Initializable} from "openzeppelin5/proxy/utils/Initializable.sol";
+
+import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISiloIncentivesController} from "../interfaces/ISiloIncentivesController.sol";
+
+import {BaseIncentivesControllerCompatible} from "../base/BaseIncentivesControllerCompatible.sol";
+import {
+    IPermissionedLiquidationController
+} from "silo-core/contracts/interfaces/IPermissionedLiquidationController.sol";
+import {Whitelist} from "silo-core/contracts/hooks/_common/Whitelist.sol";
+
+/// @dev this contract should be set as a gauge for collateral or protected share tokens.
+/// It will not work if it will be set for the shared debt token.
+/// When you set it for hook with defaulting liquidation, it's recommended to keep enable to false 
+/// and use defaulting whitelist rather than permission and liquidation controller.
+contract PermissionedLiquidationController is
+    IPermissionedLiquidationController,
+    BaseIncentivesControllerCompatible,
+    Whitelist,
+    Initializable
+{
+    address public hookReceiver;
+
+    address public collateralShareToken;
+
+    PermisionedData internal _permisionedData;
+
+    bool private transient _liquidationAllowed;
+
+    modifier onlyHookReceiver() {
+        require(msg.sender == hookReceiver, OnlyHookReceiver());
+        _;
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @param _collateralShareToken collateral or protected share token address
+    function initialize(IShareToken _collateralShareToken) external initializer {
+        address hook = _collateralShareToken.hookReceiver();
+        ISiloConfig siloConfig = _collateralShareToken.siloConfig();
+        address collateralSilo = address(_collateralShareToken.silo());
+
+        ISiloConfig.ConfigData memory collateralConfig = siloConfig.getConfig(collateralSilo);
+        require(collateralConfig.lt != 0, NotCollateralSilo());
+
+        require(
+            collateralConfig.collateralShareToken == address(_collateralShareToken)
+                || collateralConfig.protectedShareToken == address(_collateralShareToken),
+            NotCollateralShareToken()
+        );
+
+        hookReceiver = hook;
+        collateralShareToken = address(_collateralShareToken);
+        _permisionedData = PermisionedData({anySilo: collateralSilo, enabled: false, pauseTokenTransfer: false});
+
+        __Whitelist_init(Ownable(hookReceiver).owner());
+    }
+
+    /// @inheritdoc IPermissionedLiquidationController
+    function setEnabled(bool _enabled) external onlyOwner {
+        require(_permisionedData.enabled != _enabled, EnabledAlreadySet());
+
+        _permisionedData.enabled = _enabled;
+        emit EnabledChanged(_enabled);
+    }
+
+    /// @inheritdoc IPermissionedLiquidationController
+    function setPause(bool _pauseTokenTransfer) external onlyOwner {
+        require(_permisionedData.pauseTokenTransfer != _pauseTokenTransfer, PauseTokenTransferAlreadySet());
+
+        _permisionedData.pauseTokenTransfer = _pauseTokenTransfer;
+        if (_pauseTokenTransfer) {
+            _permisionedData.enabled = true;
+            emit EnabledChanged(true);
+        }
+
+        emit PauseTokenTransferChanged(_pauseTokenTransfer);
+    }
+
+    /// @inheritdoc IPermissionedLiquidationController
+    function allowMeToLiquidate() external virtual onlyAllowed {
+        _liquidationAllowed = true;
+    }
+
+    /// @inheritdoc IPermissionedLiquidationController
+    function permisionedData() external view returns (PermisionedData memory data) {
+        data = _permisionedData;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function share_token() external view virtual returns (address) {
+        return collateralShareToken;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function SHARE_TOKEN() external view returns (address) {
+        return collateralShareToken;
+    }
+
+    function NOTIFIER() external view returns (address) { // solhint-disable-line func-name-mixedcase
+        return hookReceiver;
+    }
+
+    function VERSION() external pure virtual returns (string memory) { // solhint-disable-line func-name-mixedcase
+        return "PermissionedLiquidationController 4.12.0";
+    }
+
+    function afterTokenTransfer(
+        address _sender,
+        uint256 /*_senderBalance*/,
+        address /*_recipient*/,
+        uint256 /*_recipientBalance*/,
+        uint256 /*_totalSupply*/,
+        uint256 /*_amount*/
+    )
+        public
+        virtual
+        override(BaseIncentivesControllerCompatible, ISiloIncentivesController)
+        onlyHookReceiver
+    {
+        PermisionedData memory data = _permisionedData;
+
+        if (!data.enabled) return;
+
+        if (data.pauseTokenTransfer) revert PauseTokenTransferActive();
+
+        if (_liquidationAllowed) return;
+
+        // is this liquidation?
+        // After transferring collateral, the user will always be insolvent.
+        bool isLiquidation = !ISilo(data.anySilo).isSolvent(_sender);
+
+        if (isLiquidation) revert LiquidationNotAllowed();
+    }
+
+    /// @dev to keep the interface backwards compatible, we need the owner method.
+    function owner() public view virtual returns (address) {
+        uint256 count = getRoleMemberCount(DEFAULT_ADMIN_ROLE);
+        return count == 0 ? address(0) : getRoleMember(DEFAULT_ADMIN_ROLE, 0);
+    }
+
+    function _onlyOwner() internal view virtual override {
+        require(msg.sender == owner(), OnlyOwner());
+    }
+}

--- a/silo-core/contracts/incentives/functional/PermissionedLiquidationControllerFactory.sol
+++ b/silo-core/contracts/incentives/functional/PermissionedLiquidationControllerFactory.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Ownable} from "openzeppelin5/access/Ownable.sol";
+
+import {
+    IPermissionedLiquidationControllerFactory
+} from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
+import {
+    PermissionedLiquidationController
+} from "silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol";
+import {TransparentProxy} from "silo-core/contracts/utils/TransparentProxy.sol";
+
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+
+/// @notice Minimal factory for upgradeable PermissionedLiquidationController proxies.
+contract PermissionedLiquidationControllerFactory is IPermissionedLiquidationControllerFactory {
+    /// @dev Implementation used by all created proxies.
+    address public immutable IMPLEMENTATION;
+
+    constructor() {
+        IMPLEMENTATION = address(new PermissionedLiquidationController());
+    }
+
+    /// @inheritdoc IPermissionedLiquidationControllerFactory
+    function create(IShareToken _collateralShareToken) external returns (address controller) {
+        address proxyAdminOwner = Ownable(_collateralShareToken.hookReceiver()).owner();
+        bytes memory initData = abi.encodeCall(PermissionedLiquidationController.initialize, (_collateralShareToken));
+
+        controller = address(new TransparentProxy(IMPLEMENTATION, proxyAdminOwner, initData));
+
+        emit PermissionedLiquidationControllerCreated(controller, address(_collateralShareToken));
+    }
+}

--- a/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
+++ b/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+import {IAccessControl} from "openzeppelin5/access/IAccessControl.sol";
+
+import {ISiloIncentivesController} from "../incentives/interfaces/ISiloIncentivesController.sol";
+import {IVersioned} from "silo-core/contracts/interfaces/IVersioned.sol";
+
+interface IPermissionedLiquidationController is ISiloIncentivesController, IAccessControl, IVersioned {
+    struct PermisionedData {
+        /// @param anySilo one of market silo, set based on hook receiver.
+        address anySilo;
+        /// @param enabled if false, then permissions feature is disabled and liquidation can be done as usual
+        bool enabled;
+        /// @param pauseTokenTransfer if true, then token transfer will be paused and tx will be reverted
+        bool pauseTokenTransfer;
+    }
+
+    event EnabledChanged(bool _enabled);
+    event PauseTokenTransferChanged(bool _pauseTokenTransfer);
+
+    error LiquidationNotAllowed();
+    error OnlyHookReceiver();
+    error OnlyOwner();
+    error NotCollateralSilo();
+    error NotCollateralShareToken();
+    error EnabledAlreadySet();
+    error PauseTokenTransferAlreadySet();
+    error PauseTokenTransferActive();
+
+    function setEnabled(bool _enabled) external;
+
+    /// @notice when _pauseTokenTransfer is TRUE, it will automatically set enabled to true
+    function setPause(bool _pauseTokenTransfer) external;
+
+    /// @dev it will raise the flag that allows liquidation.
+    /// @notice this function can be called by approved addresses,
+    /// also, liquidation method in approved contract should be protected, otherwise, this flag can be abused.
+    function allowMeToLiquidate() external;
+
+    function hookReceiver() external view returns (address);
+
+    function owner() external view returns (address);
+
+    function permisionedData() external view returns (PermisionedData memory);
+}

--- a/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
+++ b/silo-core/contracts/interfaces/IPermissionedLiquidationController.sol
@@ -14,6 +14,8 @@ interface IPermissionedLiquidationController is ISiloIncentivesController, IAcce
         bool enabled;
         /// @param pauseTokenTransfer if true, then token transfer will be paused and tx will be reverted
         bool pauseTokenTransfer;
+        /// @param shateTokenIsDebtToken if true, that means this controller is set for debt token.
+        bool shateTokenIsDebtToken;
     }
 
     event EnabledChanged(bool _enabled);
@@ -22,8 +24,6 @@ interface IPermissionedLiquidationController is ISiloIncentivesController, IAcce
     error LiquidationNotAllowed();
     error OnlyHookReceiver();
     error OnlyOwner();
-    error NotCollateralSilo();
-    error NotCollateralShareToken();
     error EnabledAlreadySet();
     error PauseTokenTransferAlreadySet();
     error PauseTokenTransferActive();

--- a/silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol
+++ b/silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IShareToken} from "./IShareToken.sol";
+
+interface IPermissionedLiquidationControllerFactory {
+    event PermissionedLiquidationControllerCreated(
+        address indexed controller,
+        address indexed collateralShareToken
+    );
+
+    /// @notice Creates a new upgradeable PermissionedLiquidationController proxy.
+    /// @param _collateralShareToken Collateral or protected share token address
+    /// @return controller Address of the newly created proxy.
+    function create(IShareToken _collateralShareToken) external returns (address controller);
+}

--- a/silo-core/contracts/utils/TransparentProxy.sol
+++ b/silo-core/contracts/utils/TransparentProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {TransparentUpgradeableProxy} from "openzeppelin5/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract TransparentProxy is TransparentUpgradeableProxy {
+    constructor(address _implementation, address _proxyAdminOwner, bytes memory _initData)
+        TransparentUpgradeableProxy(_implementation, _proxyAdminOwner, _initData)
+    {}
+
+    receive() external payable {}
+
+    function getAdmin() public view returns (address) {
+        return _proxyAdmin();
+    }
+}

--- a/silo-core/contracts/utils/liquidationHelper/ManualLiquidationHelper.sol
+++ b/silo-core/contracts/utils/liquidationHelper/ManualLiquidationHelper.sol
@@ -7,16 +7,21 @@ import {SafeERC20} from "openzeppelin5/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "openzeppelin5/utils/math/Math.sol";
 
 import {IPartialLiquidation} from "../../interfaces/IPartialLiquidation.sol";
+import {IShareToken} from "../../interfaces/IShareToken.sol";
+import {IGaugeHookReceiver} from "../../interfaces/IGaugeHookReceiver.sol";
+import {ISiloIncentivesController} from "../../incentives/interfaces/ISiloIncentivesController.sol";
+import {IPermissionedLiquidationController} from "../../interfaces/IPermissionedLiquidationController.sol";
 
 import {ISilo} from "../../interfaces/ISilo.sol";
 import {ISiloConfig} from "../../interfaces/ISiloConfig.sol";
 import {IWrappedNativeToken} from "../../interfaces/IWrappedNativeToken.sol";
 
 import {TokenRescuer} from "../TokenRescuer.sol";
+import {Whitelist} from "../../hooks/_common/Whitelist.sol";
 
 /// @notice ManualLiquidationHelper is a utility contract that can be changed and replaced at any point.
 /// It is not considered a part of Silo protocol. Use at your own risk.
-contract ManualLiquidationHelper is TokenRescuer {
+contract ManualLiquidationHelper is TokenRescuer, Whitelist {
     using Address for address payable;
     using SafeERC20 for IERC20;
 
@@ -37,6 +42,8 @@ contract ManualLiquidationHelper is TokenRescuer {
     ) {
         NATIVE_TOKEN = _nativeToken;
         TOKENS_RECEIVER = _tokensReceiver;
+
+        __Whitelist_init(msg.sender);
     }
 
     receive() external payable {}
@@ -90,6 +97,7 @@ contract ManualLiquidationHelper is TokenRescuer {
         _executeLiquidation(_siloWithDebt, _borrower, _maxDebtToCover, _receiveSToken, _receiver);
     }
 
+    // solhint-disable-next-line function-max-lines
     function _executeLiquidation(
         ISilo _siloWithDebt,
         address _borrower,
@@ -99,6 +107,7 @@ contract ManualLiquidationHelper is TokenRescuer {
     )
         internal
         virtual
+        onlyAllowedOrPublic
     {
         require(_maxDebtToCover != 0, MaxDebtToCoverZero());
 
@@ -108,6 +117,9 @@ contract ManualLiquidationHelper is TokenRescuer {
         ) = _siloWithDebt.config().getConfigsForSolvency(_borrower);
 
         IPartialLiquidation liquidation = IPartialLiquidation(debtConfig.hookReceiver);
+        _allowMeToLiquidate(debtConfig.hookReceiver, IShareToken(collateralConfig.collateralShareToken));
+        _allowMeToLiquidate(debtConfig.hookReceiver, IShareToken(collateralConfig.protectedShareToken));
+
         IERC20 debtAsset = IERC20(debtConfig.token);
 
         (, uint256 debtToRepay,) = liquidation.maxLiquidation(_borrower);
@@ -157,5 +169,16 @@ contract ManualLiquidationHelper is TokenRescuer {
     function _transferNative(address payable _receiver, uint256 _amount) internal virtual {
         IWrappedNativeToken(address(NATIVE_TOKEN)).withdraw(_amount);
         _receiver.sendValue(_amount);
+    }
+
+    function _allowMeToLiquidate(address _hookReceiver, IShareToken _shareToken) internal virtual {
+        ISiloIncentivesController controller = IGaugeHookReceiver(_hookReceiver).configuredGauges(_shareToken);
+        if (address(controller) == address(0)) return;
+        
+        try IPermissionedLiquidationController(address(controller)).allowMeToLiquidate() {
+            // allowed
+        } catch {
+            // not allwoed or not supported
+        }
     }
 }

--- a/silo-core/deploy/MainnetDeploy.s.sol
+++ b/silo-core/deploy/MainnetDeploy.s.sol
@@ -25,6 +25,9 @@ import {SiloImplementationDeploy} from "silo-core/deploy/SiloImplementationDeplo
 import {
     LeverageRouterUsingSiloFlashloanWithGeneralSwapDeploy
 } from "silo-core/deploy/LeverageRouterUsingSiloFlashloanWithGeneralSwapDeploy.s.sol";
+import {
+    PermissionedLiquidationControllerFactoryDeploy
+} from "silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryDeploy.s.sol";
 
 /*
     FOUNDRY_PROFILE=core AGGREGATOR=1INCH \
@@ -66,13 +69,14 @@ contract MainnetDeploy is CommonDeploy {
         SiloDeployerDeploy siloDeployerDeploy = new SiloDeployerDeploy();
         LiquidationHelperDeploy liquidationHelperDeploy = new LiquidationHelperDeploy();
         SiloLensDeploy siloLensDeploy = new SiloLensDeploy();
-        TowerDeploy towerDeploy = new TowerDeploy();
         SiloRouterV2Deploy siloRouterV2Deploy = new SiloRouterV2Deploy();
-        ManualLiquidationHelperDeploy manualLiquidationHelperDeploy = new ManualLiquidationHelperDeploy();
         DKinkIRMFactoryDeploy dkinkIRMFactoryDeploy = new DKinkIRMFactoryDeploy();
 
         SiloIncentivesControllerFactoryDeploy siloIncentivesControllerFactoryDeploy =
             new SiloIncentivesControllerFactoryDeploy();
+
+        PermissionedLiquidationControllerFactoryDeploy permissionedLiquidationControllerFactoryDeploy =
+            new PermissionedLiquidationControllerFactoryDeploy();
 
         LeverageRouterUsingSiloFlashloanWithGeneralSwapDeploy leverageRouterDeploy =
             new LeverageRouterUsingSiloFlashloanWithGeneralSwapDeploy();
@@ -89,10 +93,16 @@ contract MainnetDeploy is CommonDeploy {
         siloLensDeploy.run();
         siloRouterV2Deploy.run();
         siloIncentivesControllerFactoryDeploy.run();
+        permissionedLiquidationControllerFactoryDeploy.run();
         leverageRouterDeploy.run();
 
-        manualLiquidationHelperDeploy.run(); // not for V3
-        towerDeploy.run();
+        {
+            ManualLiquidationHelperDeploy manualLiquidationHelperDeploy = new ManualLiquidationHelperDeploy();
+            manualLiquidationHelperDeploy.run(); // not for V3
+
+            TowerDeploy towerDeploy = new TowerDeploy();
+            towerDeploy.run();
+        }
 
         // execute deployer at the end, to make sure we est factories
         siloDeployerDeploy.run();

--- a/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
+++ b/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
+import {SiloIncentivesControllerDeployments} from "./SiloIncentivesControllerDeployments.sol";
+
+import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {CommonDeploy} from "../_CommonDeploy.sol";
+import {SiloCoreContracts, SiloCoreDeployments} from "silo-core/common/SiloCoreContracts.sol";
+import {IGaugeHookReceiver} from "silo-core/contracts/interfaces/IGaugeHookReceiver.sol";
+import {ISiloIncentivesController} from "silo-core/contracts/incentives/interfaces/ISiloIncentivesController.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {
+    IPermissionedLiquidationControllerFactory
+} from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
+
+/*
+    SILO=0xe394050D179b72197A458Fdfb962Ae69908Aa5A0 \
+    FOUNDRY_PROFILE=core \
+        forge script silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol \
+        --ffi --rpc-url $RPC_MAINNET --broadcast --verify
+ */
+contract PermissionedLiquidationControllerDeploy is CommonDeploy {
+    error FactoryNotFound();
+
+    function run() public {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
+
+        ISilo silo = ISilo(vm.envAddress("SILO"));
+
+        address notifier = IShareToken(address(silo)).hookReceiver();
+        address owner = Ownable(notifier).owner();
+
+        address factory = SiloCoreDeployments.get(
+            SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY, ChainsLib.chainAlias()
+        );
+
+        require(factory != address(0), FactoryNotFound());
+
+        ISiloConfig cfg = silo.config();
+
+        console2.log("SILO ID:", cfg.SILO_ID());
+
+        ISiloConfig.ConfigData memory config = cfg.getConfig(address(silo));
+        address collateralShareTokenAddress = config.collateralShareToken;
+        address protectedShareTokenAddress = config.protectedShareToken;
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        address incentivesControllerC =
+            IPermissionedLiquidationControllerFactory(factory).create(IShareToken(collateralShareTokenAddress));
+        
+        address incentivesControllerP =
+            IPermissionedLiquidationControllerFactory(factory).create(IShareToken(protectedShareTokenAddress));
+
+        vm.stopBroadcast();
+
+        // hook receiver ownership acceptance data
+        console2.log(
+            "\nHook(%s).setGauge(ic: %s, shareToken: %s)",
+            notifier,
+            incentivesControllerC,
+            collateralShareTokenAddress
+        );
+        
+        console2.log(
+            "\nHook(%s).setGauge(ic: %s, shareToken: %s)", notifier, incentivesControllerP, protectedShareTokenAddress
+        );
+
+        console2.log("QA ---");
+
+        vm.startPrank(owner);
+        IGaugeHookReceiver(notifier)
+            .setGauge(
+                ISiloIncentivesController(address(incentivesControllerC)), IShareToken(collateralShareTokenAddress)
+            );
+
+        IGaugeHookReceiver(notifier)
+            .setGauge(
+                ISiloIncentivesController(address(incentivesControllerP)), IShareToken(protectedShareTokenAddress)
+            );
+
+        IGaugeHookReceiver(notifier).removeGauge(IShareToken(collateralShareTokenAddress));
+        IGaugeHookReceiver(notifier).removeGauge(IShareToken(protectedShareTokenAddress));
+
+        vm.stopPrank();
+
+        SiloIncentivesControllerDeployments.save({
+            _chain: ChainsLib.chainAlias(), _shareToken: collateralShareTokenAddress, _deployed: incentivesControllerC
+        });
+
+        SiloIncentivesControllerDeployments.save({
+            _chain: ChainsLib.chainAlias(), _shareToken: protectedShareTokenAddress, _deployed: incentivesControllerP
+        });
+    }
+}

--- a/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
+++ b/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol
@@ -5,7 +5,10 @@ import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
 import {SiloIncentivesControllerDeployments} from "./SiloIncentivesControllerDeployments.sol";
 
 import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin5/token/ERC20/extensions/IERC20Metadata.sol";
 import {console2} from "forge-std/console2.sol";
+import {StdCheats} from "forge-std/StdCheats.sol";
 
 import {CommonDeploy} from "../_CommonDeploy.sol";
 import {SiloCoreContracts, SiloCoreDeployments} from "silo-core/common/SiloCoreContracts.sol";
@@ -24,7 +27,7 @@ import {
         forge script silo-core/deploy/incentives-controller/PermissionedLiquidationControllerDeploy.s.sol \
         --ffi --rpc-url $RPC_MAINNET --broadcast --verify
  */
-contract PermissionedLiquidationControllerDeploy is CommonDeploy {
+contract PermissionedLiquidationControllerDeploy is CommonDeploy, StdCheats {
     error FactoryNotFound();
 
     function run() public {
@@ -39,7 +42,7 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
             SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY, ChainsLib.chainAlias()
         );
 
-        require(factory != address(0), FactoryNotFound());
+        require(factory != address(0), string.concat(SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY, " not found"));
 
         ISiloConfig cfg = silo.config();
 
@@ -48,6 +51,10 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         ISiloConfig.ConfigData memory config = cfg.getConfig(address(silo));
         address collateralShareTokenAddress = config.collateralShareToken;
         address protectedShareTokenAddress = config.protectedShareToken;
+        address debtShareTokenAddress = config.debtShareToken;
+
+        ISiloIncentivesController debtGauge = IGaugeHookReceiver(notifier).configuredGauges(IShareToken(debtShareTokenAddress));
+        bool deployForDebt = address(debtGauge) == address(0);
 
         vm.startBroadcast(deployerPrivateKey);
 
@@ -56,6 +63,12 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         
         address incentivesControllerP =
             IPermissionedLiquidationControllerFactory(factory).create(IShareToken(protectedShareTokenAddress));
+
+        address incentivesControllerD;
+        if (deployForDebt) {
+            incentivesControllerD =
+                IPermissionedLiquidationControllerFactory(factory).create(IShareToken(debtShareTokenAddress));
+        }
 
         vm.stopBroadcast();
 
@@ -71,6 +84,12 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
             "\nHook(%s).setGauge(ic: %s, shareToken: %s)", notifier, incentivesControllerP, protectedShareTokenAddress
         );
 
+        if (deployForDebt) {
+            console2.log(
+                "\nHook(%s).setGauge(ic: %s, shareToken: %s)", notifier, incentivesControllerD, debtShareTokenAddress
+            );
+        }
+
         console2.log("QA ---");
 
         vm.startPrank(owner);
@@ -84,10 +103,23 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
                 ISiloIncentivesController(address(incentivesControllerP)), IShareToken(protectedShareTokenAddress)
             );
 
+        if (deployForDebt) {
+            IGaugeHookReceiver(notifier).setGauge(
+                ISiloIncentivesController(address(incentivesControllerD)), IShareToken(debtShareTokenAddress)
+            );
+        }
+
         IGaugeHookReceiver(notifier).removeGauge(IShareToken(collateralShareTokenAddress));
         IGaugeHookReceiver(notifier).removeGauge(IShareToken(protectedShareTokenAddress));
 
+        if (deployForDebt) {
+            IGaugeHookReceiver(notifier).removeGauge(IShareToken(debtShareTokenAddress));
+        }
+
         vm.stopPrank();
+
+        // Cheat-only smoke test (fake user + `deal`); does not use PRIVATE_KEY and is not broadcast.
+        _qaSiloSmoke(cfg);
 
         SiloIncentivesControllerDeployments.save({
             _chain: ChainsLib.chainAlias(), _shareToken: collateralShareTokenAddress, _deployed: incentivesControllerC
@@ -96,5 +128,56 @@ contract PermissionedLiquidationControllerDeploy is CommonDeploy {
         SiloIncentivesControllerDeployments.save({
             _chain: ChainsLib.chainAlias(), _shareToken: protectedShareTokenAddress, _deployed: incentivesControllerP
         });
+    }
+
+    function _qaSiloSmoke(ISiloConfig siloConfig) private {
+        address depositor = makeAddr("depositor");
+        (address silo0Addr, address silo1Addr) = siloConfig.getSilos();
+        ISilo silo0 = ISilo(silo0Addr);
+        ISilo silo1 = ISilo(silo1Addr);
+
+        (uint256 unit0, uint256 unit1) = _qaDealForSilos(silo0, silo1, depositor);
+
+        vm.startPrank(depositor);
+
+        _qaDepositOnSilo(silo0, depositor, unit0 * 100);
+        _qaDepositOnSilo(silo1, depositor, unit1 * 100);
+
+        vm.warp(block.timestamp + 1 days);
+
+        require(_qaBorrow(silo0, depositor) || _qaBorrow(silo1, depositor), "QA: borrow failed");
+    }
+
+    function _qaDealForSilos(ISilo silo0, ISilo silo1, address depositor) private returns (uint256 unit0, uint256 unit1) {
+        address asset0 = silo0.asset();
+        address asset1 = silo1.asset();
+        unit0 = 10 ** uint256(IERC20Metadata(asset0).decimals());
+        unit1 = 10 ** uint256(IERC20Metadata(asset1).decimals());
+        deal(asset0, depositor, unit0 * 2_000);
+        deal(asset1, depositor, unit1 * 2_000);
+    }
+
+    function _qaDepositOnSilo(
+        ISilo _silo,
+        address _depositor,
+        uint256 _amount
+    ) private {
+        address asset = _silo.asset();
+        IERC20(asset).approve(address(_silo), type(uint256).max);
+        _silo.deposit(_amount, _depositor, ISilo.CollateralType.Protected);
+        _silo.deposit(_amount, _depositor, ISilo.CollateralType.Collateral);
+    }
+
+    function _qaBorrow(ISilo _silo, address _depositor) internal returns (bool success) {
+        uint256 maxBorrow0 = _silo.maxBorrow(_depositor);
+
+        if (maxBorrow0 == 0) return false;
+
+        uint256 shares = _silo.borrow(maxBorrow0, _depositor, _depositor);
+        
+        vm.warp(block.timestamp + 1 days);
+
+        _silo.repayShares(shares, _depositor);
+        success = true;
     }
 }

--- a/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryDeploy.s.sol
+++ b/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryDeploy.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {CommonDeploy} from "../_CommonDeploy.sol";
+import {SiloCoreContracts} from "silo-core/common/SiloCoreContracts.sol";
+import {
+    PermissionedLiquidationControllerFactory
+} from "silo-core/contracts/incentives/functional/PermissionedLiquidationControllerFactory.sol";
+import {
+    IPermissionedLiquidationControllerFactory
+} from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
+
+/*
+    FOUNDRY_PROFILE=core \
+        forge script silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryDeploy.s.sol \
+        --ffi --rpc-url $RPC_MAINNET --broadcast --verify
+ */
+contract PermissionedLiquidationControllerFactoryDeploy is CommonDeploy {
+    function run() public returns (IPermissionedLiquidationControllerFactory factory) {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        factory = new PermissionedLiquidationControllerFactory();
+
+        vm.stopBroadcast();
+
+        _registerDeployment(address(factory), SiloCoreContracts.PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY);
+    }
+}

--- a/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryUpgrade.s.sol
+++ b/silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryUpgrade.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {console2} from "forge-std/console2.sol";
+
+import {ChainsLib} from "silo-foundry-utils/lib/ChainsLib.sol";
+
+import {CommonDeploy} from "../_CommonDeploy.sol";
+import {SiloIncentivesControllerDeployments} from "./SiloIncentivesControllerDeployments.sol";
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
+import {ProxyAdmin} from "openzeppelin5/proxy/transparent/ProxyAdmin.sol";
+import {ITransparentUpgradeableProxy} from "openzeppelin5/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentProxy} from "silo-core/contracts/utils/TransparentProxy.sol";
+
+/*
+    SILO=0xe394050D179b72197A458Fdfb962Ae69908Aa5A0 \
+    IMPLEMENTATION=0x0000000000000000000000000000000000000001 \
+    FOUNDRY_PROFILE=core \
+        forge script silo-core/deploy/incentives-controller/PermissionedLiquidationControllerFactoryUpgrade.s.sol \
+        --ffi --rpc-url $RPC_MAINNET --broadcast --verify
+ */
+contract PermissionedLiquidationControllerFactoryUpgrade is CommonDeploy {
+    error InvalidImplementation();
+    error ControllerNotFound();
+
+    function run() public {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
+        address implementation = vm.envAddress("IMPLEMENTATION");
+        require(implementation != address(0), InvalidImplementation());
+
+        ISilo silo = ISilo(vm.envAddress("SILO"));
+        ISiloConfig.ConfigData memory config = silo.config().getConfig(address(silo));
+
+        address collateralController =
+            SiloIncentivesControllerDeployments.get(ChainsLib.chainAlias(), config.collateralShareToken);
+        address protectedController =
+            SiloIncentivesControllerDeployments.get(ChainsLib.chainAlias(), config.protectedShareToken);
+
+        require(collateralController != address(0), ControllerNotFound());
+        require(protectedController != address(0), ControllerNotFound());
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        _upgrade(collateralController, implementation);
+        _upgrade(protectedController, implementation);
+
+        vm.stopBroadcast();
+
+        console2.log("Permissioned controller upgraded (collateral):", collateralController);
+        console2.log("Permissioned controller upgraded (protected):", protectedController);
+        console2.log("New implementation:", implementation);
+        console2.log("Notifier:", IShareToken(address(silo)).hookReceiver());
+    }
+
+    function _upgrade(address _controllerProxy, address _newImplementation) internal {
+        address proxyAdmin = TransparentProxy(payable(_controllerProxy)).getAdmin();
+
+        ProxyAdmin(proxyAdmin)
+            .upgradeAndCall(ITransparentUpgradeableProxy(payable(_controllerProxy)), _newImplementation, bytes(""));
+    }
+}

--- a/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
@@ -30,7 +30,8 @@ contract TransitionCollateralTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.transitionCollateral, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "transitionCollateral (when debt)",
-            292350 // 74K for interest
+            292263, // 74K for interest
+            500
         );
     }
 }

--- a/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
+++ b/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
+import {Ownable} from "openzeppelin5/access/Ownable.sol";
+import {IAccessControl} from "openzeppelin5/access/IAccessControl.sol";
+
+import {SafeERC20} from "openzeppelin5/token/ERC20/utils/SafeERC20.sol";
+
+import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
+import {IGaugeHookReceiver} from "silo-core/contracts/interfaces/IGaugeHookReceiver.sol";
+import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
+import {IPartialLiquidation} from "silo-core/contracts/interfaces/IPartialLiquidation.sol";
+
+import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
+import {SiloConfigOverride} from "../../_common/fixtures/SiloFixture.sol";
+import {SiloFixture} from "../../_common/fixtures/SiloFixture.sol";
+import {IntegrationTest} from "silo-foundry-utils/networks/IntegrationTest.sol";
+import {MintableToken} from "../../_common/MintableToken.sol";
+import {SiloLens} from "silo-core/contracts/SiloLens.sol";
+import {ManualLiquidationHelper} from "silo-core/contracts/utils/liquidationHelper/ManualLiquidationHelper.sol";
+import {
+    PermissionedLiquidationControllerFactory
+} from "silo-core/contracts/incentives/functional/PermissionedLiquidationControllerFactory.sol";
+import {
+    IPermissionedLiquidationController
+} from "silo-core/contracts/interfaces/IPermissionedLiquidationController.sol";
+import {
+    BaseIncentivesControllerCompatible
+} from "silo-core/contracts/incentives/base/BaseIncentivesControllerCompatible.sol";
+import {
+    PermissionedLiquidationController
+} from "silo-core/contracts/incentives/functional/PermissionedLiquidationController.sol";
+import {IPartialLiquidationByDefaulting} from "silo-core/contracts/interfaces/IPartialLiquidationByDefaulting.sol";
+
+import {ProxyAdmin} from "openzeppelin5/proxy/transparent/ProxyAdmin.sol";
+import {ITransparentUpgradeableProxy} from "openzeppelin5/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentProxy} from "silo-core/contracts/utils/TransparentProxy.sol";
+import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
+
+contract NewImplementation is PermissionedLiquidationController {
+    function owner() public view override returns (address) {
+        return msg.sender;
+    }
+
+    function abc() public pure returns (string memory) {
+        return "abc";
+    }
+}
+
+/*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc PartialLiquidationPermissionedTest
+*/
+contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest {
+    using SafeERC20 for IERC20;
+
+    bytes32 public constant ALLOWED_ROLE = keccak256("ALLOWED_ROLE");
+
+    PermissionedLiquidationControllerFactory factory;
+
+    uint256 constant DEPOSIT_AMOUNT = 1e6;
+    uint256 constant MAX_AMOUNT = 1000e6;
+
+    address depositor = address(0xdddddd);
+    address borrower = address(0xBBBBBB);
+
+    MintableToken weth;
+    MintableToken usdc;
+    SiloLens siloLens;
+
+    ISilo siloWeth;
+    ISilo siloUsdc;
+
+    IPermissionedLiquidationController controllerC;
+    IPermissionedLiquidationController controllerP;
+
+    ManualLiquidationHelper manualLiquidation;
+    IPartialLiquidationByDefaulting hookV2;
+
+    function setUp() public {
+        factory = new PermissionedLiquidationControllerFactory();
+        weth = new MintableToken(18);
+        token0 = weth;
+        usdc = new MintableToken(6);
+        token1 = usdc;
+
+        SiloConfigOverride memory overrides;
+        overrides.token0 = address(weth);
+        overrides.token1 = address(usdc);
+        vm.label(address(weth), "WETH");
+        vm.label(address(usdc), "USDC");
+        overrides.configName = SiloConfigsNames.SILO_LOCAL_NO_ORACLE_DEFAULTING0;
+
+        SiloFixture siloFixture = new SiloFixture();
+
+        address hook;
+        (, silo0, silo1,,, hook) = siloFixture.deploy_local(overrides);
+        partialLiquidation = IPartialLiquidation(hook);
+        hookV2 = IPartialLiquidationByDefaulting(hook);
+
+        siloLens = new SiloLens();
+        manualLiquidation = new ManualLiquidationHelper(makeAddr("WETH"), payable(address(this)));
+
+        (siloWeth, siloUsdc) = silo0.asset() == address(weth) ? (silo0, silo1) : (silo1, silo0);
+
+        weth.setOnDemand(true);
+        usdc.setOnDemand(true);
+
+        _fetchControllers();
+        _enablePermissionsIfDisabled();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_enabled
+    */
+    function test_permisioned_liquidation_enabled() public {
+        vm.expectRevert(abi.encodeWithSelector(IPermissionedLiquidationController.OnlyOwner.selector));
+        controllerC.setEnabled(false);
+
+        vm.startPrank(IPermissionedLiquidationController(address(controllerC)).owner());
+
+        vm.expectRevert(abi.encodeWithSelector(IPermissionedLiquidationController.EnabledAlreadySet.selector));
+        controllerC.setEnabled(true);
+
+        controllerC.setEnabled(false);
+
+        vm.stopPrank();
+
+        assertFalse(controllerC.permisionedData().enabled, "we set false above");
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_grantAllowedRole
+    */
+    function test_permisioned_liquidation_grantAllowedRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), bytes32(0)
+            )
+        );
+        controllerC.grantRole(ALLOWED_ROLE, address(manualLiquidation));
+
+        vm.prank(IPermissionedLiquidationController(address(controllerC)).owner());
+        controllerC.grantRole(ALLOWED_ROLE, address(manualLiquidation));
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_vars
+    */
+    function test_permisioned_liquidation_vars_collteral() public view {
+        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
+
+        _permisioned_liquidation_vars(address(controllerC), IShareToken(collateralShareToken));
+    }
+
+    function test_permisioned_liquidation_vars_protected() public view {
+        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
+
+        _permisioned_liquidation_vars(address(controllerP), IShareToken(protectedShareToken));
+    }
+
+    function _permisioned_liquidation_vars(address _collateralController, IShareToken _shareToken) internal view {
+        BaseIncentivesControllerCompatible controller = BaseIncentivesControllerCompatible(_collateralController);
+
+        assertEq(
+            IPermissionedLiquidationController(_collateralController).owner(),
+            Ownable(address(partialLiquidation)).owner(),
+            "controller owner is a hook owner"
+        );
+
+        assertEq(controller.share_token(), address(_shareToken), "controller share token should match");
+        assertEq(controller.SHARE_TOKEN(), address(_shareToken), "controller SHARE_TOKEN should match");
+        assertEq(controller.NOTIFIER(), address(partialLiquidation), "controller notifier should be hook");
+
+        assertEq(
+            address(IGaugeHookReceiver(address(partialLiquidation)).configuredGauges(_shareToken)),
+            address(controller),
+            "controller should be configured for share token"
+        );
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_protected_hookV1
+    */
+    function test_permisioned_liquidation_protected_hookV1() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Protected);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        _grantAllowedRole();
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        _printBorrowerLTV();
+    }
+    
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_protected_hookV2
+    */
+    function test_permisioned_liquidation_protected_hookV2() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Protected);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        _grantAllowedRole(address(this));
+        controllerP.allowMeToLiquidate(); // it will work here only because foundy is one single tx
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        _printBorrowerLTV();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_collteral_hookV1
+    */
+    function test_permisioned_liquidation_collteral_hookV1() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Collateral);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        _grantAllowedRole();
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        _printBorrowerLTV();
+    }
+    
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_collteral_hookV2
+    */
+    function test_permisioned_liquidation_collteral_hookV2() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Collateral);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        _grantAllowedRole(address(this));
+        controllerP.allowMeToLiquidate(); // invalid controller
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        controllerC.allowMeToLiquidate(); // it will work here only because foundy is one single tx
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        _printBorrowerLTV();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_disable
+    */
+    function test_permisioned_liquidation_disable_hookV1() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Collateral);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        vm.prank(controllerC.owner());
+        controllerC.setEnabled(false);
+
+        // when disabled, liquidation is allowed
+        manualLiquidation.executeLiquidation(siloUsdc, borrower);
+
+        _printBorrowerLTV();
+    }
+    
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_disable_hookV2
+    */
+    function test_permisioned_liquidation_disable_hookV2() public {
+        _createPositionToLiquidate(ISilo.CollateralType.Collateral);
+
+        _printBorrowerLTV();
+
+        vm.expectRevert(IPermissionedLiquidationController.LiquidationNotAllowed.selector);
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        vm.prank(controllerC.owner());
+        controllerC.setEnabled(false);
+
+        // when disabled, liquidation is allowed
+        hookV2.liquidationCallByDefaulting(borrower);
+
+        _printBorrowerLTV();
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_proxy_owner
+    */
+    function test_permisioned_liquidation_proxy_owner() public view {
+        address proxyAdmin = TransparentProxy(payable(address(controllerC))).getAdmin();
+        assertEq(Ownable(address(proxyAdmin)).owner(), Ownable(address(partialLiquidation)).owner(), "proxy admin owner should be hook owner");
+    }
+    
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_contoller_owner
+    */
+    function test_permisioned_liquidation_contoller_owner() public view {
+        assertEq(controllerC.owner(), Ownable(address(partialLiquidation)).owner(), "controllerC owner should be hook owner");
+        assertEq(controllerP.owner(), Ownable(address(partialLiquidation)).owner(), "controllerP owner should be hook owner");
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_upgrade
+    */
+    function test_permisioned_liquidation_upgrade() public {
+        assertTrue(controllerC.permisionedData().enabled, "active controller is enabled");
+
+        IPermissionedLiquidationController newImplementation = new NewImplementation();
+        assertFalse(newImplementation.permisionedData().enabled, "inactive controller is disabled");
+
+        IGaugeHookReceiver hook = IGaugeHookReceiver(address(partialLiquidation));
+        IShareToken shareToken = IShareToken(address(silo0));
+
+        address beforeUpgrade = address(hook.configuredGauges(shareToken));
+
+        _upgrade(address(controllerC), address(newImplementation));
+
+        address afterUpgrade = address(hook.configuredGauges(shareToken));
+
+        assertEq(beforeUpgrade, afterUpgrade, "configured gauge addressshould not change");
+        
+        assertTrue(
+            IPermissionedLiquidationController(afterUpgrade).permisionedData().enabled,
+            "after upgrade enabled flag should stay enabled, because storage is contant"
+        );
+
+        assertEq(NewImplementation(afterUpgrade).abc(), "abc", "after upgrade we have new method abc");
+    }
+
+    function _grantAllowedRole(address _address) internal {
+        vm.startPrank(IPermissionedLiquidationController(address(controllerC)).owner());
+        controllerC.grantRole(ALLOWED_ROLE, _address);
+        controllerP.grantRole(ALLOWED_ROLE, _address);
+        vm.stopPrank();
+    }
+
+    function _grantAllowedRole() internal {
+        _grantAllowedRole(address(manualLiquidation));
+    }
+
+    function _enablePermissionsIfDisabled() internal {
+        if (controllerC.permisionedData().enabled) return;
+
+        vm.startPrank(IPermissionedLiquidationController(address(controllerC)).owner());
+        controllerC.setEnabled(true);
+        controllerP.setEnabled(true);
+        vm.stopPrank();
+    }
+
+    function _createPositionToLiquidate(ISilo.CollateralType _type) internal {
+        _depositForBorrow(10e6, depositor);
+
+        _deposit(100e18, borrower, _type);
+        _borrow(silo1.maxBorrow(borrower), borrower);
+
+        _withdraw(silo0.maxWithdraw(borrower, _type), borrower, _type);
+
+        vm.warp(block.timestamp + 3 days);
+
+        assertFalse(silo0.isSolvent(borrower), "Borrower is still solvent");
+    }
+
+    function _fetchControllers() internal {
+        IGaugeHookReceiver hook = IGaugeHookReceiver(IShareToken(address(silo0)).hookReceiver());
+        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
+        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
+
+        controllerC = IPermissionedLiquidationController(address(hook.configuredGauges(IShareToken(collateralShareToken))));
+        controllerP = IPermissionedLiquidationController(address(hook.configuredGauges(IShareToken(protectedShareToken))));
+    }
+
+    function _printBorrowerLTV() internal {
+        emit log_named_decimal_uint("borrower LTV", siloLens.getUserLTV(silo0, borrower), 16);
+    }
+
+    function _upgrade(address _controllerProxy, address _newImplementation) internal {
+        address proxyAdmin = TransparentProxy(payable(_controllerProxy)).getAdmin();
+
+        vm.prank(Ownable(address(proxyAdmin)).owner());
+        ProxyAdmin(proxyAdmin)
+            .upgradeAndCall(ITransparentUpgradeableProxy(payable(_controllerProxy)), _newImplementation, bytes(""));
+    }
+}

--- a/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
+++ b/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
@@ -106,6 +106,8 @@ contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest
         weth.setOnDemand(true);
         usdc.setOnDemand(true);
 
+        _setupPermissionedControllers();
+
         _fetchControllers();
         _enablePermissionsIfDisabled();
     }
@@ -177,6 +179,28 @@ contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest
             address(controller),
             "controller should be configured for share token"
         );
+    }
+
+    /*
+    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_permisioned_liquidation_remove
+    */
+    function test_permisioned_liquidation_remove() public {
+        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
+        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
+        address debtShareToken = silo1.config().getConfig(address(silo1)).debtShareToken;
+
+        vm.startPrank(IPermissionedLiquidationController(address(controllerC)).owner());
+        IPermissionedLiquidationController debtController = IPermissionedLiquidationController(factory.create(IShareToken(debtShareToken)));
+        IGaugeHookReceiver(address(partialLiquidation)).setGauge(debtController, IShareToken(debtShareToken));
+        vm.stopPrank();
+
+        _createPositionToLiquidate(ISilo.CollateralType.Protected);
+
+        vm.startPrank(IPermissionedLiquidationController(address(controllerC)).owner());
+        IGaugeHookReceiver(address(partialLiquidation)).removeGauge(IShareToken(debtShareToken));
+        IGaugeHookReceiver(address(partialLiquidation)).removeGauge(IShareToken(protectedShareToken));
+        IGaugeHookReceiver(address(partialLiquidation)).removeGauge(IShareToken(collateralShareToken));
+        vm.stopPrank();
     }
 
     /*
@@ -390,5 +414,19 @@ contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest
         vm.prank(Ownable(address(proxyAdmin)).owner());
         ProxyAdmin(proxyAdmin)
             .upgradeAndCall(ITransparentUpgradeableProxy(payable(_controllerProxy)), _newImplementation, bytes(""));
+    }
+
+    function _setupPermissionedControllers() internal {
+        IGaugeHookReceiver hook = IGaugeHookReceiver(IShareToken(address(silo0)).hookReceiver());
+        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
+        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
+
+        controllerC = IPermissionedLiquidationController(factory.create(IShareToken(collateralShareToken)));
+        controllerP = IPermissionedLiquidationController(factory.create(IShareToken(protectedShareToken)));
+
+        vm.startPrank(Ownable(address(hook)).owner());
+        hook.setGauge(controllerC, IShareToken(collateralShareToken));
+        hook.setGauge(controllerP, IShareToken(protectedShareToken));
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Problem

release `PermissionedLiquidationController`

## Solution

no deployment, deployment will be done with the next release 4.13.1.
We already deployed the contract with a version 4.13.0 (but release was closed). Now, after the change, even if the contract is not released, I don't want the same version with the fix, so to make is clean we will use next release to deploy.
