### PR TITLE
Dual Oracle Fixes

### DIFF
--- a/silo-oracles/contracts/dualOracle/DualOracle.sol
+++ b/silo-oracles/contracts/dualOracle/DualOracle.sol
@@ -169,6 +169,6 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
         whenNotPaused
         returns (uint256 quoteAmount)
     {
-        return isOverrideActive() ? manualPrice : oracle.quote(_baseAmount, _baseToken);
+        return isOverrideActive() ? _baseAmount * manualPrice / 10 ** baseTokenDecimals : oracle.quote(_baseAmount, _baseToken);
     }
 }

--- a/silo-oracles/contracts/dualOracle/DualOracle.sol
+++ b/silo-oracles/contracts/dualOracle/DualOracle.sol
@@ -99,7 +99,7 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
     /// @notice Forwards beforeQuote to the primary oracle.
     /// @inheritdoc ISiloOracle
     function beforeQuote(address _baseToken) external virtual override whenNotPaused {
-        oracle.beforeQuote(_baseToken);
+        if (!isOverrideActive()) oracle.beforeQuote(_baseToken);
     }
 
     /// @notice Immediately pauses the oracle. All quote() calls revert while paused.

--- a/silo-oracles/contracts/dualOracle/DualOracle.sol
+++ b/silo-oracles/contracts/dualOracle/DualOracle.sol
@@ -96,9 +96,12 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
         require(baseTokenDecimals != 0, BaseTokenDecimalsMustBeGreaterThanZero());
     }
 
-    /// @notice Forwards beforeQuote to the primary oracle.
+    /// @notice Forwards beforeQuote to the primary oracle when override is not active.
+    ///         Skipped when override is active so a broken primary cannot block the override.
     /// @inheritdoc ISiloOracle
     function beforeQuote(address _baseToken) external virtual override whenNotPaused {
+        require(_baseToken == _baseTokenInternal, AssetNotSupported());
+
         if (!isOverrideActive()) oracle.beforeQuote(_baseToken);
     }
 
@@ -158,8 +161,8 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
     }
 
     /// @notice Returns the price of _baseAmount of _baseToken denominated in quoteToken.
-    ///         Reverts when paused (OZ EnforcedPause).
-    ///         Returns manualPrice when override is active, otherwise delegates to the primary oracle.
+    ///         Reverts when paused or when _baseToken is not supported.
+    ///         Returns the scaled manual price when override is active, otherwise delegates to the primary oracle.
     /// @inheritdoc ISiloOracle
     function quote(uint256 _baseAmount, address _baseToken)
         public
@@ -169,6 +172,8 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
         whenNotPaused
         returns (uint256 quoteAmount)
     {
+        require(_baseToken == _baseTokenInternal, AssetNotSupported());
+
         quoteAmount = isOverrideActive()
             ? _baseAmount * manualPrice / 10 ** baseTokenDecimals
             : oracle.quote(_baseAmount, _baseToken);

--- a/silo-oracles/contracts/dualOracle/DualOracle.sol
+++ b/silo-oracles/contracts/dualOracle/DualOracle.sol
@@ -169,6 +169,8 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
         whenNotPaused
         returns (uint256 quoteAmount)
     {
-        return isOverrideActive() ? _baseAmount * manualPrice / 10 ** baseTokenDecimals : oracle.quote(_baseAmount, _baseToken);
+        quoteAmount = isOverrideActive()
+            ? _baseAmount * manualPrice / 10 ** baseTokenDecimals
+            : oracle.quote(_baseAmount, _baseToken);
     }
 }

--- a/silo-oracles/contracts/dualOracle/DualOracle.sol
+++ b/silo-oracles/contracts/dualOracle/DualOracle.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {Ownable2StepUpgradeable} from "openzeppelin5-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {PausableUpgradeable} from "openzeppelin5-upgradeable/utils/PausableUpgradeable.sol";
+import {Math} from "openzeppelin5/utils/math/Math.sol";
 import {SafeCast} from "openzeppelin5/utils/math/SafeCast.sol";
 
 import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
