### PR TITLE
additional options for silo deployer

### DIFF
--- a/silo-core/contracts/SiloDeployer.sol
+++ b/silo-core/contracts/SiloDeployer.sol
@@ -34,6 +34,8 @@ import {TransparentProxy} from "silo-core/contracts/utils/TransparentProxy.sol";
 
 /// @notice Silo Deployer
 contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
+    bytes32 public constant ALLOWED_ROLE = keccak256("ALLOWED_ROLE");
+
     // solhint-disable var-name-mixedcase
     IInterestRateModelV2Factory public immutable IRM_CONFIG_FACTORY;
     IDynamicKinkModelFactory public immutable DYNAMIC_KINK_MODEL_FACTORY;
@@ -47,6 +49,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
 
     /// @notice variable to store the final hook owner
     address internal transient _finalHookOwner;
+    bytes32 internal transient _allowedRole;
 
     constructor(
         IInterestRateModelV2Factory _irmConfigFactory,
@@ -76,6 +79,28 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         ClonableHookReceiver calldata _clonableHookReceiver,
         ISiloConfig.InitData memory _siloInitData
     ) external returns (ISiloConfig siloConfig) {
+        return deploy({
+            _oracles: _oracles, 
+            _irmConfigData0: _irmConfigData0, 
+            _irmConfigData1: _irmConfigData1, 
+            _clonableHookReceiver: _clonableHookReceiver, 
+            _siloInitData: _siloInitData, 
+            _marketOptions: MarketOptions({
+                addressesWithPausableRole: new address[](0),
+                permissionedLiquidators: new address[](0)
+            })
+        });
+    }
+
+    /// @inheritdoc ISiloDeployer
+    function deploy(
+        Oracles calldata _oracles,
+        bytes calldata _irmConfigData0,
+        bytes calldata _irmConfigData1,
+        ClonableHookReceiver calldata _clonableHookReceiver,
+        ISiloConfig.InitData memory _siloInitData,
+        MarketOptions memory _marketOptions
+    ) public returns (ISiloConfig siloConfig) {
         // setUp IRMs (create if needed) and update `_siloInitData`
         _setUpIRMs(_irmConfigData0, _irmConfigData1, _siloInitData);
         // create oracles and update `_siloInitData`
@@ -100,16 +125,19 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         _createIncentivesControllerForDefaulting({
             _siloConfig: siloConfig,
             _hookReceiver: _siloInitData.hookReceiver,
-            _lt0: _siloInitData.lt0
+            _lt0: _siloInitData.lt0,
+            _permissionedLiquidators: _marketOptions.permissionedLiquidators
         });
 
-        // we always create permissioned, because we want pausing
-        _createPermissionedIncentivesControllers({
-            _siloConfig: siloConfig,
-            _hookReceiver: _siloInitData.hookReceiver,
-            _lt0: _siloInitData.lt0,
-            _lt1: _siloInitData.lt1
-        });
+        if (_marketOptions.addressesWithPausableRole.length != 0) {
+            _createPermissionedIncentivesControllers({
+                _siloConfig: siloConfig,
+                _hookReceiver: _siloInitData.hookReceiver,
+                _lt0: _siloInitData.lt0,
+                _lt1: _siloInitData.lt1,
+                _addressesWithPausableRole: _marketOptions.addressesWithPausableRole
+            });
+        }
 
         Ownable1and2Steps(_siloInitData.hookReceiver).transferOwnership1Step(_finalHookOwner);
 
@@ -122,7 +150,12 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
     }
 
     /// @notice Create an incentives controller if the hook is defaulting
-    function _createIncentivesControllerForDefaulting(ISiloConfig _siloConfig, address _hookReceiver, uint256 _lt0)
+    function _createIncentivesControllerForDefaulting(
+        ISiloConfig _siloConfig, 
+        address _hookReceiver, 
+        uint256 _lt0,
+        address[] memory _permissionedLiquidators
+    )
         internal
     {
         if (!_isDefaultingHook(_hookReceiver)) return;
@@ -141,15 +174,27 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
             _shareToken: IShareToken(debtSilo)
         });
 
-        // we have Whitelist interface for HookV2/V3
+        _whitelistLiquidators(_hookReceiver, _permissionedLiquidators);
+
+        // we have Whitelist interface for HookV2/V3, so we have to transfer roles
         _transferDefaultAdminRole(_hookReceiver);
+    }
+
+    function _whitelistLiquidators(address _hookReceiver, address[] memory _addresses) internal {
+        uint256 c = _addresses.length;
+        if (c == 0) return;
+
+        for (uint256 i = 0; i < c; i++) {
+            Whitelist(_hookReceiver).grantRole(ALLOWED_ROLE, _addresses[i]);
+        }
     }
     
     function _createPermissionedIncentivesControllers(
         ISiloConfig _siloConfig, 
         address _hookReceiver, 
         uint256 _lt0, 
-        uint256 _lt1
+        uint256 _lt1,
+        address[] memory _addressesWithPausableRole
     )
         internal
     {
@@ -158,22 +203,28 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         if (_lt0 != 0) {
             (address protectedShareToken, address collateralShareToken,) = _siloConfig.getShareTokens(silo0);
 
-            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken);
-            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken);
+            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken, _addressesWithPausableRole);
+            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken, _addressesWithPausableRole);
         }
         
         if (_lt1 != 0) {
             (address protectedShareToken, address collateralShareToken,) = _siloConfig.getShareTokens(silo1);
 
-            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken);
-            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken);
+            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken, _addressesWithPausableRole);
+            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken, _addressesWithPausableRole);
         }
     }
     
