### PR TITLE
do not skip interest accrual when irm call fails

### DIFF
--- a/silo-core/contracts/lib/SiloLendingLib.sol
+++ b/silo-core/contracts/lib/SiloLendingLib.sol
@@ -122,12 +122,16 @@ library SiloLendingLib {
         uint256 totalCollateralAssets = $.totalAssets[ISilo.AssetType.Collateral];
         uint256 totalDebtAssets = $.totalAssets[ISilo.AssetType.Debt];
 
-        uint256 rcomp = getCompoundInterestRate({
+        (uint256 rcomp, bool irmSucceeded) = getCompoundInterestRate({
             _interestRateModel: _interestRateModel,
             _totalCollateralAssets: totalCollateralAssets,
             _totalDebtAssets: totalDebtAssets,
             _lastTimestamp: lastTimestamp
         });
+
+        if (!irmSucceeded) {
+            return 0;
+        }
 
         if (rcomp == 0) {
             $.interestRateTimestamp = uint64(block.timestamp);
@@ -430,7 +434,7 @@ library SiloLendingLib {
         uint256 _totalCollateralAssets,
         uint256 _totalDebtAssets,
         uint64 _lastTimestamp
-    ) internal returns (uint256 rcomp) {
+    ) internal returns (uint256 rcomp, bool irmSucceeded) {
         try
             IInterestRateModel(_interestRateModel).getCompoundInterestRateAndUpdate(
                 _totalCollateralAssets,
@@ -439,10 +443,11 @@ library SiloLendingLib {
             )
             returns (uint256 interestRate)
         {
-            rcomp = interestRate;
+            return (interestRate, true);
         } catch {
             // do not lock silo on interest calculation
             emit IInterestRateModel.InterestRateModelError();
+            return (0, false);
         }
     }
 

--- a/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
+++ b/silo-core/test/foundry/lib/SiloLendingLib/AccrueInterestForAsset.t.sol
@@ -7,6 +7,8 @@ import {SiloStorageLib} from "silo-core/contracts/lib/SiloStorageLib.sol";
 import {ISilo} from "silo-core/contracts/interfaces/ISilo.sol";
 
 import {InterestRateModelMock} from "../../_mocks/InterestRateModelMock.sol";
+import {RevertingIRM} from "../../_mocks/RevertingIRM.sol";
+import {IInterestRateModel} from "silo-core/contracts/interfaces/IInterestRateModel.sol";
 
 // forge test -vv --mc AccrueInterestForAssetTest
 contract AccrueInterestForAssetTest is Test {
@@ -110,6 +112,34 @@ contract AccrueInterestForAssetTest is Test {
             accruedInterest * (daoFee + deployerFee) / DECIMAL_POINTS,
             "daoAndDeployerRevenue"
         );
+    }
+
+
+    /*
+    forge test -vv --mt test_accrueInterestForAsset_whenIrmReverts_timestampUnchanged
+    */
+    function test_accrueInterestForAsset_whenIrmReverts_timestampUnchanged() public {
+        uint64 oldTimestamp = 111;
+        uint64 currentTimestamp = 222;
+        vm.warp(currentTimestamp);
+
+        RevertingIRM irm = new RevertingIRM(RevertingIRM.RevertReasons.StandardRevert);
+
+        ISilo.SiloStorage storage $ = _$();
+
+        $.totalAssets[ISilo.AssetType.Collateral] = 1e18;
+        $.totalAssets[ISilo.AssetType.Debt] = 0.5e18;
+        $.interestRateTimestamp = oldTimestamp;
+
+        vm.expectEmit();
+        emit IInterestRateModel.InterestRateModelError();
+
+        uint256 accruedInterest = SiloLendingLib.accrueInterestForAsset(address(irm), 0, 0);
+
+        assertEq(accruedInterest, 0, "no interest when IRM fails");
+        assertEq($.interestRateTimestamp, oldTimestamp, "timestamp must not advance on IRM failure");
+        assertEq($.totalAssets[ISilo.AssetType.Collateral], 1e18, "collateral unchanged");
+        assertEq($.totalAssets[ISilo.AssetType.Debt], 0.5e18, "debt unchanged");
     }
 
     function _$() internal pure returns (ISilo.SiloStorage storage $) {


### PR DESCRIPTION
## Summary
- if `getCompoundInterestRateAndUpdate` reverts or OOGs inside the try/catch, `accrueInterestForAsset` no longer bumps `interestRateTimestamp` while applying zero interest
- next accrual retries with the full time delta instead of permanently losing that window (matches the concern in KnownIssues.md under IRM)
- added a unit test with `RevertingIRM` to lock the behavior

## Test plan
- [x] `FOUNDRY_PROFILE=core_test forge test --match-contract AccrueInterestForAssetTest`