@@ -175,7 +176,9 @@ contract DualOracle is IDualOracle, Aggregator, Ownable2StepUpgradeable, Pausabl
         require(_baseToken == _baseTokenInternal, AssetNotSupported());
 
         quoteAmount = isOverrideActive()
-            ? _baseAmount * manualPrice / 10 ** baseTokenDecimals
+            ? Math.mulDiv(_baseAmount, manualPrice, 10 ** baseTokenDecimals)
             : oracle.quote(_baseAmount, _baseToken);
+
+        require(quoteAmount != 0, ZeroQuote());
     }
 }

--- a/silo-oracles/contracts/interfaces/IDualOracle.sol
+++ b/silo-oracles/contracts/interfaces/IDualOracle.sol
@@ -35,6 +35,8 @@ interface IDualOracle is ISiloOracle, IVersioned {
     error PriceBelowLowerBound();
     /// @notice Submitted price is above the immutable upper bound
     error PriceAboveUpperBound();
+    /// @notice _baseToken passed to quote() or beforeQuote() is not the token this oracle prices
+    error AssetNotSupported();
 
     /// @notice Immediately pauses the oracle.
     ///         While paused, all quote() calls revert via OZ EnforcedPause.

--- a/silo-oracles/contracts/interfaces/IDualOracle.sol
+++ b/silo-oracles/contracts/interfaces/IDualOracle.sol
@@ -49,9 +49,9 @@ interface IDualOracle is ISiloOracle, IVersioned {
     /// @notice Sets the manual price and manages override activation.
     ///
     ///         Behaviour by price value:
-    ///         - _price == 0  → clears manualPrice, disables override immediately (emits OverrideDisabled)
-    ///         - _price != 0  → validates bounds, stores price (emits ManualPriceSet);
-    ///                          if override not yet active, starts the timelock (emits OverrideEnabled)
+    ///         - _price == 0  → clears manualPrice and overrideValidAt, disables override immediately (emits ManualPriceUpdated(0, 0))
+    ///         - _price != 0  → validates bounds, stores price; if override not yet active, starts the timelock
+    ///                          (emits ManualPriceUpdated(_price, overrideValidAt))
     ///
     ///         Price updates do NOT restart the timelock once the override is active.
     ///         Only callable by the owner.

--- a/silo-oracles/contracts/interfaces/IDualOracle.sol
+++ b/silo-oracles/contracts/interfaces/IDualOracle.sol
@@ -37,6 +37,8 @@ interface IDualOracle is ISiloOracle, IVersioned {
     error PriceAboveUpperBound();
     /// @notice _baseToken passed to quote() or beforeQuote() is not the token this oracle prices
     error AssetNotSupported();
+    /// @notice Computed quote rounds down to zero for a non-zero _baseAmount
+    error ZeroQuote();
 
     /// @notice Immediately pauses the oracle.
     ///         While paused, all quote() calls revert via OZ EnforcedPause.

--- a/silo-oracles/contracts/interfaces/IDualOracle.sol
+++ b/silo-oracles/contracts/interfaces/IDualOracle.sol
@@ -49,7 +49,8 @@ interface IDualOracle is ISiloOracle, IVersioned {
     /// @notice Sets the manual price and manages override activation.
     ///
     ///         Behaviour by price value:
-    ///         - _price == 0  → clears manualPrice and overrideValidAt, disables override immediately (emits ManualPriceUpdated(0, 0))
+    ///         - _price == 0  → clears manualPrice and overrideValidAt, disables override immediately
+    ///                          (emits ManualPriceUpdated(0, 0))
     ///         - _price != 0  → validates bounds, stores price; if override not yet active, starts the timelock
     ///                          (emits ManualPriceUpdated(_price, overrideValidAt))
     ///

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -13,6 +13,7 @@ import {IDualOracle} from "silo-oracles/contracts/interfaces/IDualOracle.sol";
 import {IDualOracleFactory} from "silo-oracles/contracts/interfaces/IDualOracleFactory.sol";
 import {IVersioned} from "silo-core/contracts/interfaces/IVersioned.sol";
 import {IERC20Metadata} from "silo-oracles/test/foundry/interfaces/IERC20Metadata.sol";
+import {Math} from "openzeppelin5/utils/math/Math.sol";
 import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 import {SiloOracleMock1} from "silo-oracles/test/foundry/_mocks/silo-oracles/SiloOracleMock1.sol";
 
@@ -543,11 +544,14 @@ abstract contract DualOracleBase is Test {
         vm.warp(block.timestamp + TIMELOCK);
         assertTrue(oracle.isOverrideActive());
 
-        // prevent overflow in _baseAmount * manualPrice
-        _baseAmount = bound(_baseAmount, 0, type(uint256).max / manualPrice);
+        uint256 expected = Math.mulDiv(_baseAmount, manualPrice, 10 ** oracle.baseTokenDecimals());
 
-        uint256 expected = _baseAmount * manualPrice / 10 ** oracle.baseTokenDecimals();
-        assertEq(oracle.quote(_baseAmount, baseToken), expected);
+        if (expected == 0) {
+            vm.expectRevert(IDualOracle.ZeroQuote.selector);
+            oracle.quote(_baseAmount, baseToken);
+        } else {
+            assertEq(oracle.quote(_baseAmount, baseToken), expected);
+        }
     }
 
     /*
@@ -558,15 +562,22 @@ abstract contract DualOracleBase is Test {
         uint256 _price
     ) public {
         _price = bound(_price, LOWER_BOUND, UPPER_BOUND);
-        _baseAmount = bound(_baseAmount, 0, type(uint256).max / _price);
+        // mulDiv result must fit in uint256: max result = _baseAmount * UPPER_BOUND / 1e18 = _baseAmount * 2
+        _baseAmount = bound(_baseAmount, 0, type(uint256).max / 2);
 
         vm.prank(owner);
         oracle.setManualPrice(_price);
         vm.warp(block.timestamp + TIMELOCK);
         assertTrue(oracle.isOverrideActive());
 
-        uint256 expected = _baseAmount * _price / 10 ** oracle.baseTokenDecimals();
-        assertEq(oracle.quote(_baseAmount, baseToken), expected);
+        uint256 expected = Math.mulDiv(_baseAmount, _price, 10 ** oracle.baseTokenDecimals());
+
+        if (expected == 0) {
+            vm.expectRevert(IDualOracle.ZeroQuote.selector);
+            oracle.quote(_baseAmount, baseToken);
+        } else {
+            assertEq(oracle.quote(_baseAmount, baseToken), expected);
+        }
     }
 
     /*
@@ -609,15 +620,31 @@ abstract contract DualOracleBase is Test {
     }
 
     /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_quote_revert_ZeroQuote_whenBaseAmountTooSmall_overrideActive
+    */
+    function test_quote_revert_ZeroQuote_whenBaseAmountTooSmall_overrideActive() public {
+        // manualPrice = LOWER_BOUND = 0.5e18; baseTokenDecimals = 18
+        // mulDiv(1, 0.5e18, 1e18) = 0 → ZeroQuote
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        vm.expectRevert(IDualOracle.ZeroQuote.selector);
+        oracle.quote(1, baseToken);
+    }
+
+    /*
         FOUNDRY_PROFILE=oracles forge test --mt test_quote_zeroBaseAmount_returnsZero_whenOverrideActive
     */
-    function test_quote_zeroBaseAmount_returnsZero_whenOverrideActive() public {
+    function test_quote_zeroBaseAmount_reverts_ZeroQuote_whenOverrideActive() public {
         vm.prank(owner);
         oracle.setManualPrice(UPPER_BOUND);
         vm.warp(block.timestamp + TIMELOCK);
         assertTrue(oracle.isOverrideActive());
 
-        assertEq(oracle.quote(0, baseToken), 0, "quote(0) must return 0 even with override active");
+        vm.expectRevert(IDualOracle.ZeroQuote.selector);
+        oracle.quote(0, baseToken);
     }
 
     /*

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -616,7 +616,7 @@ abstract contract DualOracleBase is Test {
 
         (, int256 answer,,,) = DualOracle(address(oracle)).latestRoundData();
         uint256 oneUnit = 10 ** oracle.baseTokenDecimals();
-        assertEq(uint256(answer), oracle.quote(oneUnit, baseToken));
+        assertEq(SafeCast.toUint256(answer), oracle.quote(oneUnit, baseToken));
     }
 
     /*

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -267,6 +267,41 @@ abstract contract DualOracleBase is Test {
     }
 
     /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_setManualPrice_rejectsBelowLowerBound
+    */
+    function testFuzz_setManualPrice_rejectsBelowLowerBound(uint256 _price) public {
+        _price = bound(_price, 1, LOWER_BOUND - 1);
+        vm.prank(owner);
+        vm.expectRevert(IDualOracle.PriceBelowLowerBound.selector);
+        oracle.setManualPrice(_price);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_setManualPrice_rejectsAboveUpperBound
+    */
+    function testFuzz_setManualPrice_rejectsAboveUpperBound(uint256 _price) public {
+        _price = bound(_price, UPPER_BOUND + 1, type(uint256).max);
+        vm.prank(owner);
+        vm.expectRevert(IDualOracle.PriceAboveUpperBound.selector);
+        oracle.setManualPrice(_price);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_setManualPrice_acceptsInBoundsPrice
+    */
+    function testFuzz_setManualPrice_acceptsInBoundsPrice(uint256 _price) public {
+        _price = bound(_price, LOWER_BOUND, UPPER_BOUND);
+        uint64 expectedValidAt = SafeCast.toUint64(block.timestamp + TIMELOCK);
+
+        vm.prank(owner);
+        oracle.setManualPrice(_price);
+
+        assertEq(oracle.manualPrice(), _price);
+        assertEq(oracle.overrideValidAt(), expectedValidAt);
+        assertFalse(oracle.isOverrideActive());
+    }
+
+    /*
         FOUNDRY_PROFILE=oracles forge test --mt test_setManualPrice_updateWhileActive_doesNotRestartTimelock
     */
     function test_setManualPrice_updateWhileActive_doesNotRestartTimelock() public {
@@ -467,6 +502,165 @@ abstract contract DualOracleBase is Test {
 
         uint256 expected = _baseAmount * manualPrice / 10 ** oracle.baseTokenDecimals();
         assertEq(oracle.quote(_baseAmount, baseToken), expected);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_quote_scaledByBaseAmount_withVariousManualPrices
+    */
+    function testFuzz_quote_scaledByBaseAmount_withVariousManualPrices(
+        uint256 _baseAmount,
+        uint256 _price
+    ) public {
+        _price = bound(_price, LOWER_BOUND, UPPER_BOUND);
+        _baseAmount = bound(_baseAmount, 0, type(uint256).max / _price);
+
+        vm.prank(owner);
+        oracle.setManualPrice(_price);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        uint256 expected = _baseAmount * _price / 10 ** oracle.baseTokenDecimals();
+        assertEq(oracle.quote(_baseAmount, baseToken), expected);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_isOverrideActive_falseBeforeBoundary
+    */
+    function testFuzz_isOverrideActive_falseBeforeBoundary(uint32 _shortfall) public {
+        _shortfall = uint32(bound(_shortfall, 1, TIMELOCK));
+
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+
+        vm.warp(block.timestamp + TIMELOCK - _shortfall);
+        assertFalse(oracle.isOverrideActive());
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_isOverrideActive_trueAtOrAfterBoundary
+    */
+    function testFuzz_isOverrideActive_trueAtOrAfterBoundary(uint32 _extra) public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+
+        vm.warp(block.timestamp + TIMELOCK + uint256(_extra));
+        assertTrue(oracle.isOverrideActive());
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_latestRoundData_answerEqualsQuoteForOneUnit
+    */
+    function testFuzz_latestRoundData_answerEqualsQuoteForOneUnit(uint256 _price) public {
+        _price = bound(_price, LOWER_BOUND, UPPER_BOUND);
+
+        vm.prank(owner);
+        oracle.setManualPrice(_price);
+        vm.warp(block.timestamp + TIMELOCK);
+
+        (, int256 answer,,,) = DualOracle(address(oracle)).latestRoundData();
+        uint256 oneUnit = 10 ** oracle.baseTokenDecimals();
+        assertEq(uint256(answer), oracle.quote(oneUnit, baseToken));
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_quote_zeroBaseAmount_returnsZero_whenOverrideActive
+    */
+    function test_quote_zeroBaseAmount_returnsZero_whenOverrideActive() public {
+        vm.prank(owner);
+        oracle.setManualPrice(UPPER_BOUND);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        assertEq(oracle.quote(0, baseToken), 0, "quote(0) must return 0 even with override active");
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_scenario_priceUpdateDuringPendingTimelock_restartsTimelock
+    */
+    function test_scenario_priceUpdateDuringPendingTimelock_restartsTimelock() public {
+        vm.startPrank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+
+        // update price one second before original expiry — timelock must restart
+        vm.warp(block.timestamp + TIMELOCK - 1);
+        assertFalse(oracle.isOverrideActive());
+
+        uint64 restartedValidAt = SafeCast.toUint64(block.timestamp + TIMELOCK);
+        oracle.setManualPrice(UPPER_BOUND);
+        vm.stopPrank();
+
+        assertEq(oracle.overrideValidAt(), restartedValidAt, "timelock must restart from update time");
+
+        // original expiry no longer activates
+        vm.warp(block.timestamp + 1);
+        assertFalse(oracle.isOverrideActive(), "original boundary must not activate override");
+
+        // restarted expiry activates
+        vm.warp(uint256(restartedValidAt));
+        assertTrue(oracle.isOverrideActive());
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_scenario_pauseDuringPendingTimelock_overrideActiveAfterUnpause
+    */
+    function test_scenario_pauseDuringPendingTimelock_overrideActiveAfterUnpause() public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+        uint64 validAt = oracle.overrideValidAt();
+
+        vm.prank(owner);
+        oracle.pause();
+
+        // warp past the timelock expiry while paused
+        vm.warp(uint256(validAt) + 1);
+
+        vm.prank(owner);
+        oracle.unpause();
+
+        assertTrue(oracle.isOverrideActive(), "override must be active after unpause since timelock elapsed");
+        uint256 oneUnit = 10 ** oracle.baseTokenDecimals();
+        assertEq(oracle.quote(oneUnit, baseToken), LOWER_BOUND, "quote must return manual price");
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_scenario_newOwnerControlsOracleAfterTransfer
+    */
+    function test_scenario_newOwnerControlsOracleAfterTransfer() public {
+        address newOwner = makeAddr("NewOwner");
+
+        vm.prank(owner);
+        DualOracle(address(oracle)).transferOwnership(newOwner);
+        vm.prank(newOwner);
+        DualOracle(address(oracle)).acceptOwnership();
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, owner)
+        );
+        oracle.setManualPrice(LOWER_BOUND);
+
+        vm.startPrank(newOwner);
+        oracle.setManualPrice(LOWER_BOUND);
+        oracle.pause();
+        vm.stopPrank();
+
+        assertTrue(DualOracle(address(oracle)).paused());
+        assertEq(oracle.manualPrice(), LOWER_BOUND);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_beforeQuote_forwardsToPrimary_duringPendingTimelock
+    */
+    function test_beforeQuote_forwardsToPrimary_duringPendingTimelock() public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+
+        vm.warp(block.timestamp + TIMELOCK - 1);
+        assertFalse(oracle.isOverrideActive());
+
+        vm.expectEmit(true, false, false, false, address(oracleMock));
+        emit SiloOracleMock1.BeforeQuoteSiloOracleMock1();
+        oracle.beforeQuote(baseToken);
     }
 
     /*

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -468,6 +468,23 @@ abstract contract DualOracleBase is Test {
     }
 
     /*
+        FOUNDRY_PROFILE=oracles forge test --mt testFuzz_quote_scaledByBaseAmount_whenOverrideActive
+    */
+    function testFuzz_quote_scaledByBaseAmount_whenOverrideActive(uint256 _baseAmount) public {
+        uint256 manualPrice = LOWER_BOUND;
+        vm.prank(owner);
+        oracle.setManualPrice(manualPrice);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        // prevent overflow in _baseAmount * manualPrice
+        _baseAmount = bound(_baseAmount, 0, type(uint256).max / manualPrice);
+
+        uint256 expected = _baseAmount * manualPrice / 10 ** oracle.baseTokenDecimals();
+        assertEq(oracle.quote(_baseAmount, baseToken), expected);
+    }
+
+    /*
         FOUNDRY_PROFILE=oracles forge test --mt test_quote_resumesAfterUnpause_withOverrideActive
     */
     function test_quote_resumesAfterUnpause_withOverrideActive() public {

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -13,6 +13,7 @@ import {IDualOracle} from "silo-oracles/contracts/interfaces/IDualOracle.sol";
 import {IDualOracleFactory} from "silo-oracles/contracts/interfaces/IDualOracleFactory.sol";
 import {IVersioned} from "silo-core/contracts/interfaces/IVersioned.sol";
 import {IERC20Metadata} from "silo-oracles/test/foundry/interfaces/IERC20Metadata.sol";
+import {ISiloOracle} from "silo-core/contracts/interfaces/ISiloOracle.sol";
 import {SiloOracleMock1} from "silo-oracles/test/foundry/_mocks/silo-oracles/SiloOracleMock1.sol";
 
 /*
@@ -507,6 +508,26 @@ abstract contract DualOracleBase is Test {
     function test_beforeQuote_forwardsToPrimaryOracle() public {
         vm.expectEmit(true, false, false, false, address(oracleMock));
         emit SiloOracleMock1.BeforeQuoteSiloOracleMock1();
+        oracle.beforeQuote(baseToken);
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_beforeQuote_doesNotForwardToPrimary_whenOverrideActive
+    */
+    function test_beforeQuote_doesNotForwardToPrimary_whenOverrideActive() public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        // primary oracle is broken — its beforeQuote reverts
+        vm.mockCallRevert(
+            address(oracleMock),
+            abi.encodeWithSelector(ISiloOracle.beforeQuote.selector, baseToken),
+            "primary broken"
+        );
+
+        // override is active so DualOracle should skip the primary entirely — must not revert
         oracle.beforeQuote(baseToken);
     }
 

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -396,6 +396,52 @@ abstract contract DualOracleBase is Test {
     }
 
     /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_quote_revert_AssetNotSupported_whenOverrideActive
+    */
+    function test_quote_revert_AssetNotSupported_whenOverrideActive() public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        vm.expectRevert(IDualOracle.AssetNotSupported.selector);
+        oracle.quote(1e18, makeAddr("wrongToken"));
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_quote_revert_AssetNotSupported_whenOverrideNotActive
+    */
+    function test_quote_revert_AssetNotSupported_whenOverrideNotActive() public {
+        assertFalse(oracle.isOverrideActive());
+
+        vm.expectRevert(IDualOracle.AssetNotSupported.selector);
+        oracle.quote(1e18, makeAddr("wrongToken"));
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_beforeQuote_revert_AssetNotSupported_whenOverrideActive
+    */
+    function test_beforeQuote_revert_AssetNotSupported_whenOverrideActive() public {
+        vm.prank(owner);
+        oracle.setManualPrice(LOWER_BOUND);
+        vm.warp(block.timestamp + TIMELOCK);
+        assertTrue(oracle.isOverrideActive());
+
+        vm.expectRevert(IDualOracle.AssetNotSupported.selector);
+        oracle.beforeQuote(makeAddr("wrongToken"));
+    }
+
+    /*
+        FOUNDRY_PROFILE=oracles forge test --mt test_beforeQuote_revert_AssetNotSupported_whenOverrideNotActive
+    */
+    function test_beforeQuote_revert_AssetNotSupported_whenOverrideNotActive() public {
+        assertFalse(oracle.isOverrideActive());
+
+        vm.expectRevert(IDualOracle.AssetNotSupported.selector);
+        oracle.beforeQuote(makeAddr("wrongToken"));
+    }
+
+    /*
         FOUNDRY_PROFILE=oracles forge test --mt test_quote_revert_whenPaused
     */
     function test_quote_revert_whenPaused() public {

--- a/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
+++ b/silo-oracles/test/foundry/dualOracle/DualOracleBase.sol
@@ -43,8 +43,6 @@ abstract contract DualOracleBase is Test {
         oracle = _createDualOracle();
     }
 
-    // ─── creation ─────────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_DualOracle_creation_emitsEvents
     */
@@ -55,8 +53,6 @@ abstract contract DualOracleBase is Test {
         _createDualOracle();
     }
 
-    // ─── VERSION ──────────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_DualOracle_VERSION
     */
@@ -64,16 +60,12 @@ abstract contract DualOracleBase is Test {
         assertEq(IVersioned(address(oracle)).VERSION(), "DualOracle 4.23.0");
     }
 
-    // ─── baseToken ────────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_DualOracle_baseToken
     */
     function test_DualOracle_baseToken() public view {
         assertEq(oracle.baseToken(), oracleMock.baseToken());
     }
-
-    // ─── isOverrideActive ─────────────────────────────────────────────────────
 
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_isOverrideActive_false_initially
@@ -116,8 +108,6 @@ abstract contract DualOracleBase is Test {
         assertTrue(oracle.isOverrideActive(), "override should be active after timelock expiry");
     }
 
-    // ─── pause ────────────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_pause_revert_whenNotOwner
     */
@@ -153,8 +143,6 @@ abstract contract DualOracleBase is Test {
         oracle.pause();
         vm.stopPrank();
     }
-
-    // ─── unpause ──────────────────────────────────────────────────────────────
 
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_unpause_revert_whenNotOwner
@@ -192,8 +180,6 @@ abstract contract DualOracleBase is Test {
 
         assertFalse(DualOracle(address(oracle)).paused(), "should not be paused after unpause()");
     }
-
-    // ─── setManualPrice ───────────────────────────────────────────────────────
 
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_setManualPrice_revert_whenNotOwner
@@ -374,8 +360,6 @@ abstract contract DualOracleBase is Test {
         assertTrue(oracle.isOverrideActive());
     }
 
-    // ─── quote ────────────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_quote_revert_whenPaused
     */
@@ -500,8 +484,6 @@ abstract contract DualOracleBase is Test {
         assertEq(oracle.quote(1e18, baseToken), manualPrice, "should return manualPrice after unpause with override active");
     }
 
-    // ─── beforeQuote ──────────────────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_beforeQuote_forwardsToPrimaryOracle
     */
@@ -541,8 +523,6 @@ abstract contract DualOracleBase is Test {
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         oracle.beforeQuote(baseToken);
     }
-
-    // ─── latestRoundData (Aggregator compatibility) ───────────────────────────
 
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_latestRoundData_normalMode
@@ -610,8 +590,6 @@ abstract contract DualOracleBase is Test {
         assertEq(answeredInRound, 0);
     }
 
-    // ─── ownership (Ownable2StepUpgradeable) ──────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_ownership_initialOwner
     */
@@ -661,8 +639,6 @@ abstract contract DualOracleBase is Test {
         DualOracle(address(oracle)).acceptOwnership();
     }
 
-    // ─── immutable config getters ─────────────────────────────────────────────
-
     /*
         FOUNDRY_PROFILE=oracles forge test --mt test_getters_postInit
     */
@@ -677,8 +653,6 @@ abstract contract DualOracleBase is Test {
         assertEq(oracle.manualPrice(), 0, "manualPrice should be zero initially");
         assertEq(oracle.overrideValidAt(), 0, "overrideValidAt should be zero initially");
     }
-
-    // ─── helpers ──────────────────────────────────────────────────────────────
 
     function _beforeOracleCreation() internal virtual {
         vm.mockCall(baseToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(18));


### PR DESCRIPTION
Fixes: SILO-<!-- ticket ID -->

## Problem

Silo needs an oracle for emergency risk management without replacing the underlying oracle source.

## Solution
The Dual Oracle is a price oracle designed for Silo Finance markets that preserves a standard immutable primary price source while introducing two governance-controlled safety mechanisms: pausing and manual price control.