-    function _createPermissionedIncentivesController(address _hookReceiver, address _shareToken)
+    function _createPermissionedIncentivesController(
+        address _hookReceiver, 
+        address _shareToken, 
+        address[] memory _addressesWithPausableRole
+    )
         internal
     {
         address incentivesController = PERMISSIONED_LIQUIDATION_CONTROLLER_FACTORY.create(IShareToken(_shareToken));
+
+        _whitelistAddressesWithPausableRole(incentivesController, _addressesWithPausableRole);
 
         IGaugeHookReceiver(_hookReceiver).setGauge({
             _gauge: ISiloIncentivesController(incentivesController), 
@@ -186,6 +237,15 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
 
         // for permissioned controller we have whitelist for liquidators
         _transferDefaultAdminRole(incentivesController);
+    }
+
+    function _whitelistAddressesWithPausableRole(address _controller, address[] memory _addresses) internal {
+        uint256 c = _addresses.length;
+        if (c == 0) return;
+
+        for (uint256 i = 0; i < c; i++) {
+            Whitelist(_controller).grantRole(ALLOWED_ROLE, _addresses[i]);
+        }
     }
     
     function _transferDefaultAdminRole(address _whitelist) internal {

--- a/silo-core/contracts/SiloDeployer.sol
+++ b/silo-core/contracts/SiloDeployer.sol
@@ -34,7 +34,7 @@ import {TransparentProxy} from "silo-core/contracts/utils/TransparentProxy.sol";
 
 /// @notice Silo Deployer
 contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
-    bytes32 public constant ALLOWED_ROLE = keccak256("ALLOWED_ROLE");
+    bytes32 internal constant ALLOWED_ROLE = keccak256("ALLOWED_ROLE");
 
     // solhint-disable var-name-mixedcase
     IInterestRateModelV2Factory public immutable IRM_CONFIG_FACTORY;
@@ -49,7 +49,6 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
 
     /// @notice variable to store the final hook owner
     address internal transient _finalHookOwner;
-    bytes32 internal transient _allowedRole;
 
     constructor(
         IInterestRateModelV2Factory _irmConfigFactory,
@@ -77,30 +76,9 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         bytes calldata _irmConfigData0,
         bytes calldata _irmConfigData1,
         ClonableHookReceiver calldata _clonableHookReceiver,
-        ISiloConfig.InitData memory _siloInitData
-    ) external returns (ISiloConfig siloConfig) {
-        return deploy({
-            _oracles: _oracles, 
-            _irmConfigData0: _irmConfigData0, 
-            _irmConfigData1: _irmConfigData1, 
-            _clonableHookReceiver: _clonableHookReceiver, 
-            _siloInitData: _siloInitData, 
-            _marketOptions: MarketOptions({
-                addressesWithPausableRole: new address[](0),
-                permissionedLiquidators: new address[](0)
-            })
-        });
-    }
-
-    /// @inheritdoc ISiloDeployer
-    function deploy(
-        Oracles calldata _oracles,
-        bytes calldata _irmConfigData0,
-        bytes calldata _irmConfigData1,
-        ClonableHookReceiver calldata _clonableHookReceiver,
         ISiloConfig.InitData memory _siloInitData,
-        MarketOptions memory _marketOptions
-    ) public returns (ISiloConfig siloConfig) {
+        MarketOptions calldata _marketOptions
+    ) external returns (ISiloConfig siloConfig) {
         // setUp IRMs (create if needed) and update `_siloInitData`
         _setUpIRMs(_irmConfigData0, _irmConfigData1, _siloInitData);
         // create oracles and update `_siloInitData`
@@ -120,14 +98,17 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         });
 
         // initialize hook receiver only if it was cloned
-        _initializeHookReceiver(_siloInitData, siloConfig, _clonableHookReceiver);
+        bool isInitialized = _initializeHookReceiver(_siloInitData, siloConfig, _clonableHookReceiver);
 
-        _createIncentivesControllerForDefaulting({
-            _siloConfig: siloConfig,
-            _hookReceiver: _siloInitData.hookReceiver,
-            _lt0: _siloInitData.lt0,
-            _permissionedLiquidators: _marketOptions.permissionedLiquidators
-        });
+        if (isInitialized) {
+            // only when this is new hook
+            _createIncentivesControllerForDefaulting({
+                _siloConfig: siloConfig,
+                _hookReceiver: _siloInitData.hookReceiver,
+                _lt0: _siloInitData.lt0,
+                _permissionedLiquidators: _marketOptions.permissionedLiquidators
+            });
+        }
 
         if (_marketOptions.addressesWithPausableRole.length != 0) {
             _createPermissionedIncentivesControllers({
@@ -139,14 +120,17 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
             });
         }
 
-        Ownable1and2Steps(_siloInitData.hookReceiver).transferOwnership1Step(_finalHookOwner);
+        if (isInitialized) {
+            // only if this is new hook
+            Ownable1and2Steps(_siloInitData.hookReceiver).transferOwnership1Step(_finalHookOwner);
+        }
 
         emit SiloCreated(siloConfig);
     }
 
     /// @inheritdoc IVersioned
     function VERSION() external pure returns (string memory version) {
-        return "SiloDeployer 4.12.0";
+        return "SiloDeployer 4.16.0";
     }
 
     /// @notice Create an incentives controller if the hook is defaulting
@@ -154,7 +138,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         ISiloConfig _siloConfig, 
         address _hookReceiver, 
         uint256 _lt0,
-        address[] memory _permissionedLiquidators
+        address[] calldata _permissionedLiquidators
     )
         internal
     {
@@ -180,7 +164,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         _transferDefaultAdminRole(_hookReceiver);
     }
 
-    function _whitelistLiquidators(address _hookReceiver, address[] memory _addresses) internal {
+    function _whitelistLiquidators(address _hookReceiver, address[] calldata _addresses) internal {
         uint256 c = _addresses.length;
         if (c == 0) return;
 
@@ -194,31 +178,39 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         address _hookReceiver, 
         uint256 _lt0, 
         uint256 _lt1,
-        address[] memory _addressesWithPausableRole
+        address[] calldata _addressesWithPausableRole
     )
         internal
     {
         (address silo0, address silo1) = _siloConfig.getSilos();
 
         if (_lt0 != 0) {
-            (address protectedShareToken, address collateralShareToken,) = _siloConfig.getShareTokens(silo0);
-
-            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken, _addressesWithPausableRole);
-            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken, _addressesWithPausableRole);
+            _createPermissionedIncentivesControllerForSilo(_siloConfig, _hookReceiver, silo0, _addressesWithPausableRole);
         }
         
         if (_lt1 != 0) {
-            (address protectedShareToken, address collateralShareToken,) = _siloConfig.getShareTokens(silo1);
-
-            _createPermissionedIncentivesController(_hookReceiver, collateralShareToken, _addressesWithPausableRole);
-            _createPermissionedIncentivesController(_hookReceiver, protectedShareToken, _addressesWithPausableRole);
+            _createPermissionedIncentivesControllerForSilo(_siloConfig, _hookReceiver, silo1, _addressesWithPausableRole);
         }
+    }
+    
+    function _createPermissionedIncentivesControllerForSilo(
+        ISiloConfig _siloConfig, 
+        address _hookReceiver,
+        address _silo,
+        address[] calldata _addressesWithPausableRole
+    )
+        internal
+    {
+        (address protectedShareToken, address collateralShareToken,) = _siloConfig.getShareTokens(_silo);
+
+        _createPermissionedIncentivesController(_hookReceiver, collateralShareToken, _addressesWithPausableRole);
+        _createPermissionedIncentivesController(_hookReceiver, protectedShareToken, _addressesWithPausableRole);
     }
     
     function _createPermissionedIncentivesController(
         address _hookReceiver, 
         address _shareToken, 
-        address[] memory _addressesWithPausableRole
+        address[] calldata _addressesWithPausableRole
     )
         internal
     {
@@ -239,7 +231,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         _transferDefaultAdminRole(incentivesController);
     }
 
-    function _whitelistAddressesWithPausableRole(address _controller, address[] memory _addresses) internal {
+    function _whitelistAddressesWithPausableRole(address _controller, address[] calldata _addresses) internal {
         uint256 c = _addresses.length;
         if (c == 0) return;
 
@@ -420,7 +412,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
     /// @notice Create an oracle if it is not specified in the `_siloInitData` and has tx details for the creation
     /// @param _siloInitData Silo configuration for the silo creation
     /// @param _oracles Oracles creation details (factory and creation tx input)
-    function _createOracles(ISiloConfig.InitData memory _siloInitData, Oracles memory _oracles) internal {
+    function _createOracles(ISiloConfig.InitData memory _siloInitData, Oracles calldata _oracles) internal {
         if (_siloInitData.solvencyOracle0 == address(0)) {
             _siloInitData.solvencyOracle0 = _createOracle(_oracles.solvencyOracle0);
         }
@@ -484,7 +476,7 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
         ISiloConfig.InitData memory _siloInitData,
         ISiloConfig _siloConfig,
         ClonableHookReceiver calldata _clonableHookReceiver
-    ) internal {
+    ) internal returns (bool isInitialized) {
         if (_clonableHookReceiver.implementation != address(0)) {
             // init data must be address
             require(_clonableHookReceiver.initializationData.length == 32, InvalidHookInitData());
@@ -497,6 +489,8 @@ contract SiloDeployer is Create2Factory, ISiloDeployer, IVersioned {
                     // override owner so we can set the incentives controller
                     _data: abi.encode(address(this))
                 });
+
+            isInitialized = true;
         }
     }
 

--- a/silo-core/contracts/interfaces/ISiloDeployer.sol
+++ b/silo-core/contracts/interfaces/ISiloDeployer.sol
@@ -71,20 +71,4 @@ interface ISiloDeployer {
     )
         external
         returns (ISiloConfig siloConfig);
-    
-    /// @notice Deploy silo (backwards compatible method)
-    /// @param _oracles Oracles to be create during the silo creation
-    /// @param _irmConfigData0 IRM config data for a silo `_TOKEN0`
-    /// @param _irmConfigData1 IRM config data for a silo `_TOKEN1`
-    /// @param _clonableHookReceiver Hook receiver implementation to clone (ignored if implementation has address(0))
-    /// @param _siloInitData Silo configuration for the silo creation
-    function deploy(
-        Oracles calldata _oracles,
-        bytes calldata _irmConfigData0,
-        bytes calldata _irmConfigData1,
-        ClonableHookReceiver calldata _clonableHookReceiver,
-        ISiloConfig.InitData memory _siloInitData
-    )
-        external
-        returns (ISiloConfig siloConfig);
 }

--- a/silo-core/contracts/interfaces/ISiloDeployer.sol
+++ b/silo-core/contracts/interfaces/ISiloDeployer.sol
@@ -35,6 +35,13 @@ interface ISiloDeployer {
         address initialOwner;
     }
 
+    struct MarketOptions {
+        /// @param addressesWithPausableRole list of addresses that are allowed to pause token transfers via gauge
+        address[] addressesWithPausableRole;
+        /// @param permissionedLiquidators list of addresses that are allowed to perform liquidations
+        address[] permissionedLiquidators;
+    }
+
     /// @dev Emit after the Silo creation
     event SiloCreated(ISiloConfig siloConfig);
 
@@ -47,7 +54,25 @@ interface ISiloDeployer {
     /// @dev Revert if the hook initialization data is different from expected
     error InvalidHookInitData();
 
-    /// @notice Deploy silo
+    /// @notice Deploy silo with additional options for the market
+    /// @param _oracles Oracles to be create during the silo creation
+    /// @param _irmConfigData0 IRM config data for a silo `_TOKEN0`
+    /// @param _irmConfigData1 IRM config data for a silo `_TOKEN1`
+    /// @param _clonableHookReceiver Hook receiver implementation to clone (ignored if implementation has address(0))
+    /// @param _siloInitData Silo configuration for the silo creation
+    /// @param _marketOptions additional market options for the silo creation
+    function deploy(
+        Oracles calldata _oracles,
+        bytes calldata _irmConfigData0,
+        bytes calldata _irmConfigData1,
+        ClonableHookReceiver calldata _clonableHookReceiver,
+        ISiloConfig.InitData memory _siloInitData,
+        MarketOptions calldata _marketOptions
+    )
+        external
+        returns (ISiloConfig siloConfig);
+    
+    /// @notice Deploy silo (backwards compatible method)
     /// @param _oracles Oracles to be create during the silo creation
     /// @param _irmConfigData0 IRM config data for a silo `_TOKEN0`
     /// @param _irmConfigData1 IRM config data for a silo `_TOKEN1`

--- a/silo-core/deploy/silo/SiloDeploy.s.sol
+++ b/silo-core/deploy/silo/SiloDeploy.s.sol
@@ -118,12 +118,15 @@ abstract contract SiloDeploy is CommonDeploy {
 
         vm.startBroadcast(deployerPrivateKey);
 
+        ISiloDeployer.MarketOptions memory marketOptions;
+
         siloConfig = siloDeployer.deploy({
             _oracles: oracles,
             _irmConfigData0: irmConfigData0,
             _irmConfigData1: irmConfigData1,
             _clonableHookReceiver: hookReceiver,
-            _siloInitData: siloInitData
+            _siloInitData: siloInitData,
+            _marketOptions: marketOptions
         });
 
         vm.stopBroadcast();

--- a/silo-core/test/foundry/Silo/deploy/SiloDeployer.t.sol
+++ b/silo-core/test/foundry/Silo/deploy/SiloDeployer.t.sol
@@ -13,7 +13,6 @@ import {
     IPermissionedLiquidationControllerFactory
 } from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
 import {SiloDeployer} from "silo-core/contracts/SiloDeployer.sol";
-import {Whitelist} from "silo-core/contracts/hooks/_common/Whitelist.sol";
 
 contract SiloDeployerMock is SiloDeployer {
     constructor()
@@ -32,9 +31,6 @@ contract SiloDeployerMock is SiloDeployer {
     function isDefaultingHook(address _hook) external view returns (bool isDefaulting) {
         return _isDefaultingHook(_hook);
     }
-}
-
-contract WhitelistMock is Whitelist {
 }
 
 /*
@@ -57,10 +53,5 @@ contract SiloDeployerTest is Test {
 
     function test_siloDeployer_isDefaultingHook_neverRevert(address _hook) public view {
         siloDeployer.isDefaultingHook(_hook);
-    }
-
-    function test_siloDeployer_ALLOWED_ROLE() public {
-        WhitelistMock whitelist = new WhitelistMock();
-        assertEq(siloDeployer.ALLOWED_ROLE(), whitelist.ALLOWED_ROLE(), "depoyer role has to mach whitelist role");
     }
 }

--- a/silo-core/test/foundry/Silo/deploy/SiloDeployer.t.sol
+++ b/silo-core/test/foundry/Silo/deploy/SiloDeployer.t.sol
@@ -13,6 +13,7 @@ import {
     IPermissionedLiquidationControllerFactory
 } from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
 import {SiloDeployer} from "silo-core/contracts/SiloDeployer.sol";
+import {Whitelist} from "silo-core/contracts/hooks/_common/Whitelist.sol";
 
 contract SiloDeployerMock is SiloDeployer {
     constructor()
@@ -31,6 +32,9 @@ contract SiloDeployerMock is SiloDeployer {
     function isDefaultingHook(address _hook) external view returns (bool isDefaulting) {
         return _isDefaultingHook(_hook);
     }
+}
+
+contract WhitelistMock is Whitelist {
 }
 
 /*
@@ -53,5 +57,10 @@ contract SiloDeployerTest is Test {
 
     function test_siloDeployer_isDefaultingHook_neverRevert(address _hook) public view {
         siloDeployer.isDefaultingHook(_hook);
+    }
+
+    function test_siloDeployer_ALLOWED_ROLE() public {
+        WhitelistMock whitelist = new WhitelistMock();
+        assertEq(siloDeployer.ALLOWED_ROLE(), whitelist.ALLOWED_ROLE(), "depoyer role has to mach whitelist role");
     }
 }

--- a/silo-core/test/foundry/Silo/hooks/SiloBeforeHooksTest.t.sol
+++ b/silo-core/test/foundry/Silo/hooks/SiloBeforeHooksTest.t.sol
@@ -3,24 +3,23 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {IHookReceiver} from "silo-core/contracts/interfaces/IHookReceiver.sol";
 import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
 import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
 import {Hook} from "silo-core/contracts/lib/Hook.sol";
-import {HookReceiverBootstrapMock} from "silo-core/test/foundry/_mocks/HookReceiverBootstrapMock.sol";
 import {SiloFixture} from "../../_common/fixtures/SiloFixture.sol";
 import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
 import {MintableToken} from "../../_common/MintableToken.sol";
 import {SiloConfigOverride} from "../../_common/fixtures/SiloFixture.sol";
 
-contract HookReceiver is HookReceiverBootstrapMock, Test {
+contract HookReceiver is IHookReceiver, Test {
     bool imIn;
 
     uint24 hooksBefore;
     uint24 hooksAfter;
-    ISiloConfig siloConfig;
+    ISiloConfig public siloConfig;
 
-    function initialize(ISiloConfig _siloConfig, bytes calldata) external override {
-        if (owner() == address(0)) _transferOwnership(msg.sender);
+    function initialize(ISiloConfig _siloConfig, bytes calldata) external {
         siloConfig = _siloConfig;
     }
 
@@ -53,7 +52,7 @@ contract HookReceiver is HookReceiverBootstrapMock, Test {
     }
 
     /// @notice return hooksBefore and hooksAfter configuration
-    function hookReceiverConfig(address) external view override returns (uint24, uint24) {
+    function hookReceiverConfig(address) external view returns (uint24, uint24) {
         return (hooksBefore, hooksAfter);
     }
 
@@ -79,7 +78,8 @@ contract SiloBeforeHooksTest is SiloLittleHelper, Test {
     }
 
     function setUp() public {
-        HookReceiver hookReceiverImplementation = new HookReceiver();
+        _hookReceiver = new HookReceiver();
+        _hookReceiverAddr = address(_hookReceiver);
 
         SiloFixture siloFixture = new SiloFixture();
         SiloConfigOverride memory configOverride;
@@ -91,14 +91,16 @@ contract SiloBeforeHooksTest is SiloLittleHelper, Test {
 
         configOverride.token0 = address(token0);
         configOverride.token1 = address(token1);
-        configOverride.hookReceiverImplementation = address(hookReceiverImplementation);
 
-        (_siloConfig, silo0, silo1,,, _hookReceiverAddr) = siloFixture.deploy_local(configOverride);
-        _hookReceiver = HookReceiver(payable(_hookReceiverAddr));
+        configOverride.hookReceiver = _hookReceiverAddr;
+
+        (_siloConfig, silo0, silo1,,,) = siloFixture.deploy_local(configOverride);
 
         _deposit(1e18, BORROWER);
         _depositForBorrow(1e18, BORROWER);
         _depositForBorrow(10, DEPOSITOR);
+
+        _hookReceiver.initialize(_siloConfig, "");
     }
 
     /*

--- a/silo-core/test/foundry/Silo/hooks/SiloHooks.i.sol
+++ b/silo-core/test/foundry/Silo/hooks/SiloHooks.i.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "openzeppelin5/token/ERC20/IERC20.sol";
 
-import {HookReceiverBootstrapMock} from "silo-core/test/foundry/_mocks/HookReceiverBootstrapMock.sol";
+import {HookReceiverMock} from "silo-core/test/foundry/_mocks/HookReceiverMock.sol";
 import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
 
 import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
@@ -20,28 +20,12 @@ import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
 /*
 FOUNDRY_PROFILE=core_test forge test -vvv --ffi --mc SiloHooksTest
 */
-contract SiloHooksBootstrapMock is HookReceiverBootstrapMock {
-    uint24 internal _hooksBefore;
-    uint24 internal _hooksAfter;
-
-    function setHookReceiverConfig(uint24 hooksBefore, uint24 hooksAfter) external {
-        _hooksBefore = hooksBefore;
-        _hooksAfter = hooksAfter;
-    }
-
-    function hookReceiverConfig(address) external view override returns (uint24 hooksBefore, uint24 hooksAfter) {
-        return (_hooksBefore, _hooksAfter);
-    }
-
-    receive() external payable {}
-}
-
 contract SiloHooksTest is SiloLittleHelper, Test {
     uint24 constant HOOKS_BEFORE = 1;
     uint24 constant HOOKS_AFTER = 2;
 
     SiloFixture internal _siloFixture;
-    SiloHooksBootstrapMock internal _hookReceiverMock;
+    HookReceiverMock internal _hookReceiverMock;
     ISiloConfig internal _siloConfig;
 
     address internal _thridParty = makeAddr("ThirdParty");
@@ -54,19 +38,17 @@ contract SiloHooksTest is SiloLittleHelper, Test {
         _siloFixture = new SiloFixture();
         SiloConfigOverride memory configOverride;
 
-        SiloHooksBootstrapMock hookReceiverImplementation = new SiloHooksBootstrapMock();
-        hookReceiverImplementation.setHookReceiverConfig(HOOKS_BEFORE, HOOKS_AFTER);
+        _hookReceiverMock = new HookReceiverMock(address(0));
+        _hookReceiverMock.hookReceiverConfigMock(HOOKS_BEFORE, HOOKS_AFTER);
+
+        _hookReceiverAddr = _hookReceiverMock.ADDRESS();
 
         configOverride.token0 = makeAddr("token0");
         configOverride.token1 = makeAddr("token1");
-        configOverride.hookReceiverImplementation = address(hookReceiverImplementation);
-        configOverride.configName = SiloConfigsNames.SILO_LOCAL_NO_ORACLE_SILO;
+        configOverride.hookReceiver = _hookReceiverAddr;
+        configOverride.configName = SiloConfigsNames.SILO_LOCAL_DEPLOYER;
 
-        (_siloConfig, silo0, silo1,,, _hookReceiverAddr) = _siloFixture.deploy_local(configOverride);
-        _hookReceiverMock = SiloHooksBootstrapMock(payable(_hookReceiverAddr));
-        _hookReceiverMock.setHookReceiverConfig(HOOKS_BEFORE, HOOKS_AFTER);
-        silo0.updateHooks();
-        silo1.updateHooks();
+        (_siloConfig, silo0, silo1,,,) = _siloFixture.deploy_local(configOverride);
     }
 
     /*
@@ -89,7 +71,7 @@ contract SiloHooksTest is SiloLittleHelper, Test {
         uint24 newHooksBefore = 3;
         uint24 newHooksAfter = 4;
 
-        _hookReceiverMock.setHookReceiverConfig(newHooksBefore, newHooksAfter);
+        _hookReceiverMock.hookReceiverConfigMock(newHooksBefore, newHooksAfter);
 
         silo0.updateHooks();
 

--- a/silo-core/test/foundry/Silo/reentrancy/methods/silo-hook-v2/ValidateControllerForCollateralReentrancyTest.sol
+++ b/silo-core/test/foundry/Silo/reentrancy/methods/silo-hook-v2/ValidateControllerForCollateralReentrancyTest.sol
@@ -6,11 +6,11 @@ import {MethodReentrancyTest} from "../MethodReentrancyTest.sol";
 import {TestStateLib} from "../../TestState.sol";
 
 contract ValidateControllerForCollateralReentrancyTest is MethodReentrancyTest {
-    function callMethod() external view {
+    function callMethod() external {
         _ensureItWillNotRevert();
     }
 
-    function verifyReentrancy() external view {
+    function verifyReentrancy() external {
         _ensureItWillNotRevert();
     }
 
@@ -18,12 +18,15 @@ contract ValidateControllerForCollateralReentrancyTest is MethodReentrancyTest {
         description = "validateControllerForCollateral(address)";
     }
 
-    function _ensureItWillNotRevert() internal view {
+    function _ensureItWillNotRevert() internal {
         address silo0 = address(TestStateLib.silo0());
         address silo1 = address(TestStateLib.silo1());
         IPartialLiquidationByDefaulting hook = _getHook();
 
+        // silo0 is debt silo
         hook.validateControllerForCollateral(silo0);
+
+        vm.expectRevert(IPartialLiquidationByDefaulting.NoControllerForCollateral.selector);
         hook.validateControllerForCollateral(silo1);
     }
 

--- a/silo-core/test/foundry/Silo/transitionCollateral/TransitionCollateralReentrancy.i.sol
+++ b/silo-core/test/foundry/Silo/transitionCollateral/TransitionCollateralReentrancy.i.sol
@@ -8,14 +8,10 @@ import {SafeERC20} from "openzeppelin5/token/ERC20/utils/SafeERC20.sol";
 import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
 
 import {Hook} from "silo-core/contracts/lib/Hook.sol";
-import {IHookReceiver} from "silo-core/contracts/interfaces/IHookReceiver.sol";
 import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
 import {ICrossReentrancyGuard} from "silo-core/contracts/interfaces/ICrossReentrancyGuard.sol";
 import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
-import {IPartialLiquidation} from "silo-core/contracts/interfaces/IPartialLiquidation.sol";
-import {BaseHookReceiver} from "silo-core/contracts/hooks/_common/BaseHookReceiver.sol";
 import {PartialLiquidation} from "silo-core/contracts/hooks/liquidation/PartialLiquidation.sol";
-import {HookReceiverBootstrapMock} from "silo-core/test/foundry/_mocks/HookReceiverBootstrapMock.sol";
 
 import {SiloConfigOverride} from "../../_common/fixtures/SiloFixture.sol";
 import {SiloFixture} from "../../_common/fixtures/SiloFixture.sol";
@@ -25,12 +21,11 @@ import {MintableToken} from "../../_common/MintableToken.sol";
 /*
 FOUNDRY_PROFILE=core_test forge test -vvv --ffi --mc TransitionCollateralReentrancyTest
 */
-contract TransitionCollateralReentrancyTest is SiloLittleHelper, Test, PartialLiquidation, HookReceiverBootstrapMock {
+contract TransitionCollateralReentrancyTest is SiloLittleHelper, Test, PartialLiquidation {
     using Hook for uint256;
     using SafeERC20 for IERC20;
 
-    bool public afterActionExecuted;
-    TransitionCollateralReentrancyTest internal _hook;
+    bool afterActionExecuted;
 
     function setUp() public {
         SiloFixture siloFixture = new SiloFixture();
@@ -40,35 +35,21 @@ contract TransitionCollateralReentrancyTest is SiloLittleHelper, Test, PartialLi
         token1 = new MintableToken(7);
         configOverride.token0 = address(token0);
         configOverride.token1 = address(token1);
-        configOverride.hookReceiverImplementation = address(this);
-        configOverride.configName = SiloConfigsNames.SILO_LOCAL_NO_ORACLE_SILO;
+        configOverride.hookReceiver = address(this);
+        configOverride.configName = SiloConfigsNames.SILO_LOCAL_DEPLOYER;
 
-        address hook;
-        (siloConfig, silo0, silo1,,, hook) = siloFixture.deploy_local(configOverride);
-        _hook = TransitionCollateralReentrancyTest(payable(hook));
-        partialLiquidation = PartialLiquidation(hook);
+        (siloConfig, silo0, silo1,,,) = siloFixture.deploy_local(configOverride);
+        partialLiquidation = this;
 
         silo0.updateHooks();
     }
 
-    function initialize(ISiloConfig _siloConfig, bytes calldata)
-        public
-        override(HookReceiverBootstrapMock, IHookReceiver)
-    {
-        if (owner() == address(0)) _transferOwnership(msg.sender);
-        siloConfig = _siloConfig;
-        (address _silo0, address _silo1) = _siloConfig.getSilos();
-        silo0 = ISilo(_silo0);
-        silo1 = ISilo(_silo1);
-        token0 = MintableToken(_siloConfig.getConfig(_silo0).token);
-        token1 = MintableToken(_siloConfig.getConfig(_silo1).token);
-        partialLiquidation = PartialLiquidation(address(this));
-    }
+    function initialize(ISiloConfig, bytes calldata) public override {}
 
     function hookReceiverConfig(address _silo)
         external
         view
-        override(HookReceiverBootstrapMock, BaseHookReceiver)
+        override
         returns (uint24 hooksBefore, uint24 hooksAfter)
     {
         hooksBefore = 0;
@@ -91,20 +72,18 @@ contract TransitionCollateralReentrancyTest is SiloLittleHelper, Test, PartialLi
 
         if (silo0.isSolvent(borrower)) return; // we want insolvent case
 
-        IPartialLiquidation hook = IPartialLiquidation(address(this));
-
         token1.mint(address(this), 5);
-        IERC20(token1).safeIncreaseAllowance(address(hook), 5);
+        IERC20(token1).safeIncreaseAllowance(address(partialLiquidation), 5);
 
         afterActionExecuted = true;
 
-        (uint256 collateralToLiquidate, uint256 debtToRepay,) = hook.maxLiquidation(borrower);
+        (uint256 collateralToLiquidate, uint256 debtToRepay,) = partialLiquidation.maxLiquidation(borrower);
 
         assertEq(collateralToLiquidate, 3, "collateralToLiquidate (5 - 2 underestimation)");
         assertEq(debtToRepay, 5, "debtToRepay");
 
         vm.expectRevert(ICrossReentrancyGuard.CrossReentrantCall.selector);
-        hook.liquidationCall(address(token0), address(token1), borrower, debtToRepay, false);
+        partialLiquidation.liquidationCall(address(token0), address(token1), borrower, debtToRepay, false);
     }
 
     /*
@@ -119,7 +98,7 @@ contract TransitionCollateralReentrancyTest is SiloLittleHelper, Test, PartialLi
         vm.prank(borrower);
         silo0.transitionCollateral(depositedShares / 2, borrower, ISilo.CollateralType.Collateral);
 
-        assertTrue(_hook.afterActionExecuted(), "afterActionExecuted");
+        assertTrue(afterActionExecuted, "afterActionExecuted");
         assertTrue(silo0.isSolvent(borrower), "borrower is solvent after transition of collateral");
 
         (, ISiloConfig.ConfigData memory debt) = siloConfig.getConfigsForSolvency(borrower);

--- a/silo-core/test/foundry/Silo/updateHooks/UpdateHooks.i.sol
+++ b/silo-core/test/foundry/Silo/updateHooks/UpdateHooks.i.sol
@@ -13,8 +13,6 @@ import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
     forge test --ffi -vv --mc UpdateHooksTest
 */
 contract UpdateHooksTest is SiloLittleHelper, Test {
-    using Hook for uint256;
-
     ISiloConfig siloConfig;
 
     uint24 private _hooksBefore = 123;
@@ -34,39 +32,31 @@ contract UpdateHooksTest is SiloLittleHelper, Test {
     }
 
     /*
-    FOUNDRY_PROFILE=core_test forge test --ffi -vv --mt test_updateHooks_anyoneCanCall
+    forge test --ffi -vv --mt test_updateHooks_anyoneCanCall
     */
     function test_updateHooks_anyoneCanCall() public {
         vm.expectEmit(true, true, true, true);
-        emit HooksUpdated(
-            0, uint24(Hook.PROTECTED_TOKEN.addAction(Hook.COLLATERAL_TOKEN).addAction(Hook.SHARE_TOKEN_TRANSFER))
-        );
+        emit HooksUpdated(0, 0);
 
         silo1.updateHooks();
     }
 
     /*
-    FOUNDRY_PROFILE=core_test forge test --ffi -vv --mt test_updateHooks_whenNothingChanged
+    forge test --ffi -vv --mt test_updateHooks_emitEvent
     */
     function test_updateHooks_whenNothingChanged() public {
         // we expect not have reverts when no update was done
         silo0.updateHooks();
 
-        uint256 hookAfter = uint24(Hook.PROTECTED_TOKEN.addAction(Hook.COLLATERAL_TOKEN).addAction(Hook.SHARE_TOKEN_TRANSFER));
-
         vm.expectEmit(true, true, true, true);
-        // casting to 'uint24' is safe because hook is always uint24
-        // forge-lint: disable-next-line(unsafe-typecast)
-        emit HooksUpdated(0, uint24(hookAfter));
+        emit HooksUpdated(0, 0);
 
         silo0.updateHooks();
 
         silo1.updateHooks();
 
         vm.expectEmit(true, true, true, true);
-        // casting to 'uint24' is safe because hook is always uint24
-        // forge-lint: disable-next-line(unsafe-typecast)
-        emit HooksUpdated(0, uint24(hookAfter));
+        emit HooksUpdated(0, 0);
 
         silo1.updateHooks();
     }

--- a/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDebt.i.sol
+++ b/silo-core/test/foundry/Silo/withdraw/WithdrawWhenNoDebt.i.sol
@@ -10,7 +10,7 @@ import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
 import {SiloMathLib} from "silo-core/contracts/lib/SiloMathLib.sol";
 
 import {SiloConfigsNames} from "silo-core/deploy/silo/SiloDeployments.sol";
-import {HookReceiverBootstrapMock} from "silo-core/test/foundry/_mocks/HookReceiverBootstrapMock.sol";
+import {HookReceiverMock} from "silo-core/test/foundry/_mocks/HookReceiverMock.sol";
 
 import {MintableToken} from "../../_common/MintableToken.sol";
 import {SiloConfigOverride} from "../../_common/fixtures/SiloFixture.sol";
@@ -19,7 +19,7 @@ import {SiloFixture} from "../../_common/fixtures/SiloFixture.sol";
 import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
 
 /*
-    FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc WithdrawWhenNoDebtTest
+    forge test -vv --ffi --mc WithdrawWhenNoDebtTest
 */
 contract WithdrawWhenNoDebtTest is SiloLittleHelper, Test {
     ISiloConfig siloConfig;
@@ -28,13 +28,16 @@ contract WithdrawWhenNoDebtTest is SiloLittleHelper, Test {
         token0 = new MintableToken(18);
         token1 = new MintableToken(18);
 
-        HookReceiverBootstrapMock hookReceiverImplementation = new HookReceiverBootstrapMock();
+        // Setting the hook receiver mock to force Actions lib _hookCallAfter fn execution
+        HookReceiverMock hookReceiverMock = new HookReceiverMock(address(0));
+        // Hook receiver config doesn't matter for this test
+        hookReceiverMock.hookReceiverConfigMock(0, 0);
 
         SiloConfigOverride memory overrides;
         overrides.token0 = address(token0);
         overrides.token1 = address(token1);
-        overrides.hookReceiverImplementation = address(hookReceiverImplementation);
-        overrides.configName = SiloConfigsNames.SILO_LOCAL_NO_ORACLE_SILO;
+        overrides.hookReceiver = hookReceiverMock.ADDRESS();
+        overrides.configName = SiloConfigsNames.SILO_LOCAL_DEPLOYER;
 
         SiloFixture siloFixture = new SiloFixture();
 

--- a/silo-core/test/foundry/_common/SiloLittleHelper.sol
+++ b/silo-core/test/foundry/_common/SiloLittleHelper.sol
@@ -19,6 +19,7 @@ import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
 import {
     IPermissionedLiquidationController
 } from "silo-core/contracts/interfaces/IPermissionedLiquidationController.sol";
+import {IPermissionedLiquidationControllerFactory} from "silo-core/contracts/interfaces/IPermissionedLiquidationControllerFactory.sol";
 
 import {MintableToken} from "./MintableToken.sol";
 import {SiloFixture, SiloConfigOverride} from "./fixtures/SiloFixture.sol";
@@ -92,6 +93,23 @@ abstract contract SiloLittleHelper is CommonBase {
             IPermissionedLiquidationController(gaugeP).allowMeToLiquidate();
             vm.stopPrank();
         }
+    }
+
+    function _setupPermissionedControllers(IPermissionedLiquidationControllerFactory _factory) 
+        internal 
+        returns (IPermissionedLiquidationController controllerC, IPermissionedLiquidationController controllerP) 
+    {
+        IGaugeHookReceiver hook = IGaugeHookReceiver(IShareToken(address(silo0)).hookReceiver());
+        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
+        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
+
+        controllerC = IPermissionedLiquidationController(_factory.create(IShareToken(collateralShareToken)));
+        controllerP = IPermissionedLiquidationController(_factory.create(IShareToken(protectedShareToken)));
+
+        vm.startPrank(Ownable(address(hook)).owner());
+        hook.setGauge(controllerC, IShareToken(collateralShareToken));
+        hook.setGauge(controllerP, IShareToken(protectedShareToken));
+        vm.stopPrank();
     }
 
     function _setPermissionedLiquidationState(ISiloConfig _siloConfig, bool _enabled) internal {

--- a/silo-core/test/foundry/gas/Deposit1st.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit1st.gas.sol
@@ -15,7 +15,7 @@ contract Deposit1stGasTest is Gas, Test {
         _gasTestsInit();
     }
 
-    // forge test -vv --ffi --mt test_gas_firstDeposit
+    // FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_gas_firstDeposit
     //  194207 - when __accrueInterest returns 2 configs
     // -188200  when __accrueInterest returns config and we pul configs in lib
     function test_gas_firstDeposit() public {
@@ -24,7 +24,7 @@ contract Deposit1stGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "Deposit1st ever",
-            198809,
+            167935,
             1000
         );
     }

--- a/silo-core/test/foundry/gas/Deposit2nd.gas.sol
+++ b/silo-core/test/foundry/gas/Deposit2nd.gas.sol
@@ -8,7 +8,7 @@ import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
 import {Gas} from "./Gas.sol";
 
 /*
-forge test -vv --ffi --mt test_gas_ | grep -i '\[GAS\]'
+FOUNDRY_PROFILE=core_test forge test -vv --ffi --mt test_gas_ | grep -i '\[GAS\]'
 */
 contract Deposit2ndGasTest is Gas, Test {
     function setUp() public {
@@ -24,7 +24,7 @@ contract Deposit2ndGasTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.deposit, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "Deposit2nd (no interest)",
-            110230,
+            79356,
             1000
         );
     }

--- a/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/DepositAccrueInterest.gas.sol
@@ -34,7 +34,7 @@ contract DepositAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.deposit, (ASSETS, DEPOSITOR, ISilo.CollateralType.Collateral)),
             "DepositAccrueInterest",
-            164947,
+            134012,
             1000
         );
     }

--- a/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/LiquidationAccrueInterest.gas.sol
@@ -39,7 +39,7 @@ contract LiquidationAccrueInterestGasTest is Gas, Test {
                 IPartialLiquidation.liquidationCall, (address(token0), address(token1), BORROWER, ASSETS / 2, false)
             ),
             "LiquidationCall with accrue interest",
-            499316,
+            471209,
             3000
         );
     }

--- a/silo-core/test/foundry/gas/TransferCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransferCollateral.gas.sol
@@ -32,7 +32,7 @@ contract TransferCollateralTest is Gas, Test {
             address(collateralShareToken),
             abi.encodeCall(IERC20.transfer, (BORROWER, 1)),
             "TransferCollateral (when debt)",
-            140464
+            111816
         );
     }
 }

--- a/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
+++ b/silo-core/test/foundry/gas/TransitionCollateral.gas.sol
@@ -30,7 +30,7 @@ contract TransitionCollateralTest is Gas, Test {
             address(silo0),
             abi.encodeCall(ISilo.transitionCollateral, (ASSETS, BORROWER, ISilo.CollateralType.Collateral)),
             "transitionCollateral (when debt)",
-            343742, // 74K for interest
+            292263, // 74K for interest
             500
         );
     }

--- a/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
+++ b/silo-core/test/foundry/gas/WitdhrawPartAccrueInterest.gas.sol
@@ -32,7 +32,7 @@ contract WithdrawPartAccrueInterestGasTest is Gas, Test {
             address(silo1),
             abi.encodeCall(ISilo.withdraw, (ASSETS / 10, DEPOSITOR, DEPOSITOR, ISilo.CollateralType.Collateral)),
             "Withdraw partial with accrue interest",
-            236505,
+            205504,
             1000
         );
     }

--- a/silo-core/test/foundry/incentives/SiloIncentivesControllerGaugeLike.t.sol
+++ b/silo-core/test/foundry/incentives/SiloIncentivesControllerGaugeLike.t.sol
@@ -151,7 +151,6 @@ contract SiloIncentivesControllerGaugeLikeTest is SiloLittleHelper, Test {
      */
     function test_gaugeLikeIncentives_with_gaugeHookReceiver() public {
         ISiloConfig siloConfig = _setUpLocalFixture(SiloConfigsNames.SILO_LOCAL_GAUGE_HOOK_RECEIVER);
-        _removePermissionedLiquidationController(siloConfig);
         (address silo0,) = siloConfig.getSilos();
 
         IGaugeHookReceiver gaugeHookReceiver = IGaugeHookReceiver(IShareToken(address(silo0)).hookSetup().hookReceiver);

--- a/silo-core/test/foundry/liquidation/defaulting/DefaultingLiquidationCommon.sol
+++ b/silo-core/test/foundry/liquidation/defaulting/DefaultingLiquidationCommon.sol
@@ -76,9 +76,6 @@ abstract contract DefaultingLiquidationCommon is DefaultingLiquidationAsserts {
         vm.label(address(this), "TESTER");
 
         gauge = defaulting.validateControllerForCollateral(address(debtSilo));
-
-        // We have permissions gauge controller set by default. For defaulting QA, we have to remove it.
-        _removePermissionedLiquidationController();
     }
 
     /*

--- a/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
+++ b/silo-core/test/foundry/liquidation/partialLiquidation/PartialLiquidationPermisioned.t.sol
@@ -106,7 +106,7 @@ contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest
         weth.setOnDemand(true);
         usdc.setOnDemand(true);
 
-        // _setupPermissionedControllers();
+        (controllerC, controllerP) = _setupPermissionedControllers(factory);
 
         _fetchControllers();
         _enablePermissionsIfDisabled();
@@ -414,19 +414,5 @@ contract PartialLiquidationPermissionedTest is SiloLittleHelper, IntegrationTest
         vm.prank(Ownable(address(proxyAdmin)).owner());
         ProxyAdmin(proxyAdmin)
             .upgradeAndCall(ITransparentUpgradeableProxy(payable(_controllerProxy)), _newImplementation, bytes(""));
-    }
-
-    function _setupPermissionedControllers() internal {
-        IGaugeHookReceiver hook = IGaugeHookReceiver(IShareToken(address(silo0)).hookReceiver());
-        address collateralShareToken = silo0.config().getConfig(address(silo0)).collateralShareToken;
-        address protectedShareToken = silo0.config().getConfig(address(silo0)).protectedShareToken;
-
-        controllerC = IPermissionedLiquidationController(factory.create(IShareToken(collateralShareToken)));
-        controllerP = IPermissionedLiquidationController(factory.create(IShareToken(protectedShareToken)));
-
-        vm.startPrank(Ownable(address(hook)).owner());
-        hook.setGauge(controllerC, IShareToken(collateralShareToken));
-        hook.setGauge(controllerP, IShareToken(protectedShareToken));
-        vm.stopPrank();
     }
 }

--- a/silo-core/test/foundry/utils/hook-receivers/HookCallsOutsideAction.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/HookCallsOutsideAction.t.sol
@@ -8,13 +8,10 @@ import {IERC20} from "openzeppelin5/token/ERC20/ERC20.sol";
 import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
 import {IERC3156FlashBorrower} from "silo-core/contracts/interfaces/IERC3156FlashBorrower.sol";
 import {IERC20R} from "silo-core/contracts/interfaces/IERC20R.sol";
-import {IHookReceiver} from "silo-core/contracts/interfaces/IHookReceiver.sol";
 import {ISiloConfig} from "silo-core/contracts/interfaces/ISiloConfig.sol";
 import {PartialLiquidation} from "silo-core/contracts/hooks/liquidation/PartialLiquidation.sol";
-import {BaseHookReceiver} from "silo-core/contracts/hooks/_common/BaseHookReceiver.sol";
 import {SiloLensLib} from "silo-core/contracts/lib/SiloLensLib.sol";
 import {Hook} from "silo-core/contracts/lib/Hook.sol";
-import {HookReceiverBootstrapMock} from "silo-core/test/foundry/_mocks/HookReceiverBootstrapMock.sol";
 
 import {SiloLittleHelper} from "../../_common/SiloLittleHelper.sol";
 import {MintableToken} from "../../_common/MintableToken.sol";
@@ -24,13 +21,7 @@ import {SiloFixture} from "../../_common/fixtures/SiloFixture.sol";
 /*
 FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc HookCallsOutsideActionTest
 */
-contract HookCallsOutsideActionTest is
-    PartialLiquidation,
-    HookReceiverBootstrapMock,
-    IERC3156FlashBorrower,
-    SiloLittleHelper,
-    Test
-{
+contract HookCallsOutsideActionTest is PartialLiquidation, IERC3156FlashBorrower, SiloLittleHelper, Test {
     using Hook for uint256;
     using SiloLensLib for ISilo;
 
@@ -49,12 +40,11 @@ contract HookCallsOutsideActionTest is
         SiloConfigOverride memory overrides;
         overrides.token0 = address(token0);
         overrides.token1 = address(token1);
-        overrides.hookReceiverImplementation = address(this);
+        overrides.hookReceiver = address(this);
 
         SiloFixture siloFixture = new SiloFixture();
-        address hook;
-        (siloConfig, silo0, silo1,,, hook) = siloFixture.deploy_local(overrides);
-        partialLiquidation = PartialLiquidation(hook);
+        (siloConfig, silo0, silo1,,,) = siloFixture.deploy_local(overrides);
+        partialLiquidation = this;
 
         _setAllHooks();
 
@@ -165,17 +155,8 @@ contract HookCallsOutsideActionTest is
         silo1.withdrawFees();
     }
 
-    function initialize(ISiloConfig _config, bytes calldata _ownerData)
-        public
-        override(HookReceiverBootstrapMock, IHookReceiver)
-    {
-        if (address(siloConfig) == address(0)) {
-            siloConfig = _config;
-        } else {
-            assertEq(address(siloConfig), address(_config), "SiloConfig addresses should match");
-        }
-
-        _transferOwnership(abi.decode(_ownerData, (address)));
+    function initialize(ISiloConfig _config, bytes calldata) public view override {
+        assertEq(address(siloConfig), address(_config), "SiloConfig addresses should match");
     }
 
     function beforeAction(address, uint256 _action, bytes calldata) external override {
@@ -224,12 +205,7 @@ contract HookCallsOutsideActionTest is
         return FLASHLOAN_CALLBACK;
     }
 
-    function hookReceiverConfig(address)
-        external
-        view
-        override(HookReceiverBootstrapMock, BaseHookReceiver)
-        returns (uint24 hooksBefore, uint24 hooksAfter)
-    {
+    function hookReceiverConfig(address) external view override returns (uint24 hooksBefore, uint24 hooksAfter) {
         hooksBefore = configuredHooksBefore;
         hooksAfter = configuredHooksAfter;
     }

--- a/silo-core/test/foundry/utils/hook-receivers/gauge/GaugeHookReceiver.t.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/gauge/GaugeHookReceiver.t.sol
@@ -24,8 +24,6 @@ import {TransferOwnership} from "../../../_common/TransferOwnership.sol";
 
 // FOUNDRY_PROFILE=core_test forge test -vv --ffi --mc GaugeHookReceiverTest
 contract GaugeHookReceiverTest is SiloLittleHelper, Test, TransferOwnership {
-    using Hook for uint256;
-    
     IGaugeHookReceiver internal _hookReceiver;
     ISiloConfig internal _siloConfig;
 
@@ -55,8 +53,6 @@ contract GaugeHookReceiverTest is SiloLittleHelper, Test, TransferOwnership {
         address deployer = vm.addr(deployerPrivateKey);
 
         _dao = deployer;
-
-        _removePermissionedLiquidationController(_siloConfig);
     }
 
     // FOUNDRY_PROFILE=core_test forge test --ffi -vvv --mt testReInitialization
@@ -157,8 +153,7 @@ contract GaugeHookReceiverTest is SiloLittleHelper, Test, TransferOwnership {
 
         (uint24 hooksBefore, uint24 hooksAfter) = _hookReceiver.hookReceiverConfig(silo0);
 
-        // The deployer is setting up a gauges for both tokens on deployment.
-        uint256 action = Hook.shareTokenTransfer(Hook.COLLATERAL_TOKEN).addAction(Hook.PROTECTED_TOKEN);
+        uint256 action = Hook.shareTokenTransfer(Hook.COLLATERAL_TOKEN);
 
         assertEq(uint256(hooksBefore), 0, "Hooks before should be 0");
         assertEq(uint256(hooksAfter), action, "Hooks after should match action");
@@ -166,7 +161,7 @@ contract GaugeHookReceiverTest is SiloLittleHelper, Test, TransferOwnership {
         IShareToken.HookSetup memory silo0Hooks = IShareToken(address(silo0)).hookSetup();
 
         assertEq(uint256(silo0Hooks.hooksBefore), 0, "[aster setup 0] hooks before should be 0");
-        assertEq(uint256(silo0Hooks.hooksAfter), action, "[after setup 0] hooks after should match action");
+        assertEq(uint256(silo0Hooks.hooksAfter), action, "[aster setup 0] hooks after should match action");
 
         IShareToken.HookSetup memory silo1Hooks = IShareToken(address(silo1)).hookSetup();
 
@@ -227,10 +222,10 @@ contract GaugeHookReceiverTest is SiloLittleHelper, Test, TransferOwnership {
         vm.prank(_dao);
         _hookReceiver.setGauge(ISiloIncentivesController(_gauge), IShareToken(debtShareToken));
 
-        uint256 action = Hook.shareTokenTransfer(Hook.DEBT_TOKEN).addAction(Hook.PROTECTED_TOKEN).addAction(Hook.COLLATERAL_TOKEN);
+        uint256 action = Hook.shareTokenTransfer(Hook.DEBT_TOKEN);
 
         (, uint24 hooksAfter) = _hookReceiver.hookReceiverConfig(silo0);
-        assertEq(uint256(hooksAfter), action, "set gause should set the correct hook");
+        assertEq(uint256(hooksAfter), action);
 
         bytes memory data = _getEncodedData();
 

--- a/silo-core/test/foundry/utils/hook-receivers/liquidation/LiquidationCall.i.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/liquidation/LiquidationCall.i.sol
@@ -15,6 +15,9 @@ import {IShareToken} from "silo-core/contracts/interfaces/IShareToken.sol";
 import {IInterestRateModel} from "silo-core/contracts/interfaces/IInterestRateModel.sol";
 import {SiloLensLib} from "silo-core/contracts/lib/SiloLensLib.sol";
 import {SiloMathLib} from "silo-core/contracts/lib/SiloMathLib.sol";
+import {
+    PermissionedLiquidationControllerFactory
+} from "silo-core/contracts/incentives/functional/PermissionedLiquidationControllerFactory.sol";
 
 import {SiloLittleHelper} from "../../../_common/SiloLittleHelper.sol";
 
@@ -60,6 +63,7 @@ contract LiquidationCallTest is SiloLittleHelper, Test {
         assertEq(silo0Config.liquidationFee, 0.05e18, "liquidationFee0");
         assertEq(silo1Config.liquidationFee, 0.025e18, "liquidationFee1");
 
+        _setupPermissionedControllers(new PermissionedLiquidationControllerFactory());
         _setPermissionedLiquidationState(siloConfig, true);
     }
 

--- a/silo-core/test/foundry/utils/hook-receivers/pendle-rewards-claimer/PendleRewardsClaimer.i.sol
+++ b/silo-core/test/foundry/utils/hook-receivers/pendle-rewards-claimer/PendleRewardsClaimer.i.sol
@@ -85,9 +85,6 @@ contract PendleRewardsClaimerTest is SiloLittleHelper, Test, TransferOwnership {
         _deployer = vm.addr(uint256(vm.envBytes32("PRIVATE_KEY")));
 
         vm.prank(_deployer);
-        gaugeHookReceiver.removeGauge(IShareToken(address(protected)));
-
-        vm.prank(_deployer);
         gaugeHookReceiver.setGauge(_incentivesController, IShareToken(address(protected)));
 
         PendleRewardsClaimerHarness claimer = new PendleRewardsClaimerHarness();
@@ -347,9 +344,7 @@ contract PendleRewardsClaimerTest is SiloLittleHelper, Test, TransferOwnership {
         );
     }
 
-    /*
-    AGGREGATOR=1INCH FOUNDRY_PROFILE=core_test forge test --ffi --mt test_hookConfigurationDuringInit -vv
-    */
+    // FOUNDRY_PROFILE=core_test forge test --ffi --mt test_hookConfigurationDuringInit -vv
     function test_hookConfigurationDuringInit() public view {
         (uint24 hooksBefore, uint24 hooksAfter) = _hookReceiver.hookReceiverConfig(address(silo0));
 
@@ -358,7 +353,7 @@ contract PendleRewardsClaimerTest is SiloLittleHelper, Test, TransferOwnership {
 
         // After actions should include protected token transfers
         uint256 protectedTransferAction = Hook.shareTokenTransfer(Hook.PROTECTED_TOKEN);
-        assertEq(Hook.matchAction(hooksAfter, protectedTransferAction), true, "After actions should be configured");
+        assertTrue(Hook.matchAction(protectedTransferAction, hooksAfter), "After actions should be configured");
     }
 
     // FOUNDRY_PROFILE=core_test forge test --ffi --mt test_rewardToken_isSiloAsset -vv

--- a/silo-oracles/test/foundry/silo-deployer/SiloDeployerWithOracle.sol
+++ b/silo-oracles/test/foundry/silo-deployer/SiloDeployerWithOracle.sol
@@ -67,12 +67,15 @@ abstract contract SiloDeployerWithOracle is Test, DKinkIRMConfigDataReader {
             implementation: hookImpl, initializationData: abi.encode(address(this))
         });
 
+        ISiloDeployer.MarketOptions memory marketOptions;
+
         siloConfig = siloDeployer.deploy({
             _oracles: oracles,
             _irmConfigData0: irmConfigData0,
             _irmConfigData1: irmConfigData1,
             _clonableHookReceiver: hookReceiver,
-            _siloInitData: siloInitData
+            _siloInitData: siloInitData,
+            _marketOptions: marketOptions
         });
 
         (address silo0,) = siloConfig.getSilos();


### PR DESCRIPTION
## Problem

We want gage set up to be optional, and also we want to whitelist liquidators when we deploy the market. 

## Solution

Additional options for the deployers were added:
1. First list of addresses that will be able to pause so for gages
2. Second list of addresses for liquidation permissions

Because this is optional, we also reverted changes to the tests that were previously added. 
